### PR TITLE
Split operator release and schema version metadata

### DIFF
--- a/.github/scripts/release-metadata.py
+++ b/.github/scripts/release-metadata.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Emit release metadata from the operator compatibility manifest."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    raise SystemExit(1)
+
+
+def as_dict(value: Any, context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        fail(f"{context} must be an object")
+    return value
+
+
+def load_releases(path: Path) -> list[dict[str, Any]]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(f"{path} must remain JSON-compatible YAML: {exc}")
+
+    releases = as_dict(data, str(path)).get("releases")
+    if not isinstance(releases, list):
+        fail(f"{path} must contain a releases list")
+    if not releases:
+        fail(f"{path} must contain at least one release")
+    return [as_dict(item, "release") for item in releases]
+
+
+def validate_releases(
+    releases: list[dict[str, Any]],
+    path: Path,
+    *,
+    verbose: bool = True,
+) -> None:
+    versions: set[str] = set()
+    for release in releases:
+        version = required_string(release, "version", path)
+        required_string(release, "schemaRevision", path, version)
+        required_string(release, "tamsAPI", path, version)
+        if version in versions:
+            fail(f"{path} contains duplicate release {version}")
+        versions.add(version)
+
+    for release in releases:
+        version = str(release["version"])
+        upgrade = as_dict(release.get("upgrade"), f"release {version} upgrade")
+        required_string(upgrade, "class", path, version)
+        upgrade_from = upgrade.get("from")
+        if not isinstance(upgrade_from, list):
+            fail(f"release {version} upgrade.from must be a list")
+        for source in upgrade_from:
+            if not isinstance(source, str) or not source:
+                fail(
+                    f"release {version} upgrade.from entries must be non-empty strings"
+                )
+            if source not in versions:
+                fail(
+                    f"release {version} upgrade.from references unknown "
+                    f"release {source}"
+                )
+
+    if verbose:
+        print(f"validated {len(releases)} releases in {path}")
+
+
+def required_string(
+    mapping: dict[str, Any],
+    key: str,
+    path: Path,
+    version: str | None = None,
+) -> str:
+    value = mapping.get(key)
+    context = f"release {version}" if version else str(path)
+    if not isinstance(value, str) or not value:
+        fail(f"{context} must contain non-empty {key}")
+    return value
+
+
+def emit_release_metadata(
+    version: str, releases: list[dict[str, Any]], path: Path
+) -> None:
+    validate_releases(releases, path, verbose=False)
+
+    release = None
+    for item in releases:
+        if item.get("version") == version:
+            release = item
+            break
+    if release is None:
+        fail(f"release {version} not found in {path}")
+
+    upgrade = as_dict(release.get("upgrade", {}), f"release {version} upgrade")
+    upgrade_from = upgrade.get("from", [])
+    if not isinstance(upgrade_from, list):
+        fail(f"release {version} upgrade.from must be a list")
+
+    metadata = {
+        "version": release.get("version"),
+        "schema_revision": release.get("schemaRevision"),
+        "tams_api": release.get("tamsAPI"),
+        "upgrade_class": upgrade.get("class", ""),
+        "upgrade_from": ",".join(str(item) for item in upgrade_from),
+    }
+    for key, value in metadata.items():
+        if value is None:
+            fail(f"release {version} is missing {key}")
+        print(f"{key}={value}")
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        fail(
+            "usage: release-metadata.py <version> [compatibility-file] | "
+            "release-metadata.py --validate [compatibility-file]"
+        )
+
+    if sys.argv[1] == "--validate":
+        if len(sys.argv) > 3:
+            fail("usage: release-metadata.py --validate [compatibility-file]")
+        path = (
+            Path(sys.argv[2])
+            if len(sys.argv) == 3
+            else Path("operator/compatibility.yaml")
+        )
+        validate_releases(load_releases(path), path)
+        return
+
+    if len(sys.argv) not in {2, 3}:
+        fail("usage: release-metadata.py <version> [compatibility-file]")
+
+    version = sys.argv[1]
+    path = (
+        Path(sys.argv[2]) if len(sys.argv) == 3 else Path("operator/compatibility.yaml")
+    )
+    emit_release_metadata(version, load_releases(path), path)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/docker-hub.yaml
+++ b/.github/workflows/docker-hub.yaml
@@ -42,16 +42,18 @@ jobs:
             echo "tag=type=raw,value=sha-${PR_HEAD_SHA::7}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Resolve build version
+      - name: Resolve operator build metadata
         id: build-version
         shell: bash
         run: |
           if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
             version="${GITHUB_REF_NAME#v}"
+            python3 .github/scripts/release-metadata.py "${version}" >> "$GITHUB_OUTPUT"
           else
-            version="dev"
+            echo "version=dev" >> "$GITHUB_OUTPUT"
+            echo "schema_revision=dev" >> "$GITHUB_OUTPUT"
+            echo "tams_api=8.0" >> "$GITHUB_OUTPUT"
           fi
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Extract Git metadata
         id: meta
@@ -97,6 +99,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ steps.build-version.outputs.version }}
+            SCHEMA_VERSION=${{ steps.build-version.outputs.schema_revision }}
+            TAMS_API_VERSION=${{ steps.build-version.outputs.tams_api }}
           platforms: "linux/amd64,linux/arm64"
           provenance: mode=max
           sbom: true

--- a/.github/workflows/operator-release.yaml
+++ b/.github/workflows/operator-release.yaml
@@ -45,11 +45,11 @@ jobs:
               ;;
           esac
 
-      - name: Extract version from tag
+      - name: Resolve release metadata
         id: version
         run: |
           VERSION=${GITHUB_REF_NAME#v}
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          python3 .github/scripts/release-metadata.py "${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Verify release assets are current
         run: |

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -69,6 +69,9 @@ jobs:
             exit 1
           fi
 
+      - name: Check release metadata
+        run: python3 .github/scripts/release-metadata.py --validate
+
       - name: Render remote environment overlay
         run: |
           environment="ci-single-server"

--- a/.tasks/lib/operator_chainsaw.sh
+++ b/.tasks/lib/operator_chainsaw.sh
@@ -23,13 +23,15 @@ task_operator_chainsaw_up() {
   local install_cnpg_operator="${CHAINSAW_INSTALL_CNPG_OPERATOR:-false}"
   local install_authentik_fixture="${CHAINSAW_INSTALL_AUTHENTIK_FIXTURE:-false}"
   local platform_helmfile="${CHAINSAW_PLATFORM_HELMFILE:-deploy/platform/helmfile.yaml.gotmpl}"
+  local schema_version="${SCHEMA_VERSION:-$version}"
+  local tams_api_version="${TAMS_API_VERSION:-8.0}"
 
   mkdir -p "$(dirname "$kubeconfig")" reports
 
   task_operator_chainsaw_register_cleanup "$cluster" "$keep_cluster"
 
   task_step "Operator Chainsaw: build operator image" \
-    make -C operator docker-build IMG="$operator_image" SCHEMA_VERSION="$version"
+    make -C operator docker-build IMG="$operator_image" VERSION="$version" SCHEMA_VERSION="$schema_version" TAMS_API_VERSION="$tams_api_version"
   docker tag "$operator_image" "$chainsaw_image"
 
   task_step "Operator Chainsaw: build API image" \

--- a/.tasks/lib/operator_upgrade.sh
+++ b/.tasks/lib/operator_upgrade.sh
@@ -26,6 +26,9 @@ task_operator_upgrade_previous_config_dir() {
 task_operator_upgrade_prepare_previous() {
   local previous_ref="${TAMOSS_OPERATOR_PREVIOUS_REF:-HEAD^}"
   local previous_image
+  local previous_version="${TAMOSS_OPERATOR_PREVIOUS_VERSION:-0.0.1}"
+  local previous_schema_version="${TAMOSS_OPERATOR_PREVIOUS_SCHEMA_VERSION:-$previous_version}"
+  local previous_tams_api_version="${TAMOSS_OPERATOR_PREVIOUS_TAMS_API_VERSION:-8.0}"
   local workdir="${TAMOSS_OPERATOR_UPGRADE_WORKDIR:-.local/operator-upgrade}"
   local previous_source="$workdir/previous-source"
   local previous_config_dir
@@ -44,7 +47,9 @@ task_operator_upgrade_prepare_previous() {
   if [ -z "${TAMOSS_OPERATOR_PREVIOUS_IMAGE:-}" ]; then
     task_step "Operator upgrade: build previous operator image" \
       docker build \
-        --build-arg VERSION="${TAMOSS_OPERATOR_PREVIOUS_VERSION:-0.0.1}" \
+        --build-arg VERSION="$previous_version" \
+        --build-arg SCHEMA_VERSION="$previous_schema_version" \
+        --build-arg TAMS_API_VERSION="$previous_tams_api_version" \
         -t "$previous_image" \
         -f "$previous_source/operator/Dockerfile" \
         "$previous_source"

--- a/.tasks/operator.yaml
+++ b/.tasks/operator.yaml
@@ -5,6 +5,8 @@ set: [errexit, nounset, pipefail]
 vars:
   PROFILE: '{{default "local-kind" (default (env "PROFILE") .PROFILE)}}'
   VERSION: '{{default "0.0.1" (default (env "VERSION") .VERSION)}}'
+  SCHEMA_VERSION: '{{default .VERSION (default (env "SCHEMA_VERSION") .SCHEMA_VERSION)}}'
+  TAMS_API_VERSION: '{{default "8.0" (default (env "TAMS_API_VERSION") .TAMS_API_VERSION)}}'
   OPERATOR_KUSTOMIZE_DIR: '{{default "deploy/operator" .OPERATOR_KUSTOMIZE_DIR}}'
   PLATFORM_DEPENDENCIES_FILE: '{{default "deploy/platform/dependencies.yaml" .PLATFORM_DEPENDENCIES_FILE}}'
   OPERATOR_NAMESPACE: '{{default "tamoss-system" .OPERATOR_NAMESPACE}}'
@@ -41,7 +43,7 @@ tasks:
         set -euo pipefail
         . .tasks/lib/progress.sh
         task_step "{{.STEP_LABEL}}" \
-          make -C operator docker-build IMG="{{.OPERATOR_IMAGE}}" SCHEMA_VERSION="{{.VERSION}}"
+          make -C operator docker-build IMG="{{.OPERATOR_IMAGE}}" VERSION="{{.VERSION}}" SCHEMA_VERSION="{{.SCHEMA_VERSION}}" TAMS_API_VERSION="{{.TAMS_API_VERSION}}"
 
   test:
     silent: true

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -4,6 +4,8 @@ FROM --platform=$BUILDPLATFORM golang:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION=0.0.1
+ARG SCHEMA_VERSION
+ARG TAMS_API_VERSION=8.0
 
 WORKDIR /workspace/operator
 
@@ -20,8 +22,9 @@ COPY operator/internal/ internal/
 # Build. TARGETOS and TARGETARCH are set by buildx for multi-arch builds and may
 # be empty for a plain local build, in which case Go uses the builder image
 # architecture.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -trimpath \
-    -ldflags "-X github.com/livewyer-ops/tamoss/operator/internal/schema.SchemaVersion=${VERSION}" \
+RUN schema_version="${SCHEMA_VERSION:-$VERSION}" && \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -trimpath \
+    -ldflags "-X github.com/livewyer-ops/tamoss/operator/internal/schema.SchemaVersion=${schema_version} -X github.com/livewyer-ops/tamoss/operator/internal/schema.SupportedTAMSAPIVersion=${TAMS_API_VERSION}" \
     -o /workspace/manager ./cmd
 
 # Use distroless as minimal base image to package the manager binary

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -10,7 +10,8 @@ IMG ?= livewyer/tamoss-operator:v$(VERSION)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.29.x
 SCHEMA_VERSION ?= $(VERSION)
-GO_LDFLAGS ?= -X github.com/livewyer-ops/tamoss/operator/internal/schema.SchemaVersion=$(SCHEMA_VERSION)
+TAMS_API_VERSION ?= 8.0
+GO_LDFLAGS ?= -X github.com/livewyer-ops/tamoss/operator/internal/schema.SchemaVersion=$(SCHEMA_VERSION) -X github.com/livewyer-ops/tamoss/operator/internal/schema.SupportedTAMSAPIVersion=$(TAMS_API_VERSION)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -98,7 +99,11 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	$(CONTAINER_TOOL) build --build-arg VERSION=$(SCHEMA_VERSION) -t ${IMG} -f Dockerfile ..
+	$(CONTAINER_TOOL) build \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg SCHEMA_VERSION=$(SCHEMA_VERSION) \
+		--build-arg TAMS_API_VERSION=$(TAMS_API_VERSION) \
+		-t ${IMG} -f Dockerfile ..
 
 ##@ Dependencies
 

--- a/operator/compatibility.yaml
+++ b/operator/compatibility.yaml
@@ -1,0 +1,24 @@
+{
+  "releases": [
+    {
+      "version": "8.0.0-oss1",
+      "tamsAPI": "8.0",
+      "schemaRevision": "8.0.0-oss1",
+      "upgrade": {
+        "class": "FreshInstall",
+        "from": []
+      }
+    },
+    {
+      "version": "8.1.0-oss1",
+      "tamsAPI": "8.1",
+      "schemaRevision": "8.0.0-oss1",
+      "upgrade": {
+        "class": "APIOnly",
+        "from": [
+          "8.0.0-oss1"
+        ]
+      }
+    }
+  ]
+}

--- a/operator/internal/controller/defaults/images.go
+++ b/operator/internal/controller/defaults/images.go
@@ -7,5 +7,4 @@ const (
 	DefaultPostgresClientImage = "postgres:18-alpine"
 	DefaultCNPGPostgresVersion = "18"
 	DefaultRustFSImage         = "rustfs/rustfs:1.0.0-beta.3"
-	DefaultTAMSAPIVersion      = "8.0"
 )

--- a/operator/internal/controller/resolved_status_test.go
+++ b/operator/internal/controller/resolved_status_test.go
@@ -9,6 +9,7 @@ import (
 
 	tamossv1alpha1 "github.com/livewyer-ops/tamoss/operator/api/v1alpha1"
 	"github.com/livewyer-ops/tamoss/operator/internal/controller/defaults"
+	schemabundle "github.com/livewyer-ops/tamoss/operator/internal/schema"
 )
 
 func TestResolvedTamossStatusUsesProfileDefaults(t *testing.T) {
@@ -56,7 +57,7 @@ func TestResolvedTamossStatusUsesProfileDefaults(t *testing.T) {
 	if tamoss.Status.Resolved.Versions.Tamoss != "dev" {
 		t.Fatalf("expected runtime version from local-kind image tag, got %#v", tamoss.Status.Resolved.Versions)
 	}
-	if tamoss.Status.Resolved.Versions.TAMSAPI != defaults.DefaultTAMSAPIVersion {
+	if tamoss.Status.Resolved.Versions.TAMSAPI != schemabundle.SupportedTAMSAPIVersion {
 		t.Fatalf("expected TAMS API compatibility version, got %#v", tamoss.Status.Resolved.Versions)
 	}
 	if tamoss.Status.Resolved.Resources.API != "example-api" ||

--- a/operator/internal/controller/tamoss_status_resolved.go
+++ b/operator/internal/controller/tamoss_status_resolved.go
@@ -76,7 +76,7 @@ func resolvedTamossStatus(tamoss *tamossv1alpha1.Tamoss) tamossv1alpha1.Resolved
 		Versions: tamossv1alpha1.ResolvedVersionStatus{
 			Schema:  schemabundle.SchemaVersion,
 			Tamoss:  resolvedRuntimeVersion(tamoss),
-			TAMSAPI: defaults.DefaultTAMSAPIVersion,
+			TAMSAPI: schemabundle.SupportedTAMSAPIVersion,
 		},
 	}
 	if tamoss.Spec.Backends.DB.Provider() == tamossv1alpha1.BackendProvidedByCNPG && tamoss.Spec.Backends.DB.CNPG != nil {

--- a/operator/internal/schema/bundle.go
+++ b/operator/internal/schema/bundle.go
@@ -1,3 +1,3 @@
 package schema
 
-const SupportedTAMSAPIVersion = "8.0"
+var SupportedTAMSAPIVersion = "8.0"

--- a/operator/internal/schema/verify_test.go
+++ b/operator/internal/schema/verify_test.go
@@ -11,6 +11,12 @@ func TestSchemaVersionDefaultsToDevelopmentMarker(t *testing.T) {
 	}
 }
 
+func TestSupportedTAMSAPIVersionDefaultsTo80(t *testing.T) {
+	if SupportedTAMSAPIVersion != "8.0" {
+		t.Fatalf("expected default TAMS API compatibility version %q, got %q", "8.0", SupportedTAMSAPIVersion)
+	}
+}
+
 func TestValidateVersionRejectsPlaceholders(t *testing.T) {
 	for _, version := range []string{"", "0.0.0", "v0.0.0"} {
 		if err := ValidateVersion(version); err == nil {
@@ -34,5 +40,24 @@ func TestIsSupportedStartingVersion(t *testing.T) {
 	}
 	if IsSupportedStartingVersion("unknown") {
 		t.Fatal("unknown schema version should not be supported")
+	}
+}
+
+func TestIsSupportedStartingVersionAcceptsPreviousRevision(t *testing.T) {
+	currentVersion := SchemaVersion
+	previousVersion := PreviousSupportedSchemaVersion
+	defer func() {
+		SchemaVersion = currentVersion
+		PreviousSupportedSchemaVersion = previousVersion
+	}()
+
+	SchemaVersion = "8.1.0-oss1"
+	PreviousSupportedSchemaVersion = "8.0.0-oss1"
+
+	if !IsSupportedStartingVersion("8.0.0-oss1") {
+		t.Fatal("previous supported schema revision should be accepted")
+	}
+	if IsSupportedStartingVersion("7.9.0-oss1") {
+		t.Fatal("unsupported previous schema revision should be rejected")
 	}
 }


### PR DESCRIPTION
## Summary

Separates TAMOSS release tags from DB schema revisions and TAMS API compatibility in operator builds so we can map upgrades more accurately. 

## Validation

- [ ] `task check` passes locally.
- [ ] Relevant focused suites were run, or the reason they are not needed is
      explained below.
- [ ] `task security:audit` was run for dependency, packaging, or workflow
      changes.
- [ ] `task openapi:check` was run for API, OpenAPI, or BBC vendor changes.
- [ ] New or changed environment variables are documented in
      `docs/configuration.md`.
- [ ] BBC compatibility is unaffected, or `task test:bbc` and the BBC
      inventory were updated.
- [ ] Operator Chainsaw changes include the relevant local/CI run result, plus
      follow-up links for deferred branch-protection, flake-soak, or HA cases.