### PR TITLE
Fix release schema metadata builds

### DIFF
--- a/.github/scripts/release-metadata.py
+++ b/.github/scripts/release-metadata.py
@@ -88,6 +88,7 @@ def emit_release_metadata(
     version: str, releases: list[dict[str, Any]], path: Path
 ) -> None:
     validate_releases(releases, path, verbose=False)
+    releases_by_version = {str(item.get("version")): item for item in releases}
 
     release = None
     for item in releases:
@@ -102,9 +103,22 @@ def emit_release_metadata(
     if not isinstance(upgrade_from, list):
         fail(f"release {version} upgrade.from must be a list")
 
+    previous_schema_revisions = {
+        required_string(
+            releases_by_version[str(item)], "schemaRevision", path, str(item)
+        )
+        for item in upgrade_from
+    }
+    if len(previous_schema_revisions) > 1:
+        fail(
+            f"release {version} upgrade.from references multiple schema revisions: "
+            f"{', '.join(sorted(previous_schema_revisions))}"
+        )
+
     metadata = {
         "version": release.get("version"),
         "schema_revision": release.get("schemaRevision"),
+        "previous_schema_revision": next(iter(previous_schema_revisions), ""),
         "tams_api": release.get("tamsAPI"),
         "upgrade_class": upgrade.get("class", ""),
         "upgrade_from": ",".join(str(item) for item in upgrade_from),

--- a/.github/workflows/docker-hub.yaml
+++ b/.github/workflows/docker-hub.yaml
@@ -222,10 +222,13 @@ jobs:
         run: |
           if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
             version="${GITHUB_REF_NAME#v}"
+            python3 .github/scripts/release-metadata.py "${version}" >> "$GITHUB_OUTPUT"
           else
-            version="dev"
+            echo "version=dev" >> "$GITHUB_OUTPUT"
+            echo "schema_revision=dev" >> "$GITHUB_OUTPUT"
+            echo "previous_schema_revision=" >> "$GITHUB_OUTPUT"
+            echo "tams_api=8.0" >> "$GITHUB_OUTPUT"
           fi
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Extract Git metadata
         id: meta
@@ -270,6 +273,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ steps.build-version.outputs.version }}
+            SCHEMA_VERSION=${{ steps.build-version.outputs.schema_revision }}
+            PREVIOUS_SCHEMA_VERSION=${{ steps.build-version.outputs.previous_schema_revision }}
+            TAMS_API_VERSION=${{ steps.build-version.outputs.tams_api }}
           platforms: "linux/amd64,linux/arm64"
           provenance: mode=max
           sbom: true

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -5,6 +5,7 @@ ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION=0.0.1
 ARG SCHEMA_VERSION
+ARG PREVIOUS_SCHEMA_VERSION
 ARG TAMS_API_VERSION=8.0
 
 WORKDIR /workspace/operator
@@ -23,8 +24,9 @@ COPY operator/internal/ internal/
 # be empty for a plain local build, in which case Go uses the builder image
 # architecture.
 RUN schema_version="${SCHEMA_VERSION:-$VERSION}" && \
+    previous_schema_version="${PREVIOUS_SCHEMA_VERSION:-}" && \
     CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -trimpath \
-    -ldflags "-X github.com/livewyer-ops/tamoss/operator/internal/schema.SchemaVersion=${schema_version} -X github.com/livewyer-ops/tamoss/operator/internal/schema.SupportedTAMSAPIVersion=${TAMS_API_VERSION}" \
+    -ldflags "-X github.com/livewyer-ops/tamoss/operator/internal/schema.SchemaVersion=${schema_version} -X github.com/livewyer-ops/tamoss/operator/internal/schema.PreviousSupportedSchemaVersion=${previous_schema_version} -X github.com/livewyer-ops/tamoss/operator/internal/schema.SupportedTAMSAPIVersion=${TAMS_API_VERSION}" \
     -o /workspace/manager ./cmd
 
 # Use distroless as minimal base image to package the manager binary

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -10,8 +10,9 @@ IMG ?= livewyer/tamoss-operator:v$(VERSION)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.29.x
 SCHEMA_VERSION ?= $(VERSION)
+PREVIOUS_SCHEMA_VERSION ?=
 TAMS_API_VERSION ?= 8.0
-GO_LDFLAGS ?= -X github.com/livewyer-ops/tamoss/operator/internal/schema.SchemaVersion=$(SCHEMA_VERSION) -X github.com/livewyer-ops/tamoss/operator/internal/schema.SupportedTAMSAPIVersion=$(TAMS_API_VERSION)
+GO_LDFLAGS ?= -X github.com/livewyer-ops/tamoss/operator/internal/schema.SchemaVersion=$(SCHEMA_VERSION) -X github.com/livewyer-ops/tamoss/operator/internal/schema.PreviousSupportedSchemaVersion=$(PREVIOUS_SCHEMA_VERSION) -X github.com/livewyer-ops/tamoss/operator/internal/schema.SupportedTAMSAPIVersion=$(TAMS_API_VERSION)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -102,6 +103,7 @@ docker-build: ## Build docker image with the manager.
 	$(CONTAINER_TOOL) build \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg SCHEMA_VERSION=$(SCHEMA_VERSION) \
+		--build-arg PREVIOUS_SCHEMA_VERSION=$(PREVIOUS_SCHEMA_VERSION) \
 		--build-arg TAMS_API_VERSION=$(TAMS_API_VERSION) \
 		-t ${IMG} -f Dockerfile ..
 

--- a/operator/compatibility.yaml
+++ b/operator/compatibility.yaml
@@ -21,13 +21,24 @@
       }
     },
     {
+      "version": "8.0.0-oss3",
+      "tamsAPI": "8.0",
+      "schemaRevision": "8.0.0-oss1",
+      "upgrade": {
+        "class": "APIOnly",
+        "from": [
+          "8.0.0-oss1"
+        ]
+      }
+    },
+    {
       "version": "8.1.0-oss1",
       "tamsAPI": "8.1",
       "schemaRevision": "8.0.0-oss1",
       "upgrade": {
         "class": "APIOnly",
         "from": [
-          "8.0.0-oss2"
+          "8.0.0-oss3"
         ]
       }
     }

--- a/src/app/tamoss/Dockerfile
+++ b/src/app/tamoss/Dockerfile
@@ -2,6 +2,7 @@
 FROM python:3.11.14-alpine3.22
 
 ARG VERSION=tamoss-dev
+ARG TAMS_API_VERSION=8.0
 
 LABEL "org.opencontainers.image.authors"="LiveWyer"
 LABEL "org.opencontainers.image.description"="TAMOSS API server"
@@ -18,7 +19,8 @@ EXPOSE 8000
 ENV PYTHONPATH=/app/app \
   UV_CACHE_DIR=/tmp/uv-cache \
   TAMOSS_VERSION=${VERSION} \
-  TAMOSS_SERVICE_VERSION=${VERSION}
+  TAMOSS_SERVICE_VERSION=${VERSION} \
+  TAMOSS_TAMS_API_VERSION=${TAMS_API_VERSION}
 
 COPY --chown=1001:1001 src/app ./app
 

--- a/tests/scripts/test_release_metadata.py
+++ b/tests/scripts/test_release_metadata.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from tests.support.paths import REPO_ROOT
+
+SCRIPT = REPO_ROOT / ".github/scripts/release-metadata.py"
+
+
+def run_metadata(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        cwd=REPO_ROOT,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+def parse_output(output: str) -> dict[str, str]:
+    items: dict[str, str] = {}
+    for line in output.splitlines():
+        key, _, value = line.partition("=")
+        items[key] = value
+    return items
+
+
+def test_release_metadata_emits_previous_schema_revision() -> None:
+    result = run_metadata("8.0.0-oss2")
+
+    assert result.returncode == 0, result.stderr
+    metadata = parse_output(result.stdout)
+    assert metadata["version"] == "8.0.0-oss2"
+    assert metadata["schema_revision"] == "8.0.0-oss1"
+    assert metadata["previous_schema_revision"] == "8.0.0-oss1"
+    assert metadata["tams_api"] == "8.0"
+
+
+def test_release_metadata_emits_corrected_80_release_metadata() -> None:
+    result = run_metadata("8.0.0-oss3")
+
+    assert result.returncode == 0, result.stderr
+    metadata = parse_output(result.stdout)
+    assert metadata["version"] == "8.0.0-oss3"
+    assert metadata["schema_revision"] == "8.0.0-oss1"
+    assert metadata["previous_schema_revision"] == "8.0.0-oss1"
+    assert metadata["tams_api"] == "8.0"
+    assert metadata["upgrade_from"] == "8.0.0-oss1"
+
+
+def test_release_metadata_rejects_multiple_previous_schema_revisions(
+    tmp_path: Path,
+) -> None:
+    manifest = tmp_path / "compatibility.json"
+    manifest.write_text(
+        """
+        {
+          "releases": [
+            {
+              "version": "8.0.0-oss1",
+              "schemaRevision": "schema-a",
+              "tamsAPI": "8.0",
+              "upgrade": {"class": "Initial", "from": []}
+            },
+            {
+              "version": "8.0.0-oss2",
+              "schemaRevision": "schema-b",
+              "tamsAPI": "8.0",
+              "upgrade": {"class": "Schema", "from": ["8.0.0-oss1"]}
+            },
+            {
+              "version": "8.0.0-oss3",
+              "schemaRevision": "schema-c",
+              "tamsAPI": "8.0",
+              "upgrade": {
+                "class": "Schema",
+                "from": ["8.0.0-oss1", "8.0.0-oss2"]
+              }
+            }
+          ]
+        }
+        """,
+        encoding="utf-8",
+    )
+
+    result = run_metadata("8.0.0-oss3", str(manifest))
+
+    assert result.returncode == 1
+    assert "references multiple schema revisions" in result.stderr


### PR DESCRIPTION
Builds release operator images from compatibility metadata so product tags, schema revisions and previous supported schema revisions stay distinct. Adds 8.0.0-oss3 as the corrected 8.0 API-only release path and moves the 8.1 upgrade baseline to it.