### PR TITLE
Align Webhook Publishing for Collections and Segments

### DIFF
--- a/src/app/tamoss/adapters/postgres_repository/flows_sources.py
+++ b/src/app/tamoss/adapters/postgres_repository/flows_sources.py
@@ -292,7 +292,7 @@ class PostgresFlowSourceMixin:
                         THEN parent.record->'data'->'flow_collection'
                         ELSE '[]'::jsonb
                     END
-                ) AS item(value)
+                ) WITH ORDINALITY AS item(value, ordinality)
                 JOIN tamoss_flows AS child
                   ON child.id::text = item.value->>'id'
                 WHERE parent.source_id IS NOT NULL
@@ -302,7 +302,7 @@ class PostgresFlowSourceMixin:
                     parent.source_id = ANY(%(source_ids)s::uuid[])
                     OR child.source_id = ANY(%(source_ids)s::uuid[])
                   )
-                ORDER BY parent.source_id, child.source_id, role
+                ORDER BY parent.source_id, parent.id, item.ordinality
                 """,
                 {"source_ids": requested_ids},
             )

--- a/src/app/tamoss/adapters/postgres_repository/queues.py
+++ b/src/app/tamoss/adapters/postgres_repository/queues.py
@@ -171,6 +171,7 @@ class PostgresQueueMixin:
                     claimed_by,
                     claim_expires_at,
                     record,
+                    created_at,
                     updated_at
                 )
                 VALUES (
@@ -182,6 +183,7 @@ class PostgresQueueMixin:
                     %(claimed_by)s,
                     %(claim_expires_at)s,
                     %(record)s,
+                    %(created_at)s,
                     NOW()
                 )
                 ON CONFLICT (id) DO UPDATE SET
@@ -203,6 +205,7 @@ class PostgresQueueMixin:
                     "claimed_by": delivery.claimed_by,
                     "claim_expires_at": delivery.claim_expires_at,
                     "record": Jsonb(record),
+                    "created_at": delivery.created,
                 },
             )
 
@@ -585,6 +588,8 @@ def _claim_worker_records(
             FROM candidates
             WHERE {alias}.id = candidates.id
             RETURNING
+                {alias}.created_at,
+                {alias}.id,
                 {alias}.record,
                 {alias}.status,
                 {alias}.{state_column},
@@ -606,4 +611,6 @@ def _claim_worker_records(
             "lease_seconds": lease_seconds,
         },
     )
-    return [mapper(row) for row in cur.fetchall()]
+    rows = cur.fetchall()
+    rows.sort(key=lambda row: (row[0], str(row[1])))
+    return [mapper(row[2:]) for row in rows]

--- a/src/app/tamoss/application/contexts/deletion.py
+++ b/src/app/tamoss/application/contexts/deletion.py
@@ -122,6 +122,12 @@ class DeletionUseCases:
                 )
                 flow.segments_updated = utc_now()
                 self.repository.save_flow(flow)
+                webhooking.publish_flow_event(
+                    repository=self.webhook_repository,
+                    resource_repository=self.repository,
+                    event_type="flows/updated",
+                    flow=flow,
+                )
             return None
 
         timerange_to_delete = matching_timerange

--- a/src/app/tamoss/application/contexts/deletion_processor.py
+++ b/src/app/tamoss/application/contexts/deletion_processor.py
@@ -296,6 +296,12 @@ def _process_segment_delete_request(
     )
     flow.segments_updated = utc_now()
     repository.save_flow(flow)
+    webhooking.publish_flow_event(
+        repository=webhook_repository,
+        resource_repository=repository,
+        event_type="flows/updated",
+        flow=flow,
+    )
     if remaining_timerange == "()":
         return None
     return remaining_timerange

--- a/src/app/tamoss/application/contexts/flows.py
+++ b/src/app/tamoss/application/contexts/flows.py
@@ -14,13 +14,13 @@ from tamoss.auth import Identity
 from tamoss.contract.generated import contract_models
 from tamoss.domain.flow_collections import (
     collected_by_by_flow_id,
+    collection_aware_flow_timeranges,
     collection_child_id,
     flow_collection,
     flow_with_collected_by,
 )
 from tamoss.domain.model import FlowRecord, MediaObjectRecord, SourceRecord, utc_now
 from tamoss.domain.pagination import Page
-from tamoss.domain.segments import timerange_union
 from tamoss.domain.tags import TagValue, valid_tag_value
 from tamoss.domain.timeranges import normalized_timerange_bounds
 from tamoss.errors import BadRequest, Forbidden, NotFound
@@ -214,19 +214,63 @@ class FlowUseCases:
         )
 
     def flow_timerange(self, flow_id: UUID, timerange: str | None = None) -> str:
-        self.get_flow(flow_id)
-        flow_range = self._flow_timerange(flow_id)
+        flow = self.get_flow(flow_id)
+        try:
+            flow_range = TimeRange.from_str(
+                self._flow_timeranges([flow_id], seed_flows=[flow])[flow_id]
+            )
+        except ValueError as exc:
+            raise BadRequest("Bad request. Invalid stored Segment timerange.") from exc
         requested_range = parse_query_timerange(timerange)
         if requested_range is None:
             return str(flow_range)
         return str(flow_range.intersect_with(requested_range))
 
     def flow_timeranges(self, flow_ids: Iterable[UUID]) -> dict[UUID, str]:
+        return self._flow_timeranges(flow_ids)
+
+    def _flow_timeranges(
+        self,
+        flow_ids: Iterable[UUID],
+        *,
+        seed_flows: Iterable[FlowRecord] = (),
+    ) -> dict[UUID, str]:
         requested_ids = list(dict.fromkeys(flow_ids))
         if not requested_ids:
             return {}
-        timeranges = self.repository.flow_timeranges(requested_ids)
-        return {flow_id: timeranges.get(flow_id, "()") for flow_id in requested_ids}
+        flows = self._flows_for_timerange_resolution(requested_ids, seed_flows)
+        direct_timeranges = self.repository.flow_timeranges(flow.id for flow in flows)
+        try:
+            return collection_aware_flow_timeranges(
+                flows,
+                direct_timeranges,
+                requested_ids,
+            )
+        except ValueError as exc:
+            raise BadRequest("Bad request. Invalid stored Segment timerange.") from exc
+
+    def _flows_for_timerange_resolution(
+        self,
+        flow_ids: Iterable[UUID],
+        seed_flows: Iterable[FlowRecord] = (),
+    ) -> list[FlowRecord]:
+        flows_by_id = {flow.id: flow for flow in seed_flows}
+        pending = list(dict.fromkeys(flow_ids))
+        index = 0
+        while index < len(pending):
+            flow_id = pending[index]
+            index += 1
+            flow = flows_by_id.get(flow_id)
+            if flow is None:
+                flow = self.repository.get_flow(flow_id)
+                if flow is None:
+                    continue
+                flows_by_id[flow.id] = flow
+            for item in flow_collection(flow):
+                child_id = collection_child_id(item)
+                if child_id is not None and child_id not in flows_by_id:
+                    pending.append(child_id)
+        return list(flows_by_id.values())
 
     def get_flow(
         self, flow_id: UUID, *, include_collected_by: bool = False
@@ -237,14 +281,6 @@ class FlowUseCases:
         if include_collected_by:
             return self._flow_with_collected_by(flow)
         return flow
-
-    def _flow_timerange(self, flow_id: UUID) -> TimeRange:
-        try:
-            return TimeRange.from_str(
-                timerange_union(self.repository.list_segments(flow_id))
-            )
-        except ValueError as exc:
-            raise BadRequest("Bad request. Invalid stored Segment timerange.") from exc
 
     def get_flow_collection(self, flow_id: UUID) -> list[dict]:
         flow = self.get_flow(flow_id)

--- a/src/app/tamoss/application/contexts/object_get_urls.py
+++ b/src/app/tamoss/application/contexts/object_get_urls.py
@@ -25,6 +25,8 @@ def objects_get_urls(
     media_object_list = list(media_objects)
     if accept_get_urls is not None and not accept_get_urls:
         return {media_object.id: [] for media_object in media_object_list}
+    if accept_storage_ids is not None and not accept_storage_ids:
+        accept_storage_ids = None
     controlled_get_urls = _controlled_get_urls_by_object(
         media_object_list,
         object_storage=object_storage,

--- a/src/app/tamoss/application/contexts/segments.py
+++ b/src/app/tamoss/application/contexts/segments.py
@@ -154,6 +154,12 @@ class SegmentUseCases:
                 media_objects=updated_media_objects.values(),
                 segments=accepted_segments,
             )
+            webhooking.publish_flow_event(
+                repository=self.webhook_repository,
+                resource_repository=self.flow_repository,
+                event_type="flows/updated",
+                flow=flow,
+            )
             webhooking.publish_segments_added(
                 repository=self.webhook_repository,
                 resource_repository=self.flow_repository,

--- a/src/app/tamoss/application/webhooks.py
+++ b/src/app/tamoss/application/webhooks.py
@@ -166,15 +166,24 @@ def webhook_matches(
 ) -> bool:
     if event_type not in _list_of_strings(webhook_data.get("events")):
         return False
-    return (
-        _selector_matches(flow_ids, _list_of_strings(webhook_data.get("flow_ids")))
-        and _selector_matches(
-            source_ids, _list_of_strings(webhook_data.get("source_ids"))
+    is_flow_event = event_type.startswith("flows/")
+    flow_filter_matches = True
+    flow_collected_filter_matches = True
+    if is_flow_event:
+        flow_filter_matches = _selector_matches(
+            flow_ids,
+            _list_of_strings(webhook_data.get("flow_ids")),
         )
-        and _selector_matches(
+        flow_collected_filter_matches = _selector_matches(
             flow_collected_by_ids,
             _list_of_strings(webhook_data.get("flow_collected_by_ids")),
         )
+    return (
+        flow_filter_matches
+        and _selector_matches(
+            source_ids, _list_of_strings(webhook_data.get("source_ids"))
+        )
+        and flow_collected_filter_matches
         and _selector_matches(
             source_collected_by_ids,
             _list_of_strings(webhook_data.get("source_collected_by_ids")),
@@ -341,10 +350,21 @@ def publish_source_event(
     event_type: str,
     source: SourceRecord,
 ) -> list[WebhookDeliveryRecord]:
+    relationship = resource_repository.source_relationships_for([source.id]).get(
+        source.id
+    )
     return publish_webhook_event(
         repository=repository,
         event_type=event_type,
-        event_factory=lambda _webhook: {"source": source_payload(source)},
+        event_factory=lambda _webhook: {
+            "source": source_payload(
+                source,
+                source_collection=(
+                    relationship.source_collection if relationship else None
+                ),
+                collected_by=relationship.collected_by if relationship else None,
+            )
+        },
         flow=None,
         source=source,
         flow_collected_by_ids=[],
@@ -378,7 +398,6 @@ def segment_payload(
         "timerange": segment.timerange,
         "ts_offset": segment.ts_offset,
         "last_duration": segment.last_duration,
-        "object_timerange": segment.object_timerange,
         "sample_offset": segment.sample_offset,
         "sample_count": segment.sample_count,
         "get_urls": get_urls,

--- a/src/app/tamoss/domain/flow_collections.py
+++ b/src/app/tamoss/domain/flow_collections.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import Iterable, Mapping
 from dataclasses import replace
 from uuid import UUID
 
 from tamoss.domain.model import FlowRecord
+from tamoss.domain.timeranges import timerange_union_strings
 
 
 def flow_data_value(flow: FlowRecord, name: str) -> object:
@@ -64,3 +66,45 @@ def collection_role(item: object) -> str | None:
     if raw_role is None:
         return None
     return str(raw_role)
+
+
+def collection_aware_flow_timeranges(
+    flows: Iterable[FlowRecord],
+    direct_timeranges: Mapping[UUID, str],
+    flow_ids: Iterable[UUID],
+) -> dict[UUID, str]:
+    flows_by_id = {flow.id: flow for flow in flows}
+    cache: dict[UUID, str] = {}
+
+    def resolved_timerange(flow_id: UUID, visiting: set[UUID]) -> str:
+        if flow_id in cache:
+            return cache[flow_id]
+        if flow_id in visiting:
+            return _direct_timerange(direct_timeranges.get(flow_id)) or "()"
+
+        visiting.add(flow_id)
+        timeranges: list[str | None] = [
+            _direct_timerange(direct_timeranges.get(flow_id))
+        ]
+        flow = flows_by_id.get(flow_id)
+        if flow is not None:
+            for item in flow_collection(flow):
+                child_id = collection_child_id(item)
+                if child_id is not None:
+                    timeranges.append(resolved_timerange(child_id, visiting))
+        visiting.remove(flow_id)
+
+        merged = timerange_union_strings(timeranges) or "()"
+        cache[flow_id] = merged
+        return merged
+
+    return {
+        flow_id: resolved_timerange(flow_id, set())
+        for flow_id in list(dict.fromkeys(flow_ids))
+    }
+
+
+def _direct_timerange(timerange: str | None) -> str | None:
+    if timerange in {None, "()"}:
+        return None
+    return timerange

--- a/src/app/tamoss/ports/repositories.py
+++ b/src/app/tamoss/ports/repositories.py
@@ -130,6 +130,11 @@ class WebhookResourceRepository(Protocol):
 
     def get_source(self, source_id: UUID) -> SourceRecord | None: ...
 
+    def source_relationships_for(
+        self,
+        source_ids: Iterable[UUID],
+    ) -> dict[UUID, SourceRelationships]: ...
+
 
 class WebhookRepository(WebhookEventRepository, Protocol):
     def list_webhooks_page(

--- a/tests/adapters/bbc/test_flows_sources_and_segments.py
+++ b/tests/adapters/bbc/test_flows_sources_and_segments.py
@@ -215,6 +215,63 @@ def test_list_flows_can_include_timerange_compatibility_extension(
     assert_bbc_error(invalid.json())
 
 
+def test_collection_flows_include_child_timerange_compatibility_extension(
+    client: TestClient,
+) -> None:
+    first_flow_id = uuid4()
+    first_source_id = uuid4()
+    second_flow_id = uuid4()
+    second_source_id = uuid4()
+    parent_flow_id = uuid4()
+    parent_source_id = uuid4()
+
+    assert (
+        client.put(
+            f"/flows/{first_flow_id}",
+            json=video_flow_payload(first_flow_id, first_source_id),
+        ).status_code
+        == 201
+    )
+    assert (
+        client.put(
+            f"/flows/{second_flow_id}",
+            json=video_flow_payload(second_flow_id, second_source_id),
+        ).status_code
+        == 201
+    )
+    assert (
+        client.put(
+            f"/flows/{parent_flow_id}",
+            json=multi_flow_payload(parent_flow_id, parent_source_id),
+        ).status_code
+        == 201
+    )
+    register_segment(client, first_flow_id, timerange="[0:0_10:0)")
+    register_segment(client, second_flow_id, timerange="[20:0_30:0)")
+
+    collection = client.put(
+        f"/flows/{parent_flow_id}/flow_collection",
+        json=[
+            flow_collection_item(first_flow_id, role="video"),
+            flow_collection_item(second_flow_id, role="audio"),
+        ],
+    )
+    assert collection.status_code == 204
+
+    detail = client.get(
+        f"/flows/{parent_flow_id}", params={"include_timerange": "true"}
+    )
+    assert detail.status_code == 200
+    assert detail.json()["timerange"] == "[0:0_30:0)"
+
+    listed = client.get(
+        "/flows",
+        params={"source_id": str(parent_source_id), "include_timerange": "true"},
+    )
+    assert listed.status_code == 200
+    assert listed.json()[0]["timerange"] == "[0:0_30:0)"
+
+
 def test_flow_put_replaces_tags_when_omitted(client: TestClient) -> None:
     flow_id = uuid4()
     source_id = uuid4()

--- a/tests/adapters/bbc/test_webhooks.py
+++ b/tests/adapters/bbc/test_webhooks.py
@@ -216,25 +216,158 @@ def test_webhook_queues_bbc_flow_source_and_segment_events(
     assert event_types == [
         "sources/created",
         "flows/created",
+        "flows/updated",
         "flows/segments_added",
         "sources/updated",
         "flows/segments_deleted",
+        "flows/updated",
         "flows/deleted",
         "sources/deleted",
     ]
     assert deliveries[1].payload["event"]["flow"]["id"] == str(flow_id)
-    assert deliveries[2].payload["event"]["segments"][0]["object_id"] == object_id
-    assert deliveries[2].payload["event"]["segments"][0]["get_urls"][0]["label"] == (
+    assert deliveries[2].payload["event"]["flow"]["segments_updated"]
+    assert deliveries[3].payload["event"]["segments"][0]["object_id"] == object_id
+    assert deliveries[3].payload["event"]["segments"][0]["get_urls"][0]["label"] == (
         PRIMARY_BACKEND_LABEL
     )
-    assert deliveries[2].payload["event"]["segments"][0]["get_urls"][0][
+    assert deliveries[3].payload["event"]["segments"][0]["get_urls"][0][
         "storage_id"
     ] == str(PRIMARY_BACKEND_ID)
-    assert deliveries[4].payload["event"]["timerange"] == "[0:0_10:0)"
+    assert deliveries[5].payload["event"]["timerange"] == "[0:0_10:0)"
+    assert deliveries[6].payload["event"]["flow"]["segments_updated"]
     assert (
         client.get(f"/service/webhooks/{webhook.json()['id']}").json()["status"]
         == "started"
     )
+
+
+def test_webhook_flow_event_keeps_bbc_projection_without_collection_timerange(
+    tamoss_app: FastAPI,
+    client: TestClient,
+) -> None:
+    child_flow_id = uuid4()
+    child_source_id = uuid4()
+    parent_flow_id = uuid4()
+    parent_source_id = uuid4()
+
+    created_child = client.put(
+        f"/flows/{child_flow_id}",
+        json=video_flow_payload(child_flow_id, child_source_id),
+    )
+    assert created_child.status_code == 201
+    register_segment(client, child_flow_id, timerange="[0:0_10:0)")
+
+    created_parent = client.put(
+        f"/flows/{parent_flow_id}",
+        json=multi_flow_payload(parent_flow_id, parent_source_id),
+    )
+    assert created_parent.status_code == 201
+    webhook = client.post(
+        "/service/webhooks",
+        json=webhook_payload(events=["flows/updated"]),
+    )
+    assert webhook.status_code == 201
+
+    updated_collection = client.put(
+        f"/flows/{parent_flow_id}/flow_collection",
+        json=[flow_collection_item(child_flow_id)],
+    )
+    assert updated_collection.status_code == 204
+
+    deliveries = tamoss_app.state.tamoss_use_cases.repository.list_webhook_deliveries()
+    assert [delivery.event_type for delivery in deliveries] == ["flows/updated"]
+    payload = deliveries[0].payload["event"]["flow"]
+    assert payload["id"] == str(parent_flow_id)
+    assert "timerange" not in payload
+
+
+def test_webhook_source_events_ignore_flow_only_filters(
+    tamoss_app: FastAPI,
+    client: TestClient,
+) -> None:
+    source_id = uuid4()
+    flow_id = uuid4()
+    created = client.put(
+        f"/flows/{flow_id}",
+        json=video_flow_payload(flow_id, source_id),
+    )
+    assert created.status_code == 201
+    webhook = client.post(
+        "/service/webhooks",
+        json=webhook_payload(
+            events=["sources/updated"],
+            flow_ids=["00000000-0000-4000-8000-000000000001"],
+            flow_collected_by_ids=["00000000-0000-4000-8000-000000000002"],
+            source_ids=[str(source_id)],
+        ),
+    )
+    assert webhook.status_code == 201
+
+    updated = client.put(f"/sources/{source_id}/label", json="updated")
+    assert updated.status_code == 204
+
+    deliveries = tamoss_app.state.tamoss_use_cases.repository.list_webhook_deliveries()
+    assert [delivery.event_type for delivery in deliveries] == ["sources/updated"]
+    assert deliveries[0].payload["event"]["source"]["id"] == str(source_id)
+
+
+def test_webhook_empty_storage_filter_keeps_get_urls(
+    tamoss_app: FastAPI,
+    client: TestClient,
+) -> None:
+    source_id = uuid4()
+    flow_id = uuid4()
+    created = client.put(
+        f"/flows/{flow_id}",
+        json=video_flow_payload(flow_id, source_id),
+    )
+    assert created.status_code == 201
+    webhook = client.post(
+        "/service/webhooks",
+        json=webhook_payload(
+            events=["flows/segments_added"],
+            accept_storage_ids=[],
+            verbose_storage=True,
+        ),
+    )
+    assert webhook.status_code == 201
+
+    register_segment(client, flow_id)
+
+    deliveries = tamoss_app.state.tamoss_use_cases.repository.list_webhook_deliveries()
+    assert [delivery.event_type for delivery in deliveries] == ["flows/segments_added"]
+    get_urls = deliveries[0].payload["event"]["segments"][0]["get_urls"]
+    assert get_urls
+    assert {get_url["storage_id"] for get_url in get_urls} == {str(PRIMARY_BACKEND_ID)}
+
+
+def test_webhook_segment_payload_omits_object_timerange(
+    tamoss_app: FastAPI,
+    client: TestClient,
+) -> None:
+    source_id = uuid4()
+    flow_id = uuid4()
+    created = client.put(
+        f"/flows/{flow_id}",
+        json=video_flow_payload(flow_id, source_id),
+    )
+    assert created.status_code == 201
+    webhook = client.post(
+        "/service/webhooks",
+        json=webhook_payload(events=["flows/segments_added"]),
+    )
+    assert webhook.status_code == 201
+
+    object_id = register_segment(
+        client,
+        flow_id,
+        object_timerange="[10:0_20:0)",
+    )
+
+    deliveries = tamoss_app.state.tamoss_use_cases.repository.list_webhook_deliveries()
+    segment = deliveries[0].payload["event"]["segments"][0]
+    assert segment["object_id"] == object_id
+    assert "object_timerange" not in segment
 
 
 def test_webhook_source_collection_filter_matches_child_events(
@@ -282,4 +415,7 @@ def test_webhook_source_collection_filter_matches_child_events(
     event_types = [delivery.event_type for delivery in deliveries]
     assert event_types == ["sources/updated", "flows/updated"]
     assert deliveries[0].payload["event"]["source"]["id"] == str(child_source_id)
+    assert deliveries[0].payload["event"]["source"]["collected_by"] == [
+        str(parent_source_id)
+    ]
     assert deliveries[1].payload["event"]["flow"]["id"] == str(child_flow_id)

--- a/tests/adapters/postgres/test_repository.py
+++ b/tests/adapters/postgres/test_repository.py
@@ -711,14 +711,21 @@ def test_use_cases_project_flow_collection_relationships_with_postgres(
 ) -> None:
     use_cases = _use_cases(postgres_repo)
     identity = _identity()
-    parent_flow_id = uuid4()
-    parent_source_id = uuid4()
-    child_flow_id = uuid4()
-    child_source_id = uuid4()
+    parent_flow_id = UUID("00000000-0000-4000-8000-000000000100")
+    parent_source_id = UUID("00000000-0000-4000-8000-000000000101")
+    child_flow_id = UUID("00000000-0000-4000-8000-000000000109")
+    child_source_id = UUID("00000000-0000-4000-8000-000000000109")
+    audio_flow_id = UUID("00000000-0000-4000-8000-000000000102")
+    audio_source_id = UUID("00000000-0000-4000-8000-000000000102")
 
     use_cases.flows.put_flow(
         flow_id=child_flow_id,
         flow=_video_flow_write(child_flow_id, child_source_id),
+        identity=identity,
+    )
+    use_cases.flows.put_flow(
+        flow_id=audio_flow_id,
+        flow=_video_flow_write(audio_flow_id, audio_source_id),
         identity=identity,
     )
     use_cases.flows.put_flow(
@@ -729,18 +736,31 @@ def test_use_cases_project_flow_collection_relationships_with_postgres(
 
     use_cases.flows.set_flow_collection(
         flow_id=parent_flow_id,
-        collection=[{"id": str(child_flow_id), "role": "video"}],
+        collection=[
+            {"id": str(child_flow_id), "role": "video"},
+            {"id": str(audio_flow_id), "role": "audio"},
+        ],
         identity=identity,
     )
 
     assert use_cases.flows.get_flow_collection(parent_flow_id) == [
-        {"id": str(child_flow_id), "role": "video"}
+        {"id": str(child_flow_id), "role": "video"},
+        {"id": str(audio_flow_id), "role": "audio"},
     ]
     relationships = use_cases.sources.source_relationships()
     assert relationships[parent_source_id].source_collection == [
-        {"id": str(child_source_id), "role": "video"}
+        {"id": str(child_source_id), "role": "video"},
+        {"id": str(audio_source_id), "role": "audio"},
     ]
     assert relationships[child_source_id].collected_by == [parent_source_id]
+    assert relationships[audio_source_id].collected_by == [parent_source_id]
+    scoped_relationships = use_cases.sources.source_relationships(
+        [parent_source_id, child_source_id, audio_source_id]
+    )
+    assert scoped_relationships[parent_source_id].source_collection == [
+        {"id": str(child_source_id), "role": "video"},
+        {"id": str(audio_source_id), "role": "audio"},
+    ]
     assert use_cases.flows.get_flow(child_flow_id, include_collected_by=True).data[
         "collected_by"
     ] == [str(parent_flow_id)]
@@ -751,6 +771,10 @@ def test_use_cases_project_flow_collection_relationships_with_postgres(
     assert (
         "collected_by"
         not in use_cases.flows.get_flow(child_flow_id, include_collected_by=True).data
+    )
+    assert (
+        "collected_by"
+        not in use_cases.flows.get_flow(audio_flow_id, include_collected_by=True).data
     )
 
 
@@ -1116,3 +1140,58 @@ def test_repository_claims_delete_requests_and_webhook_deliveries_with_leases(
 
     postgres_repo.webhook_repository.delete_webhook(webhook_id)
     assert postgres_repo.webhook_repository.get_webhook(webhook_id) is None
+
+
+def test_repository_claims_webhook_deliveries_in_queue_order(
+    postgres_repo: PostgresRepository,
+) -> None:
+    webhook_id = uuid4()
+    base_time = datetime.now(UTC) - timedelta(minutes=5)
+    first_id = UUID("00000000-0000-4000-8000-000000000101")
+    second_id = UUID("00000000-0000-4000-8000-000000000102")
+    third_id = UUID("00000000-0000-4000-8000-000000000103")
+    created_times = {
+        first_id: base_time,
+        second_id: base_time + timedelta(seconds=1),
+        third_id: base_time + timedelta(seconds=2),
+    }
+
+    postgres_repo.webhook_repository.save_webhook(
+        WebhookRecord(
+            id=webhook_id,
+            data={"url": "https://webhook.example.test/tamoss"},
+            status="started",
+        )
+    )
+    for delivery_id, sequence in (
+        (third_id, "third"),
+        (first_id, "first"),
+        (second_id, "second"),
+    ):
+        created = created_times[delivery_id]
+        postgres_repo.webhook_repository.save_webhook_delivery(
+            WebhookDeliveryRecord(
+                id=delivery_id,
+                webhook_id=webhook_id,
+                webhook_snapshot={"status": "started"},
+                event_type="flows/updated",
+                event_timestamp=created,
+                payload={"sequence": sequence},
+                status="pending",
+                created=created,
+                updated=created,
+                next_attempt_at=created,
+            )
+        )
+
+    claimed = postgres_repo.webhook_repository.claim_webhook_deliveries(
+        worker_id="worker-order",
+        limit=3,
+        lease_seconds=30,
+    )
+
+    assert [delivery.payload["sequence"] for delivery in claimed] == [
+        "first",
+        "second",
+        "third",
+    ]

--- a/tests/application/test_segment_repository_shape.py
+++ b/tests/application/test_segment_repository_shape.py
@@ -19,7 +19,7 @@ from tamoss.domain.model import (
     WebhookRecord,
 )
 from tamoss.domain.pagination import Page
-from tamoss.domain.segments import SegmentTimerangeBounds
+from tamoss.domain.segments import SegmentTimerangeBounds, timerange_union
 from tamoss.settings import Settings, StorageBackendSettings
 
 from tests.support.object_storage import InMemoryObjectStorage
@@ -219,6 +219,41 @@ def test_segment_registration_uses_bounded_repository_shape() -> None:
     assert repository.append_segment_calls == 0
 
 
+def test_single_flow_timerange_uses_bounded_collection_lookup() -> None:
+    repository = CountingRepository(_storage_backend())
+    use_cases = _use_cases(repository)
+    parent_id = uuid4()
+    child_id = uuid4()
+    unrelated_id = uuid4()
+    parent = _flow(parent_id)
+    parent.data["flow_collection"] = [{"id": str(child_id), "role": "video"}]
+    repository.save_flow(parent)
+    repository.save_flow(_flow(child_id))
+    repository.save_flow(_flow(unrelated_id))
+    repository.append_segment(
+        SegmentRecord(
+            flow_id=child_id,
+            object_id="bbc/performance/child.ts",
+            timerange="[0:0_10:0)",
+        )
+    )
+    repository.append_segment(
+        SegmentRecord(
+            flow_id=unrelated_id,
+            object_id="bbc/performance/unrelated.ts",
+            timerange="[50:0_60:0)",
+        )
+    )
+    repository.reset_counts()
+
+    result = use_cases.flows.flow_timerange(parent_id)
+
+    assert result == "[0:0_10:0)"
+    assert repository.list_flows_calls == 0
+    assert repository.get_flow_calls == 2
+    assert repository.flow_timeranges_requests == [[parent_id, child_id]]
+
+
 class CountingRepository:
     def __init__(self, storage_backend: StorageBackend):
         self._storage_backend = storage_backend
@@ -228,9 +263,12 @@ class CountingRepository:
         self.reset_counts()
 
     def reset_counts(self) -> None:
+        self.get_flow_calls = 0
         self.get_object_calls = 0
         self.get_objects_calls = 0
+        self.list_flows_calls = 0
         self.save_object_calls = 0
+        self.flow_timeranges_requests: list[list[UUID]] = []
         self.list_segments_calls = 0
         self.list_segments_page_calls = 0
         self.list_segments_overlapping_calls = 0
@@ -298,6 +336,7 @@ class CountingRepository:
         self._flows[flow.id] = flow
 
     def list_flows(self) -> list[FlowRecord]:
+        self.list_flows_calls += 1
         return list(self._flows.values())
 
     def list_flows_page(self, **kwargs) -> Page[FlowRecord]:
@@ -306,9 +345,15 @@ class CountingRepository:
         return Page(items=flows[:limit], limit=limit)
 
     def flow_timeranges(self, flow_ids: Iterable[UUID]) -> dict[UUID, str]:
-        return dict.fromkeys(flow_ids, "()")
+        requested_ids = list(dict.fromkeys(flow_ids))
+        self.flow_timeranges_requests.append(requested_ids)
+        return {
+            flow_id: timerange_union(self._segments.get(flow_id, []))
+            for flow_id in requested_ids
+        }
 
     def get_flow(self, flow_id: UUID) -> FlowRecord | None:
+        self.get_flow_calls += 1
         return self._flows.get(flow_id)
 
     def get_source(self, source_id: UUID) -> SourceRecord | None:


### PR DESCRIPTION
## Summary

Aligns webhook filtering, delivery ordering, collection timeranges, and segment update publishing so webhook consumers receive consistent flow and collection events.
Adds coverage for collection webhook behavior to lock in the expected payloads and delivery order.

## Validation

- [ ] `task check` passes locally.
- [ ] Relevant focused suites were run, or the reason they are not needed is
      explained below.
- [ ] `task security:audit` was run for dependency, packaging, or workflow
      changes.
- [ ] `task openapi:check` was run for API, OpenAPI, or BBC vendor changes.
- [ ] New or changed environment variables are documented in
      `docs/configuration.md`.
- [ ] BBC compatibility is unaffected, or `task test:bbc` and the BBC
      inventory were updated.
- [ ] Operator Chainsaw changes include the relevant local/CI run result, plus
      follow-up links for deferred branch-protection, flake-soak, or HA cases.