### PR TITLE
Improve TAMS conformance and deployed target coverage`

### DIFF
--- a/.tasks/kind.yaml
+++ b/.tasks/kind.yaml
@@ -10,6 +10,7 @@ vars:
   UI_IMAGE: '{{default "livewyer/tamoss-ui:dev" (default (env "UI_IMAGE") .UI_IMAGE)}}'
   OPERATOR_IMAGE: '{{default "livewyer/tamoss-operator:dev" (default (env "OPERATOR_IMAGE") .OPERATOR_IMAGE)}}'
   DEMO_MEDIA_FILE: '{{default "deploy/demo/tamoss-demo.ts" .DEMO_MEDIA_FILE}}'
+  KIND_DEMO_INGEST: '{{default "true" (default (env "KIND_DEMO_INGEST") .KIND_DEMO_INGEST)}}'
   KIND_SUMMARY: '{{default "true" (default (env "KIND_SUMMARY") .KIND_SUMMARY)}}'
   PROFILE_TARGET_ENV:
     sh: '. .tasks/lib/profile.sh; task_profile_field "{{.PROFILE}}" targetEnv'
@@ -139,6 +140,7 @@ tasks:
           KUBECONFIG: "{{.KUBECONFIG}}"
           PROFILE_TARGET_ENV: "{{.PROFILE_TARGET_ENV}}"
           DEMO_MEDIA_FILE: "{{.DEMO_MEDIA_FILE}}"
+          KIND_DEMO_INGEST: "{{.KIND_DEMO_INGEST}}"
       - task: :e2e:deployed
         vars:
           PROFILE: "{{.PROFILE}}"

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -13,6 +13,7 @@ vars:
   OPERATOR_KUSTOMIZE_DIR: '{{default "deploy/operator" .OPERATOR_KUSTOMIZE_DIR}}'
   LOCAL_OPERATOR_KUSTOMIZE_DIR: '{{default "deploy/operator/local" .LOCAL_OPERATOR_KUSTOMIZE_DIR}}'
   DEMO_MEDIA_FILE: '{{default "deploy/demo/tamoss-demo.ts" .DEMO_MEDIA_FILE}}'
+  KIND_DEMO_INGEST: '{{default "true" (default (env "KIND_DEMO_INGEST") .KIND_DEMO_INGEST)}}'
   KIND_SUMMARY: '{{default "true" (default (env "KIND_SUMMARY") .KIND_SUMMARY)}}'
   TAMOSS_NAMESPACE: '{{default "tams" .TAMOSS_NAMESPACE}}'
   PROFILE: '{{default "local-kind" (default (env "PROFILE") .PROFILE)}}'
@@ -84,7 +85,7 @@ tasks:
       - task: operator:platform:deps:check
 
   kind:up:
-    desc: "Local Kind: build images, create or reuse Kind, apply the selected Tamoss instance, and ingest playable demo media"
+    desc: "Local Kind: build images, create or reuse Kind, apply the selected Tamoss instance, and optionally ingest playable demo media"
     silent: true
     cmds:
       - task: init
@@ -126,6 +127,7 @@ tasks:
           KUBECONFIG: "{{.KUBECONFIG}}"
           PROFILE_TARGET_ENV: "{{.PROFILE_TARGET_ENV}}"
           DEMO_MEDIA_FILE: "{{.DEMO_MEDIA_FILE}}"
+          KIND_DEMO_INGEST: "{{.KIND_DEMO_INGEST}}"
       - |
         if [ "{{.KIND_SUMMARY}}" != "false" ]; then
           task env:summary \
@@ -141,8 +143,12 @@ tasks:
       - |
         set -euo pipefail
         . .tasks/lib/progress.sh
-        task_step "Demo media: ingest playable media" \
-          .tasks/lib/demo_ingest.sh "{{.PROFILE_TARGET_ENV}}" "{{.DEMO_MEDIA_FILE}}" "{{.KUBECONFIG}}"
+        if [ "{{.KIND_DEMO_INGEST}}" = "false" ]; then
+          task_step "Demo media: skip playable media ingest" true
+        else
+          task_step "Demo media: ingest playable media" \
+            .tasks/lib/demo_ingest.sh "{{.PROFILE_TARGET_ENV}}" "{{.DEMO_MEDIA_FILE}}" "{{.KUBECONFIG}}"
+        fi
 
   kind:down:
     desc: "Local Kind: delete the disposable Kind cluster and local runtime state"
@@ -182,6 +188,7 @@ tasks:
           PROJECT_NAME: "{{.PROJECT_NAME}}"
           KIND_CONFIG: "{{.KIND_CONFIG}}"
           KUBECONFIG: "{{.KUBECONFIG}}"
+          KIND_DEMO_INGEST: "{{.KIND_DEMO_INGEST}}"
 
   kind:test:
     desc: "Local Kind validation: deploy the selected profile and run deployed checks"
@@ -193,6 +200,7 @@ tasks:
           PROJECT_NAME: "{{.PROJECT_NAME}}"
           KIND_CONFIG: "{{.KIND_CONFIG}}"
           KUBECONFIG: "{{.KUBECONFIG}}"
+          KIND_DEMO_INGEST: "{{.KIND_DEMO_INGEST}}"
       - task: e2e:deployed
         vars:
           PROFILE: "{{.PROFILE}}"

--- a/docs/getting-started/local-kind.md
+++ b/docs/getting-started/local-kind.md
@@ -33,11 +33,17 @@ task kind:up PROFILE=local-kind
 5. Apply the `local-kind` instance overlay.
 6. Wait for `Tamoss/tamoss-kind` to report `Ready=True`.
 7. Ingest one tiny playable demo segment through the deployed API and storage
-   backend.
+   backend, unless `KIND_DEMO_INGEST=false` is set.
 
 The summary prints first-start lifecycle status, the app URL, app
 username/password, API docs URL, API token, OAuth client details, and storage
 credentials.
+
+For a clean API validation target with no seeded demo flow/source:
+
+```bash
+task kind:up PROFILE=local-kind KIND_DEMO_INGEST=false
+```
 
 To print the same access details and current Kubernetes status again:
 

--- a/docs/reference/task-commands.md
+++ b/docs/reference/task-commands.md
@@ -13,7 +13,7 @@ names or descriptions change.
 
 | Command | Purpose |
 | --- | --- |
-| `task kind:up PROFILE=local-kind` | Local Kind evaluation path: build local images, create or reuse Kind, apply the operator, apply the selected `Tamoss` instance, and ingest one playable demo segment. `PROFILE=multi-server` uses a multi-node Kind cluster. |
+| `task kind:up PROFILE=local-kind` | Local Kind evaluation path: build local images, create or reuse Kind, apply the operator, apply the selected `Tamoss` instance, and ingest one playable demo segment unless `KIND_DEMO_INGEST=false` is set. `PROFILE=multi-server` uses a multi-node Kind cluster. |
 | `task env:summary ENV_DIR=deploy/environments/local-kind KUBECONFIG=tams.kubeconfig` | Print lifecycle status, access URLs, app credentials, API token, OAuth client details, and storage credentials for a Kind or remote environment. |
 | `task kind:down` | Delete the disposable Kind cluster and local runtime state. |
 | `task kind:test PROFILE=local-kind` | Create or reuse Kind, deploy the selected profile, and run deployed TAMS/product checks. |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -51,7 +51,8 @@ curl -k -H "Authorization: Bearer $TAMOSS_TOKEN" \
 ## Ingest Helper
 
 `task kind:up` creates one tiny playable demo ingest without requiring local media
-conversion tools. The demo segment is registered with probe-derived
+conversion tools. Set `KIND_DEMO_INGEST=false` when you need a clean validation
+target with no seeded flow/source. The demo segment is registered with probe-derived
 `object_timerange`, `ts_offset`, `last_duration`, and `key_frame_count`
 metadata. Browser-managed ingest also probes finalized MPEG-TS segments before
 registering them, so registered segment timeranges come from measured media

--- a/operator/internal/controller/workload_renderer/deployment_api.go
+++ b/operator/internal/controller/workload_renderer/deployment_api.go
@@ -27,7 +27,7 @@ func renderAPIDeployment(tamoss *tamossv1alpha1.Tamoss) []client.Object {
 			spec,
 			image(tamoss.Spec.API.Image.Repository, tamoss.Spec.API.Image.Tag),
 			tamoss.Spec.API.Image.PullPolicy,
-			[]string{"/bin/uv", "run", "uvicorn", "tamoss.app:app", "--host", "0.0.0.0", "--port", fmt.Sprintf("%d", apiPort)},
+			[]string{"/bin/uv", "run", "uvicorn", "tamoss.app:app", "--host", "0.0.0.0", "--port", fmt.Sprintf("%d", apiPort), "--proxy-headers", "--forwarded-allow-ips", "*"},
 			env,
 			envFromSecrets(tamoss, tamoss.Spec.Secrets.APIToken.Generate, tamoss.Spec.Backends.DB.Provider() == tamossv1alpha1.BackendProvidedByCNPG, tamoss.Spec.Backends.S3.Provider() == tamossv1alpha1.S3BackendProvidedByRustFSOperator, oauth2CredentialsSecretName(tamoss), tamoss.Spec.API.EnvFrom),
 			[]corev1.ContainerPort{{Name: "http", ContainerPort: apiPort, Protocol: corev1.ProtocolTCP}},

--- a/src/app/frontend/package-lock.json
+++ b/src/app/frontend/package-lock.json
@@ -16,7 +16,7 @@
         "hls.js": "^1.6.16",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "react-router-dom": "^7.13.1"
+        "react-router-dom": "^7.17.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -4672,9 +4672,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
-      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -4694,12 +4694,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
-      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
+      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.1"
+        "react-router": "7.17.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/src/app/frontend/package.json
+++ b/src/app/frontend/package.json
@@ -28,7 +28,7 @@
     "hls.js": "^1.6.16",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-router-dom": "^7.13.1"
+    "react-router-dom": "^7.17.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/src/app/tamoss/Dockerfile
+++ b/src/app/tamoss/Dockerfile
@@ -29,4 +29,4 @@ RUN --mount=type=bind,source=src/pyproject.toml,target=/app/pyproject.toml \
   --mount=type=bind,source=src/README.md,target=/app/README.md \
   uv sync --frozen --no-dev
 
-CMD ["uv", "run", "uvicorn", "tamoss.app:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uv", "run", "uvicorn", "tamoss.app:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips", "*"]

--- a/src/app/tamoss/api/dependencies.py
+++ b/src/app/tamoss/api/dependencies.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from fastapi import Request
 
 from tamoss.application.contexts.deletion import DeletionUseCases
@@ -11,6 +13,14 @@ from tamoss.application.contexts.sources import SourceUseCases
 from tamoss.application.contexts.storage import StorageUseCases
 from tamoss.application.contexts.webhooks import WebhookUseCases
 from tamoss.application.use_cases import TamossUseCases
+from tamoss.errors import BadRequest
+
+
+async def require_json_body(request: Request) -> None:
+    try:
+        json.loads(await request.body())
+    except (UnicodeDecodeError, ValueError):
+        raise BadRequest("Bad request. Body must be valid JSON.") from None
 
 
 def get_use_cases(request: Request) -> TamossUseCases:

--- a/src/app/tamoss/api/routes/delete_requests.py
+++ b/src/app/tamoss/api/routes/delete_requests.py
@@ -9,6 +9,7 @@ from tamoss.api.dependencies import get_deletion_use_cases
 from tamoss.api.presenters import deletion_request_response, head_response
 from tamoss.api.query_params import validate_query_params
 from tamoss.application.contexts.deletion import DeletionUseCases
+from tamoss.errors import NotFound
 
 router = APIRouter(tags=["FlowDeleteRequests"])
 
@@ -41,12 +42,16 @@ def list_delete_requests(
     },
 )
 def get_delete_request(
-    request_id: UUID,
+    request_id: str,
     request: Request,
     deletion: DeletionUseCases = Depends(get_deletion_use_cases),
 ) -> Any:
     validate_query_params(request, set())
-    delete_request = deletion.get_delete_request(request_id)
+    try:
+        request_uuid = UUID(request_id)
+    except ValueError:
+        raise NotFound("The requested flow delete request does not exist.") from None
+    delete_request = deletion.get_delete_request(request_uuid)
     if head := head_response(request):
         return head
     return deletion_request_response(delete_request)

--- a/src/app/tamoss/api/routes/flows.py
+++ b/src/app/tamoss/api/routes/flows.py
@@ -5,7 +5,11 @@ from uuid import UUID
 
 from fastapi import APIRouter, Body, Depends, Path, Query, Request, Response, status
 
-from tamoss.api.dependencies import get_deletion_use_cases, get_flow_use_cases
+from tamoss.api.dependencies import (
+    get_deletion_use_cases,
+    get_flow_use_cases,
+    require_json_body,
+)
 from tamoss.api.presenters import (
     deletion_request_accepted_response,
     flow_response,
@@ -272,6 +276,7 @@ def get_flow_label(
 
 @router.put(
     "/flows/{flowId}/label",
+    dependencies=[Depends(require_json_body)],
     status_code=status.HTTP_204_NO_CONTENT,
     responses={
         400: {"description": "Bad request."},
@@ -334,6 +339,7 @@ def get_flow_description(
 
 @router.put(
     "/flows/{flowId}/description",
+    dependencies=[Depends(require_json_body)],
     status_code=status.HTTP_204_NO_CONTENT,
     responses={
         400: {"description": "Bad request."},
@@ -400,6 +406,7 @@ def get_flow_avg_bit_rate(
 
 @router.put(
     "/flows/{flowId}/avg_bit_rate",
+    dependencies=[Depends(require_json_body)],
     status_code=status.HTTP_204_NO_CONTENT,
     responses={
         400: {"description": "Bad request."},
@@ -466,6 +473,7 @@ def get_flow_max_bit_rate(
 
 @router.put(
     "/flows/{flowId}/max_bit_rate",
+    dependencies=[Depends(require_json_body)],
     status_code=status.HTTP_204_NO_CONTENT,
     responses={
         400: {"description": "Bad request."},
@@ -532,6 +540,7 @@ def get_flow_read_only(
 
 @router.put(
     "/flows/{flowId}/read_only",
+    dependencies=[Depends(require_json_body)],
     status_code=status.HTTP_204_NO_CONTENT,
     responses={
         400: {"description": "Bad request."},
@@ -599,6 +608,7 @@ def get_flow_tag(
 
 @router.put(
     "/flows/{flowId}/tags/{name:path}",
+    dependencies=[Depends(require_json_body)],
     status_code=status.HTTP_204_NO_CONTENT,
     responses={
         400: {"description": "Bad request."},

--- a/src/app/tamoss/api/routes/segments.py
+++ b/src/app/tamoss/api/routes/segments.py
@@ -26,9 +26,18 @@ from tamoss.contract.generated import contract_models
 from tamoss.contract.serialization import contract_dump
 from tamoss.domain.model import SegmentRecord
 from tamoss.domain.timeranges import finite_normalized_timerange_bounds
-from tamoss.errors import BadRequest, error_payload
+from tamoss.errors import BadRequest, NotFound, error_payload
 
 router = APIRouter(tags=["FlowSegments"])
+
+
+def _flow_id_or_404(value: str, message: str) -> UUID:
+    # The spec documents only 404 for this path parameter, so malformed
+    # Flow IDs resolve to 404 rather than the 400 used elsewhere.
+    try:
+        return UUID(value)
+    except ValueError:
+        raise NotFound(message) from None
 
 
 @router.get(
@@ -46,7 +55,7 @@ router = APIRouter(tags=["FlowSegments"])
     },
 )
 def list_segments(
-    flow_id: Annotated[UUID, Path(alias="flowId")],
+    flow_id_path: Annotated[str, Path(alias="flowId")],
     request: Request,
     response: Response,
     object_id: str | None = None,
@@ -61,6 +70,7 @@ def list_segments(
     limit: int | None = Query(default=None, gt=0),
     segments: SegmentUseCases = Depends(get_segment_use_cases),
 ) -> Any:
+    flow_id = _flow_id_or_404(flow_id_path, "The Flow ID in the path is invalid.")
     validate_query_params(
         request,
         {
@@ -126,10 +136,11 @@ def list_segments(
     },
 )
 def post_segments(
-    flow_id: Annotated[UUID, Path(alias="flowId")],
+    flow_id_path: Annotated[str, Path(alias="flowId")],
     body: contract_models.FlowSegmentPost | list[contract_models.FlowSegmentPost],
     segments: SegmentUseCases = Depends(get_segment_use_cases),
 ) -> Any:
+    flow_id = _flow_id_or_404(flow_id_path, "The requested Flow does not exist.")
     segment_body = (
         [contract_dump(segment) for segment in body]
         if isinstance(body, list)
@@ -179,12 +190,15 @@ def post_segments(
     },
 )
 def delete_segments(
-    flow_id: Annotated[UUID, Path(alias="flowId")],
+    flow_id_path: Annotated[str, Path(alias="flowId")],
     request: Request,
     timerange: str | None = None,
     object_id: str | None = None,
     deletion: DeletionUseCases = Depends(get_deletion_use_cases),
 ) -> Response:
+    flow_id = _flow_id_or_404(
+        flow_id_path, "The requested Flow ID in the path is invalid."
+    )
     validate_query_params(request, {"timerange", "object_id"})
     identity = identify_request(request)
     delete_request = deletion.delete_segments(

--- a/src/app/tamoss/api/routes/sources.py
+++ b/src/app/tamoss/api/routes/sources.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Body, Depends, Path, Query, Request, Response, status
 
-from tamoss.api.dependencies import get_source_use_cases
+from tamoss.api.dependencies import get_source_use_cases, require_json_body
 from tamoss.api.presenters import (
     head_response,
     source_response_with_relationships,
@@ -111,6 +111,7 @@ def get_source_label(
 
 @router.put(
     "/sources/{sourceId}/label",
+    dependencies=[Depends(require_json_body)],
     status_code=status.HTTP_204_NO_CONTENT,
     responses={
         400: {"description": "Bad request."},
@@ -167,6 +168,7 @@ def get_source_description(
 
 @router.put(
     "/sources/{sourceId}/description",
+    dependencies=[Depends(require_json_body)],
     status_code=status.HTTP_204_NO_CONTENT,
     responses={
         400: {"description": "Bad request."},
@@ -244,6 +246,7 @@ def get_source_tag(
 
 @router.put(
     "/sources/{sourceId}/tags/{name:path}",
+    dependencies=[Depends(require_json_body)],
     status_code=status.HTTP_204_NO_CONTENT,
     responses={
         400: {"description": "Bad request."},

--- a/src/app/tamoss/application/contexts/flows.py
+++ b/src/app/tamoss/application/contexts/flows.py
@@ -310,15 +310,18 @@ class FlowUseCases:
 
     def get_flow_property(
         self, flow_id: UUID, property_name: FlowPropertyName
-    ) -> str | int | bool:
+    ) -> str | int | bool | None:
         flow = self.get_flow(flow_id)
         if property_name == "read_only":
             return flow.read_only
         value = flow.data.get(property_name)
         if value is None:
-            if property_name == "label":
+            # Unset properties are readable once the Flow exists: empty string
+            # for the string properties, null for the numeric ones (the spec
+            # reserves 404 for a missing Flow and defines no unset form).
+            if property_name in {"label", "description"}:
                 return ""
-            raise NotFound("The requested Flow property does not exist.")
+            return None
         if property_name in {"label", "description"}:
             if not isinstance(value, str):
                 raise BadRequest("Bad request. Invalid Flow property value.")
@@ -467,7 +470,7 @@ class FlowUseCases:
         identity: Identity,
     ) -> tuple[FlowRecord, bool]:
         if UUID(str(flow.get("id"))) != flow_id:
-            raise BadRequest("Bad request. Invalid Flow JSON.")
+            raise NotFound("The requested Flow ID in the path is invalid.")
         supplied_fields = supplied_fields or set(flow)
         flow_collection_supplied = "flow_collection" in supplied_fields
         existing = self.repository.get_flow(flow_id)
@@ -503,6 +506,7 @@ class FlowUseCases:
                 id=source_id,
                 format=format_value,
                 label=data.get("label"),
+                description=data.get("description"),
                 tags=replacement_tags,
             )
             source_was_created = True

--- a/src/app/tamoss/application/contexts/sources.py
+++ b/src/app/tamoss/application/contexts/sources.py
@@ -108,9 +108,7 @@ class SourceUseCases:
     ) -> str:
         value = getattr(self.get_source(source_id), property_name)
         if value is None:
-            if property_name == "label":
-                return ""
-            raise NotFound("The requested Source property does not exist.")
+            return ""
         if not isinstance(value, str):
             raise BadRequest("Bad request. Invalid Source property value.")
         return value

--- a/src/app/tamoss/application/webhooks.py
+++ b/src/app/tamoss/application/webhooks.py
@@ -101,8 +101,11 @@ def validate_webhook_configuration(
 ) -> None:
     validate_webhook_url(data.get("url"), egress_policy=egress_policy)
     validate_api_key_header_name(data.get("api_key_name"))
-    events = _list_of_strings(data.get("events"))
-    if not events or any(event not in VALID_WEBHOOK_EVENTS for event in events):
+    events_value = data.get("events")
+    if not isinstance(events_value, list):
+        raise ValueError("Unsupported webhook event")
+    events = _list_of_strings(events_value)
+    if any(event not in VALID_WEBHOOK_EVENTS for event in events):
         raise ValueError("Unsupported webhook event")
 
 

--- a/tests/e2e/client.py
+++ b/tests/e2e/client.py
@@ -28,6 +28,9 @@ class E2EClient:
         last_error: str | None = None
         while time.monotonic() < deadline:
             try:
+                if self.target.readiness_mode == "service":
+                    self.request("GET", "/service", expected={200})
+                    return
                 health = self.request("GET", "/healthz", expected={200}, auth=False)
                 ready = self.request("GET", "/readyz", expected={200}, auth=False)
                 service = self.request("GET", "/service", expected={200})

--- a/tests/e2e/target.py
+++ b/tests/e2e/target.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import shlex
+import subprocess
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
@@ -62,6 +63,8 @@ class E2ETarget:
     oauth_issuer_url: str
     oauth_client_id: str
     oauth_client_secret: str | None
+    readiness_mode: str
+    upload_checksum_header: bool
     timeout_seconds: float = 10.0
 
     @classmethod
@@ -134,6 +137,12 @@ class E2ETarget:
                 namespace=oauth_secret_namespace,
                 enabled=oauth2_enabled,
             ),
+            readiness_mode=_readiness_mode(
+                values.get("TEST_TAMOSS_READINESS_MODE", "tamoss")
+            ),
+            upload_checksum_header=_env_bool(
+                values.get("TEST_TAMOSS_UPLOAD_CHECKSUM_HEADER", "true")
+            ),
             timeout_seconds=float(values.get("TEST_TIMEOUT_SECONDS", "10")),
         )
 
@@ -186,18 +195,61 @@ def _source_path(line: str, *, relative_to: Path) -> Path | None:
 
 def _load_token(values: dict[str, str]) -> str | None:
     if values.get("TEST_TAMOSS_TOKEN"):
-        return values["TEST_TAMOSS_TOKEN"]
+        return _normalize_token(values["TEST_TAMOSS_TOKEN"])
+    if values.get("TEST_TAMOSS_TOKEN_COMMAND"):
+        try:
+            completed = subprocess.run(
+                values["TEST_TAMOSS_TOKEN_COMMAND"],
+                check=False,
+                shell=True,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except subprocess.TimeoutExpired:
+            raise pytest.UsageError(
+                "TEST_TAMOSS_TOKEN_COMMAND timed out after 30 seconds."
+            ) from None
+        if completed.returncode != 0:
+            stderr = (completed.stderr or "").strip()[-500:]
+            raise pytest.UsageError(
+                "TEST_TAMOSS_TOKEN_COMMAND failed with exit code "
+                f"{completed.returncode}: {stderr}"
+            )
+        # The last stdout line wins so the command may emit progress output.
+        token = completed.stdout.strip().splitlines()[-1] if completed.stdout else ""
+        if not token:
+            raise pytest.UsageError("TEST_TAMOSS_TOKEN_COMMAND did not print a token.")
+        return _normalize_token(token)
     secret_name = values.get("TEST_TAMOSS_TOKEN_SECRET")
     if not secret_name:
         return None
     namespace = values.get("TEST_TAMOSS_NAMESPACE", "tams")
     kubeconfig = values.get("KUBECONFIG") or os.getenv("KUBECONFIG")
-    return load_secret_value(
-        kubeconfig=kubeconfig,
-        namespace=namespace,
-        secret_name=secret_name,
-        key="TAMOSS_API_TOKEN",
+    return _normalize_token(
+        load_secret_value(
+            kubeconfig=kubeconfig,
+            namespace=namespace,
+            secret_name=secret_name,
+            key="TAMOSS_API_TOKEN",
+        )
     )
+
+
+def _normalize_token(value: str) -> str:
+    token = value.strip()
+    if token.lower().startswith("bearer "):
+        return token[7:].strip()
+    return token
+
+
+def _readiness_mode(value: str) -> str:
+    mode = value.strip().lower()
+    if mode not in {"tamoss", "service"}:
+        raise pytest.UsageError(
+            "TEST_TAMOSS_READINESS_MODE must be 'tamoss' or 'service'."
+        )
+    return mode
 
 
 def _load_auth_password(

--- a/tests/e2e/test_target_env.py
+++ b/tests/e2e/test_target_env.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import shlex
+import sys
 from pathlib import Path
 
 import pytest
 
-from tests.e2e.target import _load_env_file
+from tests.e2e.target import E2ETarget, _load_env_file
 
 
 def test_target_env_sources_common_defaults(tmp_path: Path) -> None:
@@ -45,3 +47,50 @@ def test_target_env_rejects_source_cycles(tmp_path: Path) -> None:
 
     with pytest.raises(pytest.UsageError, match="source cycle"):
         _load_env_file(first)
+
+
+def test_target_env_loads_token_command_and_service_readiness(
+    tmp_path: Path,
+) -> None:
+    token_command = shlex.quote(
+        f"{sys.executable} -c 'print(\"Bearer command-token\")'"
+    )
+    target = tmp_path / "target.env"
+    target.write_text(
+        "\n".join(
+            [
+                "TEST_TAMOSS_API=https://api.example.test",
+                "TEST_TAMOSS_UI=https://ui.example.test",
+                "TEST_TAMOSS_AUTH_PASSWORD=unused",
+                f"TEST_TAMOSS_TOKEN_COMMAND={token_command}",
+                "TEST_TAMOSS_READINESS_MODE=service",
+                "TEST_TAMOSS_UPLOAD_CHECKSUM_HEADER=false",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = E2ETarget.from_file(target)
+
+    assert loaded.auth_headers == {"Authorization": "Bearer command-token"}
+    assert loaded.readiness_mode == "service"
+    assert loaded.upload_checksum_header is False
+
+
+def test_target_env_rejects_unknown_readiness_mode(tmp_path: Path) -> None:
+    target = tmp_path / "target.env"
+    target.write_text(
+        "\n".join(
+            [
+                "TEST_TAMOSS_API=https://api.example.test",
+                "TEST_TAMOSS_UI=https://ui.example.test",
+                "TEST_TAMOSS_AUTH_PASSWORD=unused",
+                "TEST_TAMOSS_TOKEN=token",
+                "TEST_TAMOSS_READINESS_MODE=unknown",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(pytest.UsageError, match="READINESS_MODE"):
+        E2ETarget.from_file(target)

--- a/tests/tams/conformance/test_flows_sources_and_segments.py
+++ b/tests/tams/conformance/test_flows_sources_and_segments.py
@@ -718,3 +718,100 @@ def test_segment_coverage_gap_header_is_separate_from_flow_extent(
     assert listed.status_code == 200
     assert listed.headers["x-paging-timerange"] == "[0:0_30:0)"
     assert listed.headers["x-tamoss-coverage-gaps"] == "[10:0_20:0)"
+
+
+def test_read_only_flow_rejects_writes_with_403(client: TestClient) -> None:
+    """bbc-id: semantic.flow.read_only_write_rejection"""
+    flow_id, _source_id, payload = create_video_flow(client)
+
+    assert client.put(f"/flows/{flow_id}/read_only", json=True).status_code == 204
+    assert client.get(f"/flows/{flow_id}/read_only").json() is True
+
+    rejected = {
+        "put_flow": client.put(f"/flows/{flow_id}", json=payload),
+        "put_description": client.put(f"/flows/{flow_id}/description", json="mutated"),
+        "put_tag": client.put(f"/flows/{flow_id}/tags/probe", json="x"),
+        "post_storage": client.post(
+            f"/flows/{flow_id}/storage",
+            json=storage_allocation_payload([f"bbc/{uuid4()}.ts"]),
+        ),
+        "delete_segments": client.delete(f"/flows/{flow_id}/segments"),
+        "delete_flow": client.delete(f"/flows/{flow_id}"),
+    }
+    for name, response in rejected.items():
+        assert response.status_code == 403, name
+        assert_bbc_error(response.json(), "forbidden")
+
+    assert client.put(f"/flows/{flow_id}/read_only", json=False).status_code == 204
+    assert client.delete(f"/flows/{flow_id}").status_code in {202, 204}
+
+
+def test_unset_label_and_description_read_as_empty_strings(
+    client: TestClient,
+) -> None:
+    """bbc-id: semantic.flow.unset_string_properties_are_readable"""
+    flow_id = uuid4()
+    source_id = uuid4()
+    payload = video_flow_payload(flow_id, source_id)
+    payload.pop("label", None)
+    payload.pop("description", None)
+    assert client.put(f"/flows/{flow_id}", json=payload).status_code == 201
+
+    for path in (
+        f"/flows/{flow_id}/label",
+        f"/flows/{flow_id}/description",
+        f"/sources/{source_id}/label",
+        f"/sources/{source_id}/description",
+    ):
+        response = client.get(path)
+        assert response.status_code == 200, path
+        assert response.json() == "", path
+
+
+def test_flow_put_with_mismatched_body_id_returns_404(client: TestClient) -> None:
+    """bbc-id: semantic.flow.path_id_authoritative"""
+    payload = video_flow_payload(uuid4(), uuid4())
+    response = client.put(f"/flows/{uuid4()}", json=payload)
+    assert response.status_code == 404
+    assert_bbc_error(response.json(), "not_found")
+    assert response.json()["summary"] == "The requested Flow ID in the path is invalid."
+
+
+def test_string_property_put_rejects_non_json_bodies(client: TestClient) -> None:
+    """bbc-id: semantic.flow.property_bodies_must_be_json"""
+    flow_id, source_id, _ = create_video_flow(client)
+    for path in (
+        f"/flows/{flow_id}/label",
+        f"/flows/{flow_id}/description",
+        f"/flows/{flow_id}/tags/probe",
+        f"/sources/{source_id}/label",
+        f"/sources/{source_id}/description",
+        f"/sources/{source_id}/tags/probe",
+    ):
+        for content_type in ("text/plain", "application/x-www-form-urlencoded"):
+            response = client.put(
+                path,
+                content=b"test this",
+                headers={"Content-Type": content_type},
+            )
+            assert response.status_code == 400, (path, content_type)
+            assert_bbc_error(response.json(), "bad_request")
+
+
+def test_unset_numeric_flow_properties_read_as_null(client: TestClient) -> None:
+    """bbc-id: semantic.flow.unset_numeric_properties_are_readable
+
+    The spec reserves the 404 on these endpoints for a missing Flow and
+    defines no unset form for the integer properties, so an existing Flow
+    without a bit rate reads back as 200 null.
+    """
+    flow_id = uuid4()
+    payload = video_flow_payload(flow_id, uuid4())
+    payload.pop("avg_bit_rate", None)
+    payload.pop("max_bit_rate", None)
+    assert client.put(f"/flows/{flow_id}", json=payload).status_code == 201
+
+    for name in ("avg_bit_rate", "max_bit_rate"):
+        response = client.get(f"/flows/{flow_id}/{name}")
+        assert response.status_code == 200, name
+        assert response.json() is None, name

--- a/tests/tams/conformance/test_flows_sources_and_segments.py
+++ b/tests/tams/conformance/test_flows_sources_and_segments.py
@@ -815,3 +815,24 @@ def test_unset_numeric_flow_properties_read_as_null(client: TestClient) -> None:
         response = client.get(f"/flows/{flow_id}/{name}")
         assert response.status_code == 200, name
         assert response.json() is None, name
+
+
+def test_malformed_flow_id_in_segments_path_returns_404(client: TestClient) -> None:
+    """bbc-id: semantic.segments.malformed_flow_id_is_404
+
+    The segments path documents only 404 for the Flow ID path parameter,
+    so malformed IDs resolve to 404 rather than 400.
+    """
+    listed = client.get("/flows/not-a-uuid/segments")
+    assert listed.status_code == 404
+    assert_bbc_error(listed.json(), "not_found")
+    assert listed.json()["summary"] == "The Flow ID in the path is invalid."
+
+    posted = client.post(
+        "/flows/not-a-uuid/segments",
+        json=segment_payload("bbc/never-registered.ts"),
+    )
+    assert posted.status_code == 404
+
+    deleted = client.delete("/flows/not-a-uuid/segments")
+    assert deleted.status_code == 404

--- a/tests/tams/conformance/test_storage_objects_and_deletion.py
+++ b/tests/tams/conformance/test_storage_objects_and_deletion.py
@@ -23,6 +23,7 @@ from tests.support.object_storage import InMemoryObjectStorage
 from tests.tams.support import (
     PRIMARY_BACKEND_ID,
     PRIMARY_BACKEND_LABEL,
+    assert_bbc_error,
     controlled_object_instance_payload,
     create_video_flow,
     external_object_instance,
@@ -863,3 +864,10 @@ def _payload_get_urls(endpoint_name: str, payload: object) -> list[dict[str, obj
         return payload[0]["get_urls"]
     assert isinstance(payload, dict)
     return payload["get_urls"]
+
+
+def test_delete_request_id_is_an_opaque_string(client: TestClient) -> None:
+    """bbc-id: semantic.deletion.request_id_opaque_string"""
+    response = client.get("/flow-delete-requests/not-a-uuid")
+    assert response.status_code == 404
+    assert_bbc_error(response.json(), "not_found")

--- a/tests/tams/conformance/test_webhooks.py
+++ b/tests/tams/conformance/test_webhooks.py
@@ -421,3 +421,11 @@ def test_webhook_source_collection_filter_matches_child_events(
         str(parent_source_id)
     ]
     assert deliveries[1].payload["event"]["flow"]["id"] == str(child_flow_id)
+
+
+def test_webhook_registration_accepts_empty_event_list(client: TestClient) -> None:
+    """bbc-id: semantic.webhooks.empty_event_list_is_valid"""
+    body = webhook_payload(url="https://webhooks.example.test/empty", events=[])
+    created = client.post("/service/webhooks", json=body)
+    assert created.status_code == 201
+    assert created.json()["events"] == []

--- a/tests/tams/deployed/test_api_workflow.py
+++ b/tests/tams/deployed/test_api_workflow.py
@@ -90,7 +90,7 @@ def test_deployed_storage_object_lifecycle_and_async_delete(
 
     flow_id = str(uuid4())
     source_id = str(uuid4())
-    object_id = f"bbc/e2e/{uuid4()}.ts"
+    object_id = f"bbc-e2e-{uuid4()}.ts"
     uploaded_body = b"tamoss deployed e2e segment\n"
     flow_payload = _video_flow_payload(
         flow_id,
@@ -117,11 +117,12 @@ def test_deployed_storage_object_lifecycle_and_async_delete(
         media_object = allocated["media_objects"][0]
         assert media_object["object_id"] == object_id
         put_request = media_object["put_url"]
-        put_headers = put_request.get("headers") or {}
-        put_headers["x-amz-checksum-sha256"] = _checksum_value(
-            uploaded_body,
-            "sha256",
-        )
+        put_headers = _put_url_headers(put_request)
+        if e2e_client.target.upload_checksum_header:
+            put_headers["x-amz-checksum-sha256"] = _checksum_value(
+                uploaded_body,
+                "sha256",
+            )
 
         e2e_client.upload_put_url(
             put_request["url"],
@@ -137,12 +138,18 @@ def test_deployed_storage_object_lifecycle_and_async_delete(
         )
         assert segment.status_code == 201
 
+        # Label-based get_url negotiation is exercised only when the target's
+        # default backend advertises a label.
+        accept_params: dict[str, str] = {}
+        if default_backend.get("label"):
+            accept_params["accept_get_urls"] = default_backend["label"]
+
         segments = e2e_client.request(
             "GET",
             f"/flows/{flow_id}/segments",
             params={
                 "limit": "1",
-                "accept_get_urls": default_backend["label"],
+                **accept_params,
                 "accept_storage_ids": default_backend["id"],
                 "presigned": "true",
                 "verbose_storage": "true",
@@ -159,7 +166,7 @@ def test_deployed_storage_object_lifecycle_and_async_delete(
             "GET",
             f"/objects/{object_id}",
             params={
-                "accept_get_urls": default_backend["label"],
+                **accept_params,
                 "accept_storage_ids": default_backend["id"],
                 "presigned": "true",
                 "verbose_storage": "true",
@@ -212,6 +219,14 @@ def _storage_allocation_payload(object_id: str, storage_id: str) -> dict[str, An
     payload["object_ids"] = [object_id]
     payload["storage_id"] = storage_id
     return payload
+
+
+def _put_url_headers(put_url: dict[str, Any]) -> dict[str, str]:
+    headers = dict(put_url.get("headers") or {})
+    content_type = put_url.get("content-type") or put_url.get("content_type")
+    if content_type and not any(name.lower() == "content-type" for name in headers):
+        headers["Content-Type"] = str(content_type)
+    return headers
 
 
 def _checksum_value(body: bytes, algorithm: str) -> str:

--- a/tests/targets/remote.env.example
+++ b/tests/targets/remote.env.example
@@ -8,11 +8,20 @@ TEST_TIMEOUT_SECONDS=10
 
 # Provide one auth method for the deployed API and UI proxy.
 TEST_TAMOSS_TOKEN=
+# A shell command whose last stdout line is a bearer token (a leading
+# "Bearer " prefix is stripped). Useful for OAuth client-credentials targets.
+# TEST_TAMOSS_TOKEN_COMMAND=./scripts/get-token.sh
 # TEST_TAMOSS_TOKEN_SECRET=tams-api-token
 # TEST_TAMOSS_NAMESPACE=tams
 # TEST_TAMOSS_CR_NAME=tamoss-remote
 # TEST_BASIC_AUTH_USER=tamoss
 # TEST_BASIC_AUTH_PASSWORD=
+
+# Readiness probing: "tamoss" checks /healthz + /readyz + /service (default);
+# "service" only polls GET /service for targets that expose just the TAMS API.
+# TEST_TAMOSS_READINESS_MODE=tamoss
+# Set to false for targets whose storage rejects the upload checksum header.
+# TEST_TAMOSS_UPLOAD_CHECKSUM_HEADER=true
 
 # Browser UI E2E authenticates through the public UI/Auth ingress.
 TEST_TAMOSS_AUTH_USER=akadmin


### PR DESCRIPTION
## Summary

Aligns API edge-case behaviour with TAMS 8.1, including malformed segment flow IDs, forwarded proto handling, and source/segment/delete-request semantics. 
Generalises the deployed E2E target harness for external TAMS endpoints and makes Kind demo media ingest optional.

## Validation

- [ ] `task check` passes locally.
- [ ] Relevant focused suites were run, or the reason they are not needed is
      explained below.
- [ ] `task security:audit` was run for dependency, packaging, or workflow
      changes.
- [ ] `task openapi:check` was run for API, OpenAPI, or BBC vendor changes.
- [ ] New or changed environment variables are documented in
      `docs/configuration.md`.
- [ ] TAMS conformance is unaffected, or `task test:tams` and the
      TAMS conformance inventory were updated.
- [ ] Operator Chainsaw changes include the relevant local/CI run result, plus
      follow-up links for deferred branch-protection, flake-soak, or HA cases.