### PR TITLE
Harden storage allocation first use

### DIFF
--- a/src/app/tamoss/adapters/postgres_repository/mappers.py
+++ b/src/app/tamoss/adapters/postgres_repository/mappers.py
@@ -93,6 +93,7 @@ def _media_object_from_record(
         id=record["id"],
         timerange=record.get("timerange"),
         first_referenced_by_flow=_optional_uuid(record.get("first_referenced_by_flow")),
+        allocated_by_flow=_optional_uuid(record.get("allocated_by_flow")),
         referenced_by_flows={
             UUID(flow_id) for flow_id in record.get("referenced_by_flows", [])
         },
@@ -391,6 +392,9 @@ def _media_object_to_record(media_object: MediaObjectRecord) -> JsonRecord:
         "timerange": media_object.timerange,
         "first_referenced_by_flow": str(media_object.first_referenced_by_flow)
         if media_object.first_referenced_by_flow
+        else None,
+        "allocated_by_flow": str(media_object.allocated_by_flow)
+        if media_object.allocated_by_flow
         else None,
         "referenced_by_flows": [
             str(flow_id)

--- a/src/app/tamoss/adapters/postgres_repository/types.py
+++ b/src/app/tamoss/adapters/postgres_repository/types.py
@@ -48,6 +48,7 @@ class MediaObjectRow(TypedDict, total=False):
     id: str
     timerange: str | None
     first_referenced_by_flow: str | None
+    allocated_by_flow: str | None
     referenced_by_flows: list[str]
     instances: list[ObjectInstanceRow]
     key_frame_count: int | None

--- a/src/app/tamoss/application/contexts/segments.py
+++ b/src/app/tamoss/application/contexts/segments.py
@@ -201,6 +201,10 @@ class SegmentUseCases:
                 _has_controlled_instance(media_object)
                 and not existing_object_references
             ):
+                self._ensure_controlled_object_allocation_matches_flow(
+                    media_object,
+                    flow_id=flow.id,
+                )
                 self._ensure_controlled_object_uploaded(media_object)
             if existing_object_references:
                 if segment_post.get("object_timerange") is not None:
@@ -225,6 +229,7 @@ class SegmentUseCases:
 
         if media_object.first_referenced_by_flow is None:
             media_object.first_referenced_by_flow = flow.id
+        media_object.allocated_by_flow = None
         media_object.referenced_by_flows.add(flow.id)
         effective_object_timerange = object_timerange_from_segment_fields(
             timerange=str(segment_post["timerange"]),
@@ -288,6 +293,18 @@ class SegmentUseCases:
             media_object.bytes_written = metadata.content_length or 0
             return
         raise BadRequest("Bad request. Invalid Flow Segment JSON.")
+
+    def _ensure_controlled_object_allocation_matches_flow(
+        self, media_object: MediaObjectRecord, *, flow_id: UUID
+    ) -> None:
+        if (
+            media_object.allocated_by_flow is not None
+            and media_object.allocated_by_flow != flow_id
+        ):
+            raise BadRequest(
+                "Bad request. Allocated Object must be registered against the "
+                "Flow that requested its storage."
+            )
 
     def _ensure_segment_timerange_is_available(
         self, *, known_segments: list[SegmentRecord], timerange: str

--- a/src/app/tamoss/application/contexts/storage.py
+++ b/src/app/tamoss/application/contexts/storage.py
@@ -77,6 +77,7 @@ class StorageUseCases:
                     if self._reserve_allocated_object(
                         object_id=object_id,
                         backend=backend,
+                        flow_id=flow_id,
                     ):
                         object_ids.append(object_id)
             else:
@@ -84,6 +85,7 @@ class StorageUseCases:
                     if not self._reserve_allocated_object(
                         object_id=object_id,
                         backend=backend,
+                        flow_id=flow_id,
                     ):
                         raise BadRequest(
                             "One or more supplied object_ids already exist."
@@ -106,10 +108,10 @@ class StorageUseCases:
         return allocations
 
     def _reserve_allocated_object(
-        self, *, object_id: str, backend: StorageBackend
+        self, *, object_id: str, backend: StorageBackend, flow_id: UUID
     ) -> bool:
         self._validate_storage_object_id(object_id)
-        media_object = MediaObjectRecord(id=object_id)
+        media_object = MediaObjectRecord(id=object_id, allocated_by_flow=flow_id)
         media_object.instances.append(
             ObjectInstance(
                 storage_backend=backend,

--- a/src/app/tamoss/domain/model.py
+++ b/src/app/tamoss/domain/model.py
@@ -262,6 +262,7 @@ class MediaObjectRecord:
     id: str
     timerange: str | None = None
     first_referenced_by_flow: UUID | None = None
+    allocated_by_flow: UUID | None = None
     referenced_by_flows: set[UUID] = field(default_factory=set)
     instances: list[ObjectInstance] = field(default_factory=list)
     key_frame_count: int | None = None

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "mediatimestamp>=5.2.0",
     "psycopg[binary,pool]>=3.1.0",
     "requests>=2.33.0",
-    "pyjwt[crypto]>=2.10.0",
+    "pyjwt[crypto]>=2.13.0",
     "pydantic-settings>=2.7.0",
 ]
 

--- a/src/uv.lock
+++ b/src/uv.lock
@@ -880,11 +880,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]
@@ -1147,7 +1147,7 @@ requires-dist = [
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.1.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.7.0" },
-    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10.0" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.13.0" },
     { name = "requests", specifier = ">=2.33.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.24.0" },
 ]

--- a/tests/adapters/bbc/test_flows_sources_and_segments.py
+++ b/tests/adapters/bbc/test_flows_sources_and_segments.py
@@ -215,6 +215,70 @@ def test_list_flows_can_include_timerange_compatibility_extension(
     assert_bbc_error(invalid.json())
 
 
+def test_empty_timerange_query_discovers_empty_flows_for_retention_cleanup(
+    client: TestClient,
+) -> None:
+    segmented_flow_id, _, _ = create_video_flow(client)
+    empty_flow_id, _, _ = create_video_flow(client)
+    register_segment(client, segmented_flow_id, timerange="[0:0_10:0)")
+
+    listed = client.get(
+        "/flows",
+        params={"timerange": "()", "include_timerange": "true"},
+    )
+
+    assert listed.status_code == 200
+    payload = {item["id"]: item for item in listed.json()}
+    assert set(payload) == {str(empty_flow_id)}
+    assert payload[str(empty_flow_id)]["timerange"] == "()"
+
+    head = client.head("/flows", params={"timerange": "()"})
+    assert head.status_code == 200
+
+
+def test_retention_tags_are_discoverable_with_tag_exists_filters(
+    client: TestClient,
+) -> None:
+    segment_retention_flow_id, _, _ = create_video_flow(
+        client,
+        tags={"segment_retention_offset": "3600:0"},
+    )
+    flow_retention_flow_id, _, _ = create_video_flow(
+        client,
+        tags={"flow_retention_offset": "86400:0"},
+    )
+    regular_flow_id, _, _ = create_video_flow(client)
+
+    segment_retention = client.get(
+        "/flows",
+        params={"tag_exists.segment_retention_offset": "true"},
+    )
+    flow_retention = client.get(
+        "/flows",
+        params={"tag_exists.flow_retention_offset": "true"},
+    )
+    no_segment_retention = client.get(
+        "/flows",
+        params={"tag_exists.segment_retention_offset": "false"},
+    )
+
+    assert segment_retention.status_code == 200
+    assert [item["id"] for item in segment_retention.json()] == [
+        str(segment_retention_flow_id)
+    ]
+    assert flow_retention.status_code == 200
+    assert [item["id"] for item in flow_retention.json()] == [
+        str(flow_retention_flow_id)
+    ]
+    assert no_segment_retention.status_code == 200
+    no_segment_retention_ids = {item["id"] for item in no_segment_retention.json()}
+    assert str(segment_retention_flow_id) not in no_segment_retention_ids
+    assert {
+        str(flow_retention_flow_id),
+        str(regular_flow_id),
+    } <= no_segment_retention_ids
+
+
 def test_collection_flows_include_child_timerange_compatibility_extension(
     client: TestClient,
 ) -> None:
@@ -512,6 +576,8 @@ def test_segments_accept_bbc_bodies_and_emit_paging_headers(
     payload = listed.json()
     assert payload[0]["object_id"] == object_two
     assert payload[0]["object_timerange"] == "[100:0_110:0)"
+    assert payload[0]["sample_offset"] == 10
+    assert payload[0]["sample_count"] == 250
     assert payload[0]["get_urls"][0]["storage_id"] == str(PRIMARY_BACKEND_ID)
     assert payload[0]["get_urls"][0]["controlled"] is True
 

--- a/tests/adapters/bbc/test_storage_objects_and_deletion.py
+++ b/tests/adapters/bbc/test_storage_objects_and_deletion.py
@@ -78,6 +78,13 @@ def test_storage_allocation_and_object_instance_lifecycle(
     assert segment.status_code == 400
 
     upload_allocated_object(client, object_id)
+    other_flow_id, _, _ = create_video_flow(client)
+
+    wrong_flow_segment = client.post(
+        f"/flows/{other_flow_id}/segments",
+        json=segment_payload(object_id),
+    )
+    assert wrong_flow_segment.status_code == 400
 
     segment = client.post(
         f"/flows/{flow_id}/segments",
@@ -111,6 +118,12 @@ def test_storage_allocation_and_object_instance_lifecycle(
     )
     assert non_verbose.status_code == 200
     assert set(non_verbose.json()["get_urls"][0]) == {"url", "label", "presigned"}
+
+    reused = client.post(
+        f"/flows/{other_flow_id}/segments",
+        json=segment_payload(object_id),
+    )
+    assert reused.status_code == 201
 
     uncontrolled = client.post(
         f"/objects/{quote(object_id, safe='')}/instances",

--- a/tests/fixtures/tams/obligations.yaml
+++ b/tests/fixtures/tams/obligations.yaml
@@ -35,6 +35,18 @@ obligations:
     tests:
       - tests/adapters/bbc/test_flows_sources_and_segments.py::test_flow_collection_projects_to_source_collection_and_collected_by
 
+  - id: flows.empty-timerange-discovery
+    source: bbc-appnote:0019-implementing-retention-management
+    requirement: Empty TimeRange flow queries discover Flows with no Segments for retention cleanup workflows.
+    tests:
+      - tests/adapters/bbc/test_flows_sources_and_segments.py::test_empty_timerange_query_discovers_empty_flows_for_retention_cleanup
+
+  - id: retention.tag-discovery-primitives
+    source: bbc-appnote:0019-implementing-retention-management
+    requirement: Retention workers can discover segment and flow retention tags using tag_exists filters.
+    tests:
+      - tests/adapters/bbc/test_flows_sources_and_segments.py::test_retention_tags_are_discoverable_with_tag_exists_filters
+
   - id: segments.bulk-create
     source: bbc-adr:0029-bulk-flow-segments
     requirement: Segment registration accepts single and bulk bodies and reports per-segment failures.
@@ -55,9 +67,21 @@ obligations:
     tests:
       - tests/adapters/bbc/test_flows_sources_and_segments.py::test_segment_registration_derives_object_timerange_from_ts_offset
 
+  - id: segments.deprecated-sample-fields
+    source: bbc-adr:0036-specifying-partial-segment-usage
+    requirement: Deprecated sample_offset and sample_count fields remain stored and returned when supplied.
+    tests:
+      - tests/adapters/bbc/test_flows_sources_and_segments.py::test_segments_accept_bbc_bodies_and_emit_paging_headers
+
   - id: objects.instances.lifecycle
     source: bbc-adr:0038-improved-storage-management
     requirement: Controlled and uncontrolled object instances are managed from the object boundary.
+    tests:
+      - tests/adapters/bbc/test_storage_objects_and_deletion.py::test_storage_allocation_and_object_instance_lifecycle
+
+  - id: objects.instances.first-registration-flow-match
+    source: bbc-appnote:0018-multiple-flows-referencing-the-same-object
+    requirement: Allocated controlled Objects can only be first registered against the Flow that requested storage, then may be reused by other Flows.
     tests:
       - tests/adapters/bbc/test_storage_objects_and_deletion.py::test_storage_allocation_and_object_instance_lifecycle
 
@@ -73,6 +97,12 @@ obligations:
     requirement: Object instance updates are visible to every segment that references the same media object.
     tests:
       - tests/adapters/bbc/test_storage_objects_and_deletion.py::test_object_instance_updates_are_visible_to_all_reused_object_segments
+
+  - id: objects.instances.stale-allocation-cleanup
+    source: bbc-adr:0044-signalling-timeouts
+    requirement: Stale allocated controlled Objects are cleaned up after min_object_timeout, including stored bytes.
+    tests:
+      - tests/adapters/bbc/test_storage_objects_and_deletion.py::test_worker_cleans_up_stale_allocated_controlled_object
 
   - id: get-urls.filtering
     source: bbc-adr:0023-filter-segment-get-urls


### PR DESCRIPTION
## Summary

Adds obligation coverage for current TAMS API compatibility gaps and retention discovery primitives.
Enforces first registration of allocated controlled objects against the Flow that requested storage, while preserving later cross-Flow object reuse.


## Validation

- [ ] `task check` passes locally.
- [ ] Relevant focused suites were run, or the reason they are not needed is
      explained below.
- [ ] `task security:audit` was run for dependency, packaging, or workflow
      changes.
- [ ] `task openapi:check` was run for API, OpenAPI, or BBC vendor changes.
- [ ] New or changed environment variables are documented in
      `docs/configuration.md`.
- [ ] BBC compatibility is unaffected, or `task test:bbc` and the BBC
      inventory were updated.
- [ ] Operator Chainsaw changes include the relevant local/CI run result, plus
      follow-up links for deferred branch-protection, flake-soak, or HA cases.