### PR TITLE
Enforce presigned timeout contract

### DIFF
--- a/src/app/tamoss/adapters/object_storage.py
+++ b/src/app/tamoss/adapters/object_storage.py
@@ -269,7 +269,7 @@ class ConfiguredObjectStorage:
                 "Key": object_id,
                 "ContentType": content_type,
             },
-            ExpiresIn=self._settings.s3_presign_ttl_seconds,
+            ExpiresIn=self._settings.presigned_put_ttl_seconds(),
         )
 
     def _presign_get_url(self, *, backend: StorageBackend, object_id: str) -> str:

--- a/src/app/tamoss/application/contexts/deletion.py
+++ b/src/app/tamoss/application/contexts/deletion.py
@@ -209,7 +209,7 @@ class DeletionUseCases:
 
     def queue_stale_allocated_object_cleanups(self, *, max_objects: int = 50) -> int:
         before = utc_now() - timedelta(
-            seconds=_timestamp_duration_seconds(self.settings.min_object_timeout)
+            seconds=self.settings.min_object_timeout_seconds()
         )
         with self.repository.unit_of_work():
             media_objects = self.repository.list_unreferenced_objects_created_before(
@@ -241,11 +241,3 @@ def _has_controlled_instance(media_object: MediaObjectRecord) -> bool:
         instance.controlled and instance.storage_backend is not None
         for instance in media_object.instances
     )
-
-
-def _timestamp_duration_seconds(value: str) -> float:
-    try:
-        seconds, nanoseconds = value.split(":", 1)
-        return int(seconds) + (int(nanoseconds) / 1_000_000_000)
-    except (TypeError, ValueError) as exc:
-        raise BadRequest("Bad request. Invalid service object timeout.") from exc

--- a/src/app/tamoss/settings.py
+++ b/src/app/tamoss/settings.py
@@ -8,6 +8,7 @@ from typing import Annotated, overload
 from urllib.parse import quote, urlparse
 from uuid import UUID
 
+from mediatimestamp import Timestamp
 from pydantic import (
     BaseModel,
     Field,
@@ -22,6 +23,9 @@ from tamoss.version import BBC_TAMS_API_VERSION, TAMOSS_VERSION
 
 DEFAULT_TAMOSS_S3_STORAGE_BACKEND_ID = UUID("f1ab5b54-9703-42ed-b181-11ba1c794a7f")
 DEFAULT_WORKER_LEASE_SECONDS = 300
+NANOSECONDS_PER_SECOND = 1_000_000_000
+MIN_OBJECT_TIMEOUT_SECONDS = 300
+MIN_PRESIGNED_URL_TIMEOUT_SECONDS = 30
 
 _OAUTH2_JWT_ALGORITHMS = frozenset(
     {
@@ -221,8 +225,14 @@ class Settings(BaseSettings):
         default=10,
         validation_alias="TAMOSS_DATABASE_POOL_MAX_SIZE",
     )
-    min_object_timeout: str = "300:0"
-    min_presigned_url_timeout: str = "30:0"
+    min_object_timeout: str = Field(
+        default="300:0",
+        validation_alias="TAMOSS_MIN_OBJECT_TIMEOUT",
+    )
+    min_presigned_url_timeout: str = Field(
+        default="30:0",
+        validation_alias="TAMOSS_MIN_PRESIGNED_URL_TIMEOUT",
+    )
     s3_presign_ttl_seconds: int = Field(
         default=3600,
         validation_alias="TAMOSS_S3_PRESIGN_TTL",
@@ -441,6 +451,41 @@ class Settings(BaseSettings):
             )
         return self
 
+    @model_validator(mode="after")
+    def validate_timeout_contract(self) -> Settings:
+        min_object_timeout = _timestamp_duration_seconds(
+            self.min_object_timeout,
+            setting_name="min_object_timeout",
+        )
+        min_presigned_url_timeout = _timestamp_duration_seconds(
+            self.min_presigned_url_timeout,
+            setting_name="min_presigned_url_timeout",
+        )
+        if min_object_timeout < MIN_OBJECT_TIMEOUT_SECONDS:
+            raise ValueError("min_object_timeout must be at least 300:0")
+        if min_presigned_url_timeout < MIN_PRESIGNED_URL_TIMEOUT_SECONDS:
+            raise ValueError("min_presigned_url_timeout must be at least 30:0")
+        if min_presigned_url_timeout > min_object_timeout:
+            raise ValueError(
+                "min_presigned_url_timeout must be less than or equal to "
+                "min_object_timeout"
+            )
+        if self.s3_presign_ttl_seconds < min_presigned_url_timeout:
+            raise ValueError(
+                "TAMOSS_S3_PRESIGN_TTL must be greater than or equal to "
+                "min_presigned_url_timeout"
+            )
+        return self
+
+    def min_object_timeout_seconds(self) -> int:
+        return _timestamp_duration_seconds(
+            self.min_object_timeout,
+            setting_name="min_object_timeout",
+        )
+
+    def presigned_put_ttl_seconds(self) -> int:
+        return min(self.s3_presign_ttl_seconds, self.min_object_timeout_seconds())
+
     def api_token_value(self) -> str | None:
         return (
             read_secret_file(
@@ -554,3 +599,16 @@ def _require_url(name: str, value: str | None) -> str:
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
         raise ValueError(f"{name} must be an absolute http(s) URL")
     return candidate
+
+
+def _timestamp_duration_seconds(value: str, *, setting_name: str) -> int:
+    try:
+        nanoseconds = int(Timestamp.from_str(value).to_nanosec())
+    except Exception as exc:
+        raise ValueError(f"{setting_name} must be a valid TAMS timestamp") from exc
+    if nanoseconds < 0:
+        raise ValueError(f"{setting_name} must not be negative")
+    seconds, remainder = divmod(nanoseconds, NANOSECONDS_PER_SECOND)
+    if remainder:
+        raise ValueError(f"{setting_name} must be a whole-second TAMS timestamp")
+    return seconds

--- a/tests/adapters/storage/test_configured_object_storage_unit.py
+++ b/tests/adapters/storage/test_configured_object_storage_unit.py
@@ -154,6 +154,42 @@ def test_build_put_request_uses_flow_container_as_content_type(monkeypatch) -> N
     ]
 
 
+def test_presigned_put_urls_do_not_outlive_allocated_object_timeout(
+    monkeypatch,
+) -> None:
+    presign_calls: list[tuple[str, int]] = []
+
+    class FakeS3Client:
+        def generate_presigned_url(self, *args, **kwargs) -> str:
+            presign_calls.append((args[0], kwargs["ExpiresIn"]))
+            return f"https://storage.example.test/{args[0]}"
+
+    monkeypatch.setattr(
+        "tamoss.adapters.object_storage.boto3.client",
+        lambda *args, **kwargs: FakeS3Client(),
+    )
+
+    backend = _s3_backend()
+    storage = ConfiguredObjectStorage(
+        Settings(
+            auth_required=False,
+            min_object_timeout="300:0",
+            min_presigned_url_timeout="30:0",
+            s3_presign_ttl_seconds=3600,
+            storage_backend=_settings_backend(backend),
+        )
+    )
+
+    storage.build_put_request(
+        object_id="media/object.ts",
+        flow_container="video/mp2t",
+        backend=backend,
+    )
+    storage.build_get_urls(object_id="media/object.ts", backend=backend)
+
+    assert presign_calls == [("put_object", 300), ("get_object", 3600)]
+
+
 def test_runtime_credentials_file_takes_precedence_over_persisted_credentials(
     monkeypatch,
     tmp_path,

--- a/tests/application/test_settings.py
+++ b/tests/application/test_settings.py
@@ -14,6 +14,13 @@ from tamoss.settings import Settings, read_secret_file
         ("TAMOSS_STORAGE_BACKEND_REGISTRATION_ENABLED", "sometimes", "boolean"),
         ("TAMOSS_OAUTH2_ISSUER", "auth.example.test", "TAMOSS_OAUTH2_ISSUER"),
         ("TAMOSS_S3_ENDPOINT", "objects.internal", "TAMOSS_S3_ENDPOINT"),
+        ("TAMOSS_MIN_OBJECT_TIMEOUT", "299:0", "min_object_timeout"),
+        (
+            "TAMOSS_MIN_PRESIGNED_URL_TIMEOUT",
+            "29:0",
+            "min_presigned_url_timeout",
+        ),
+        ("TAMOSS_S3_PRESIGN_TTL", "29", "TAMOSS_S3_PRESIGN_TTL"),
     ],
 )
 def test_settings_reject_invalid_runtime_env(
@@ -123,6 +130,39 @@ def test_disabled_oauth_accepts_empty_operator_url_env(
 
 def test_storage_backend_registration_is_disabled_by_default() -> None:
     assert Settings().storage_backend_registration_enabled is False
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        (
+            {"min_presigned_url_timeout": "301:0"},
+            "min_presigned_url_timeout must be less than or equal to",
+        ),
+        (
+            {
+                "min_object_timeout": "300:500000000",
+            },
+            "min_object_timeout must be a whole-second",
+        ),
+    ],
+)
+def test_settings_reject_timeout_contracts(
+    kwargs: dict[str, object], message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        Settings(**kwargs)
+
+
+def test_settings_caps_presigned_put_ttl_at_object_timeout() -> None:
+    settings = Settings(
+        min_object_timeout="300:0",
+        min_presigned_url_timeout="30:0",
+        s3_presign_ttl_seconds=3600,
+    )
+
+    assert settings.min_object_timeout_seconds() == 300
+    assert settings.presigned_put_ttl_seconds() == 300
 
 
 def test_default_versions_are_not_placeholders() -> None:


### PR DESCRIPTION
## Summary

Align configurable TAMS timeout metadata with generated presigned URL behaviour, so allocation PUT URLs cannot outlive stale object cleanup.
Adds runtime validation for object and presigned timeout settings while preserving the existing configured TTL for GET URLs.

## Validation

- [ ] `task check` passes locally.
- [ ] Relevant focused suites were run, or the reason they are not needed is
      explained below.
- [ ] `task security:audit` was run for dependency, packaging, or workflow
      changes.
- [ ] `task openapi:check` was run for API, OpenAPI, or BBC vendor changes.
- [ ] New or changed environment variables are documented in
      `docs/configuration.md`.
- [ ] BBC compatibility is unaffected, or `task test:bbc` and the BBC
      inventory were updated.
- [ ] Operator Chainsaw changes include the relevant local/CI run result, plus
      follow-up links for deferred branch-protection, flake-soak, or HA cases.