### PR TITLE
Add operator e2e gates for drift, secret watch and field ownership

### DIFF
--- a/operator/test/chainsaw/rustfs-operator-backend/api-pod-uses-creds-secret/chainsaw-test.yaml
+++ b/operator/test/chainsaw/rustfs-operator-backend/api-pod-uses-creds-secret/chainsaw-test.yaml
@@ -88,24 +88,41 @@ spec:
 
     - name: complete simulated cleanup
       try:
-        - delete:
-            ref:
-              apiVersion: tamoss.livewyer.io/v1alpha1
-              kind: StorageBackend
-              name: tamoss-storage-default
         - script:
             env:
               - name: NAMESPACE
                 value: ($namespace)
             content: |
               set -eu
-              # chainsaw-script: this test deletes the managed StorageBackend directly, so its database cleanup job must be completed.
+              # chainsaw-script: the StorageBackend is deleted without waiting because its
+              # finalizer may need the cleanup job below to be completed first; a blocking
+              # delete operation would deadlock against its own next step.
+              kubectl -n "$NAMESPACE" delete storagebackend tamoss-storage-default --wait=false
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+              set -eu
+              # chainsaw-script: this test deletes the managed StorageBackend directly, so its
+              # database cleanup job must be completed. When the deregister job succeeds on its
+              # own against the fixture database, finalisation completes and both the job and
+              # the StorageBackend vanish before this script sees them — that is success, not
+              # an error, so the wait tolerates the StorageBackend disappearing.
               complete_job() {
                 job="$1"
                 for _ in $(seq 1 60); do
                   kubectl -n "$NAMESPACE" get job "$job" >/dev/null 2>&1 && break
+                  if ! kubectl -n "$NAMESPACE" get storagebackend tamoss-storage-default >/dev/null 2>&1; then
+                    echo "StorageBackend already finalised; no job completion needed"
+                    return 0
+                  fi
                   sleep 1
                 done
+                if ! kubectl -n "$NAMESPACE" get job "$job" >/dev/null 2>&1; then
+                  echo "job $job never appeared but StorageBackend still exists" >&2
+                  return 1
+                fi
                 now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
                 payload="$(printf '{"status":{"active":0,"ready":0,"succeeded":1,"terminating":0,"conditions":[{"type":"SuccessCriteriaMet","status":"True","lastProbeTime":"%s","lastTransitionTime":"%s"},{"type":"Complete","status":"True","lastProbeTime":"%s","lastTransitionTime":"%s"}],"completionTime":"%s"}}' "$now" "$now" "$now" "$now" "$now")"
                 kubectl -n "$NAMESPACE" patch job "$job" --subresource=status --type=merge -p "$payload" >/dev/null 2>&1 ||

--- a/operator/test/chainsaw/storagebackend-reconciliation/secret-rotation-recovers-storagebackend/assert/archive-storagebackend-missing-secret.yaml
+++ b/operator/test/chainsaw/storagebackend-reconciliation/secret-rotation-recovers-storagebackend/assert/archive-storagebackend-missing-secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: tamoss.livewyer.io/v1alpha1
+kind: StorageBackend
+metadata:
+  name: archive
+(status.phase): Progressing
+(status.backendID): 22222222-2222-5222-8222-222222222222
+(status.bucketName): archive
+(status.resolved.credentialsSecret): rotated-rustfs-auth
+(status.conditions[?type == 'Ready'] | [0].status): "False"
+(status.conditions[?type == 'Ready'] | [0].reason): MissingSecret
+(status.conditions[?type == 'BucketReady'] | [0].status): "False"
+(status.conditions[?type == 'BucketReady'] | [0].reason): MissingSecret
+(status.conditions[?type == 'DatabaseReady'] | [0].status): "False"
+(status.conditions[?type == 'DatabaseReady'] | [0].reason): MissingSecret

--- a/operator/test/chainsaw/storagebackend-reconciliation/secret-rotation-recovers-storagebackend/assert/archive-storagebackend-ready.yaml
+++ b/operator/test/chainsaw/storagebackend-reconciliation/secret-rotation-recovers-storagebackend/assert/archive-storagebackend-ready.yaml
@@ -1,0 +1,25 @@
+apiVersion: tamoss.livewyer.io/v1alpha1
+kind: StorageBackend
+metadata:
+  name: archive
+(spec.tamossRef.name): tamoss
+(status.phase): Ready
+(status.conditions[?type == 'Ready'] | [0].status): "True"
+(status.conditions[?type == 'BucketReady'] | [0].status): "True"
+(status.conditions[?type == 'DatabaseReady'] | [0].status): "True"
+(status.backendID): 22222222-2222-5222-8222-222222222222
+(status.bucketName): archive
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: archive-bucket-state
+(metadata.ownerReferences[?kind == 'StorageBackend'] | [0].name): archive
+(data.ready): "true"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: archive-db-state
+(metadata.ownerReferences[?kind == 'StorageBackend'] | [0].name): archive
+(data.ready): "true"

--- a/operator/test/chainsaw/storagebackend-reconciliation/secret-rotation-recovers-storagebackend/assert/missing-secret-event.yaml
+++ b/operator/test/chainsaw/storagebackend-reconciliation/secret-rotation-recovers-storagebackend/assert/missing-secret-event.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Event
+metadata:
+  namespace: ($namespace)
+involvedObject:
+  name: archive
+reason: MissingSecret

--- a/operator/test/chainsaw/storagebackend-reconciliation/secret-rotation-recovers-storagebackend/chainsaw-test.yaml
+++ b/operator/test/chainsaw/storagebackend-reconciliation/secret-rotation-recovers-storagebackend/chainsaw-test.yaml
@@ -1,0 +1,60 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: secret-rotation-recovers-storagebackend
+  labels:
+    test.tamoss.io/target: kind
+    test.tamoss.io/tier: standard
+    test.tamoss.io/domain: storage
+    test.tamoss.io/lifecycle: ephemeral
+    test.tamoss.io/provider: rustfs
+    test.tamoss.io/profile: none
+spec:
+  steps:
+    - name: apply storage backend with absent credentials secret
+      try:
+        - apply:
+            file: ../../fixtures/operator-namespace-rbac.yaml
+        - apply:
+            file: ../../fixtures/postgres.yaml
+        - apply:
+            file: ../../fixtures/rustfs.yaml
+        - assert:
+            file: ../../fixtures/assert/postgresql-available.yaml
+        - assert:
+            file: ../../fixtures/assert/rustfs-available.yaml
+        - assert:
+            file: ../../fixtures/assert/rustfs-bucket-ready.yaml
+        - apply:
+            file: ../../fixtures/tamoss-external.yaml
+        - apply:
+            file: resources/archive-storagebackend.yaml
+        - assert:
+            file: assert/archive-storagebackend-missing-secret.yaml
+            timeout: 2m
+        - assert:
+            file: assert/missing-secret-event.yaml
+            timeout: 1m
+    # Creating the credentials Secret is the only action in this step. No
+    # reconcile-tamoss.sh tick or annotation nudge is allowed here: the
+    # StorageBackend must be re-enqueued by the controller itself once the
+    # Secret exists.
+    - name: create credentials secret and observe recovery
+      try:
+        - apply:
+            file: resources/rotated-rustfs-auth-secret.yaml
+        - assert:
+            file: assert/archive-storagebackend-ready.yaml
+            timeout: 5m
+    # Automatic cleanup deletes later-step resources first, which would remove
+    # the credentials Secret while the StorageBackend finalizer still needs it
+    # for deprovisioning. Delete the StorageBackend here while the Secret
+    # exists so cleanup stays inside its budget.
+    - name: remove storage backend while credentials exist
+      try:
+        - delete:
+            ref:
+              apiVersion: tamoss.livewyer.io/v1alpha1
+              kind: StorageBackend
+              name: archive
+            timeout: 3m

--- a/operator/test/chainsaw/storagebackend-reconciliation/secret-rotation-recovers-storagebackend/resources/archive-storagebackend.yaml
+++ b/operator/test/chainsaw/storagebackend-reconciliation/secret-rotation-recovers-storagebackend/resources/archive-storagebackend.yaml
@@ -1,0 +1,24 @@
+apiVersion: tamoss.livewyer.io/v1alpha1
+kind: StorageBackend
+metadata:
+  name: archive
+  annotations:
+    confirmation.tamoss.livewyer.io/deletion: "true"
+spec:
+  id: 22222222-2222-5222-8222-222222222222
+  tamossRef:
+    name: tamoss
+  provider: rustfs
+  label: tamoss.us-east-1:s3:archive
+  region: us-east-1
+  bucketName: archive
+  endpoint:
+    default:
+      url: (join('', ['http://rustfs-svc.', $namespace, '.svc:9000']))
+    public:
+      url: (join('', ['http://rustfs-svc.', $namespace, '.svc:9000']))
+  credentials:
+    existingSecret: rotated-rustfs-auth
+    secretKeys:
+      accessKey: RUSTFS_ACCESS_KEY
+      secretKey: RUSTFS_SECRET_KEY

--- a/operator/test/chainsaw/storagebackend-reconciliation/secret-rotation-recovers-storagebackend/resources/rotated-rustfs-auth-secret.yaml
+++ b/operator/test/chainsaw/storagebackend-reconciliation/secret-rotation-recovers-storagebackend/resources/rotated-rustfs-auth-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rotated-rustfs-auth
+type: Opaque
+stringData:
+  RUSTFS_ACCESS_KEY: rustfsadmin
+  RUSTFS_SECRET_KEY: rustfsadmin

--- a/operator/test/chainsaw/tamoss-instance-reconciliation/disabling-worker-removes-deployment/chainsaw-test.yaml
+++ b/operator/test/chainsaw/tamoss-instance-reconciliation/disabling-worker-removes-deployment/chainsaw-test.yaml
@@ -4,7 +4,7 @@ metadata:
   name: disabling-worker-removes-deployment
   labels:
     test.tamoss.io/target: kind
-    test.tamoss.io/tier: standard
+    test.tamoss.io/tier: smoke
     test.tamoss.io/domain: instance
     test.tamoss.io/lifecycle: ephemeral
     test.tamoss.io/provider: mixed

--- a/operator/test/chainsaw/tamoss-instance-reconciliation/out-of-band-edits-are-reverted/chainsaw-test.yaml
+++ b/operator/test/chainsaw/tamoss-instance-reconciliation/out-of-band-edits-are-reverted/chainsaw-test.yaml
@@ -4,7 +4,7 @@ metadata:
   name: out-of-band-edits-are-reverted
   labels:
     test.tamoss.io/target: kind
-    test.tamoss.io/tier: standard
+    test.tamoss.io/tier: smoke
     test.tamoss.io/domain: instance
     test.tamoss.io/lifecycle: ephemeral
     test.tamoss.io/provider: mixed

--- a/operator/test/chainsaw/tamoss-instance-reconciliation/replica-count-change-is-rolled-out/assert/api-replicas-updated.yaml
+++ b/operator/test/chainsaw/tamoss-instance-reconciliation/replica-count-change-is-rolled-out/assert/api-replicas-updated.yaml
@@ -10,3 +10,6 @@ kind: Tamoss
 metadata:
   name: tamoss
 (status.replicas.api.desired): 2
+# The spec patch bumps metadata.generation, so equality proves
+# status.observedGeneration advanced with the update.
+(status.observedGeneration == metadata.generation): true

--- a/operator/test/chainsaw/tamoss-instance-reconciliation/unmanaged-fields-survive-reconcile/assert/api-deployment-annotation-survives-revert.yaml
+++ b/operator/test/chainsaw/tamoss-instance-reconciliation/unmanaged-fields-survive-reconcile/assert/api-deployment-annotation-survives-revert.yaml
@@ -1,0 +1,9 @@
+# The managed memory limit reverting proves a reconcile applied the canonical
+# Deployment; the third-party annotation must still be present afterwards.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tamoss-api
+  annotations:
+    example.com/keep: "true"
+(spec.template.spec.containers[0].resources.limits.memory): 512Mi

--- a/operator/test/chainsaw/tamoss-instance-reconciliation/unmanaged-fields-survive-reconcile/chainsaw-test.yaml
+++ b/operator/test/chainsaw/tamoss-instance-reconciliation/unmanaged-fields-survive-reconcile/chainsaw-test.yaml
@@ -1,0 +1,47 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: unmanaged-fields-survive-reconcile
+  labels:
+    test.tamoss.io/target: kind
+    test.tamoss.io/tier: standard
+    test.tamoss.io/domain: instance
+    test.tamoss.io/lifecycle: ephemeral
+    test.tamoss.io/provider: mixed
+    test.tamoss.io/profile: none
+spec:
+  steps:
+    - name: apply instance
+      try:
+        - apply:
+            file: ../../fixtures/operator-namespace-rbac.yaml
+        - apply:
+            file: ../../fixtures/postgres.yaml
+        - apply:
+            file: ../../fixtures/rustfs.yaml
+        - assert:
+            file: ../../fixtures/assert/postgresql-available.yaml
+        - assert:
+            file: ../../fixtures/assert/rustfs-available.yaml
+        - assert:
+            file: ../../fixtures/assert/rustfs-bucket-ready.yaml
+        - apply:
+            file: ../../fixtures/tamoss-external.yaml
+        - assert:
+            file: ../../fixtures/assert/tamoss-all-components-ready.yaml
+    - name: add unmanaged annotation alongside managed-field drift
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+              set -eu
+              # chainsaw-script: adds a third-party annotation and managed-field drift out-of-band, then forces a reconcile,
+              # so the single assert below proves the reconcile reverted the managed field without stripping the annotation.
+              kubectl -n "$NAMESPACE" annotate deployment tamoss-api example.com/keep=true --overwrite
+              kubectl -n "$NAMESPACE" patch deployment tamoss-api --type=json \
+                -p '[{"op":"replace","path":"/spec/template/spec/containers/0/resources/limits/memory","value":"2Gi"}]'
+              ../../scripts/reconcile-tamoss.sh tamoss
+        - assert:
+            file: assert/api-deployment-annotation-survives-revert.yaml

--- a/operator/test/chainsaw/tamoss-instance-reconciliation/watch-driven-drift-correction/assert/api-deployment-restored.yaml
+++ b/operator/test/chainsaw/tamoss-instance-reconciliation/watch-driven-drift-correction/assert/api-deployment-restored.yaml
@@ -1,0 +1,5 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tamoss-api
+(spec.template.spec.containers[0].resources.limits.memory): 512Mi

--- a/operator/test/chainsaw/tamoss-instance-reconciliation/watch-driven-drift-correction/assert/drift-corrected-event.yaml
+++ b/operator/test/chainsaw/tamoss-instance-reconciliation/watch-driven-drift-correction/assert/drift-corrected-event.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Event
+metadata:
+  namespace: ($namespace)
+involvedObject:
+  name: tamoss
+reason: DriftCorrected

--- a/operator/test/chainsaw/tamoss-instance-reconciliation/watch-driven-drift-correction/chainsaw-test.yaml
+++ b/operator/test/chainsaw/tamoss-instance-reconciliation/watch-driven-drift-correction/chainsaw-test.yaml
@@ -1,0 +1,51 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: watch-driven-drift-correction
+  labels:
+    test.tamoss.io/target: kind
+    test.tamoss.io/tier: standard
+    test.tamoss.io/domain: instance
+    test.tamoss.io/lifecycle: ephemeral
+    test.tamoss.io/provider: mixed
+    test.tamoss.io/profile: none
+spec:
+  steps:
+    - name: apply instance
+      try:
+        - apply:
+            file: ../../fixtures/operator-namespace-rbac.yaml
+        - apply:
+            file: ../../fixtures/postgres.yaml
+        - apply:
+            file: ../../fixtures/rustfs.yaml
+        - assert:
+            file: ../../fixtures/assert/postgresql-available.yaml
+        - assert:
+            file: ../../fixtures/assert/rustfs-available.yaml
+        - assert:
+            file: ../../fixtures/assert/rustfs-bucket-ready.yaml
+        - apply:
+            file: ../../fixtures/tamoss-external.yaml
+        - assert:
+            file: ../../fixtures/assert/tamoss-all-components-ready.yaml
+    # Unlike out-of-band-edits-are-reverted, this step never calls
+    # reconcile-tamoss.sh: the mutation alone must enqueue a reconcile through
+    # the operator's owned-resource watches.
+    - name: mutate managed deployment without a reconcile nudge
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+              set -eu
+              # chainsaw-script: applies out-of-band drift to a managed resource so native assertions can verify watch-driven correction.
+              kubectl -n "$NAMESPACE" patch deployment tamoss-api --type=json \
+                -p '[{"op":"replace","path":"/spec/template/spec/containers/0/resources/limits/memory","value":"2Gi"}]'
+        - assert:
+            file: assert/api-deployment-restored.yaml
+            timeout: 3m
+        - assert:
+            file: assert/drift-corrected-event.yaml
+            timeout: 1m


### PR DESCRIPTION
## Summary

Adds Chainsaw gate cases for secret-watch recovery, unmanaged-field preservation and watch-driven drift correction ahead of the operator refactor series, promotes the drift and prune cases to the smoke tier, and unblocks the deadlocked rustfs cleanup step.

## Validation

- [x] Chainsaw labels and render suites pass; all new and modified cases pass individually on a fresh kind cluster.