### PR TITLE
Add 8.0.0-oss2 release metadata

### DIFF
--- a/operator/compatibility.yaml
+++ b/operator/compatibility.yaml
@@ -10,13 +10,24 @@
       }
     },
     {
+      "version": "8.0.0-oss2",
+      "tamsAPI": "8.0",
+      "schemaRevision": "8.0.0-oss1",
+      "upgrade": {
+        "class": "APIOnly",
+        "from": [
+          "8.0.0-oss1"
+        ]
+      }
+    },
+    {
       "version": "8.1.0-oss1",
       "tamsAPI": "8.1",
       "schemaRevision": "8.0.0-oss1",
       "upgrade": {
         "class": "APIOnly",
         "from": [
-          "8.0.0-oss1"
+          "8.0.0-oss2"
         ]
       }
     }


### PR DESCRIPTION
## Summary
Adds 8.0.0-oss2 as an API-only release from 8.0.0-oss1, keeping the schema revision unchanged because no database migration is required. Updates 8.1.0-oss1 to upgrade from 8.0.0-oss2 so the compatibility path reflects the next 8.0 release before 8.1.

## Validation

- [ ] `task check` passes locally.
- [ ] Relevant focused suites were run, or the reason they are not needed is
      explained below.
- [ ] `task security:audit` was run for dependency, packaging, or workflow
      changes.
- [ ] `task openapi:check` was run for API, OpenAPI, or BBC vendor changes.
- [ ] New or changed environment variables are documented in
      `docs/configuration.md`.
- [ ] BBC compatibility is unaffected, or `task test:bbc` and the BBC
      inventory were updated.
- [ ] Operator Chainsaw changes include the relevant local/CI run result, plus
      follow-up links for deferred branch-protection, flake-soak, or HA cases.