### PR TITLE
Fix operator pruning, finalisation and secret watch efficiency

### DIFF
--- a/operator/internal/controller/auth/authentik/proxy_outpost.go
+++ b/operator/internal/controller/auth/authentik/proxy_outpost.go
@@ -225,44 +225,41 @@ func (c ProxyOutpostClient) managedBlueprintClient() (ManagedBlueprintClient, er
 	return ManagedBlueprintClient(c), nil
 }
 
-func findOAuthProvider(ctx context.Context, api ManagedBlueprintClient, name string) (oauthProvider, error) {
-	endpoint, err := api.apiURL("providers", "oauth2")
+// findByQuery lists an Authentik API collection filtered by a query parameter
+// and returns the first result accepted by match.
+func findByQuery[T any](ctx context.Context, api ManagedBlueprintClient, segments []string, queryKey, queryValue string, match func(T) bool) (T, error) {
+	var zero T
+	endpoint, err := api.apiURL(segments...)
 	if err != nil {
-		return oauthProvider{}, err
+		return zero, err
 	}
 	query := endpoint.Query()
-	query.Set("name", name)
+	query.Set(queryKey, queryValue)
 	endpoint.RawQuery = query.Encode()
-	var list oauthProviderList
+	var list struct {
+		Results []T `json:"results"`
+	}
 	if err := api.doJSON(ctx, http.MethodGet, endpoint.String(), nil, &list); err != nil {
-		return oauthProvider{}, err
+		return zero, err
 	}
 	for _, result := range list.Results {
-		if result.Name == name {
+		if match(result) {
 			return result, nil
 		}
 	}
-	return oauthProvider{}, nil
+	return zero, nil
+}
+
+func findOAuthProvider(ctx context.Context, api ManagedBlueprintClient, name string) (oauthProvider, error) {
+	return findByQuery(ctx, api, []string{"providers", "oauth2"}, "name", name, func(provider oauthProvider) bool {
+		return provider.Name == name
+	})
 }
 
 func findProxyProvider(ctx context.Context, api ManagedBlueprintClient, name string) (proxyProvider, error) {
-	endpoint, err := api.apiURL("providers", "proxy")
-	if err != nil {
-		return proxyProvider{}, err
-	}
-	query := endpoint.Query()
-	query.Set("name", name)
-	endpoint.RawQuery = query.Encode()
-	var list proxyProviderList
-	if err := api.doJSON(ctx, http.MethodGet, endpoint.String(), nil, &list); err != nil {
-		return proxyProvider{}, err
-	}
-	for _, result := range list.Results {
-		if result.Name == name {
-			return result, nil
-		}
-	}
-	return proxyProvider{}, nil
+	return findByQuery(ctx, api, []string{"providers", "proxy"}, "name", name, func(provider proxyProvider) bool {
+		return provider.Name == name
+	})
 }
 
 func upsertProxyProvider(ctx context.Context, api ManagedBlueprintClient, tamoss *tamossv1alpha1.Tamoss, oauth oauthProvider) (proxyProvider, error) {
@@ -327,23 +324,9 @@ func upsertProxyApplication(ctx context.Context, api ManagedBlueprintClient, tam
 }
 
 func findApplication(ctx context.Context, api ManagedBlueprintClient, slug string) (application, error) {
-	endpoint, err := api.apiURL("core", "applications")
-	if err != nil {
-		return application{}, err
-	}
-	query := endpoint.Query()
-	query.Set("slug", slug)
-	endpoint.RawQuery = query.Encode()
-	var list applicationList
-	if err := api.doJSON(ctx, http.MethodGet, endpoint.String(), nil, &list); err != nil {
-		return application{}, err
-	}
-	for _, result := range list.Results {
-		if result.Slug == slug {
-			return result, nil
-		}
-	}
-	return application{}, nil
+	return findByQuery(ctx, api, []string{"core", "applications"}, "slug", slug, func(app application) bool {
+		return app.Slug == slug
+	})
 }
 
 func addProviderToEmbeddedOutpost(ctx context.Context, api ManagedBlueprintClient, tamoss *tamossv1alpha1.Tamoss, providerPK int) error {
@@ -375,23 +358,9 @@ func removeProviderFromEmbeddedOutpost(ctx context.Context, api ManagedBlueprint
 }
 
 func findEmbeddedOutpost(ctx context.Context, api ManagedBlueprintClient) (outpost, error) {
-	endpoint, err := api.apiURL("outposts", "instances")
-	if err != nil {
-		return outpost{}, err
-	}
-	query := endpoint.Query()
-	query.Set("name", embeddedOutpostName)
-	endpoint.RawQuery = query.Encode()
-	var list outpostList
-	if err := api.doJSON(ctx, http.MethodGet, endpoint.String(), nil, &list); err != nil {
-		return outpost{}, err
-	}
-	for _, result := range list.Results {
-		if result.Name == embeddedOutpostName {
-			return result, nil
-		}
-	}
-	return outpost{}, nil
+	return findByQuery(ctx, api, []string{"outposts", "instances"}, "name", embeddedOutpostName, func(candidate outpost) bool {
+		return candidate.Name == embeddedOutpostName
+	})
 }
 
 func updateOutpost(ctx context.Context, api ManagedBlueprintClient, current outpost, providers []int, config map[string]any) error {

--- a/operator/internal/controller/canonical_apply.go
+++ b/operator/internal/controller/canonical_apply.go
@@ -12,13 +12,11 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	tamossv1alpha1 "github.com/livewyer-ops/tamoss/operator/api/v1alpha1"
 	"github.com/livewyer-ops/tamoss/operator/internal/controller/resource"
 )
@@ -140,37 +138,10 @@ func normalizeJSONValue(value interface{}) interface{} {
 	}
 }
 
+// ensureTypeMeta stamps the scheme-resolved GroupVersionKind onto obj so that
+// server-side apply patches always carry apiVersion and kind.
 func ensureTypeMeta(obj client.Object) {
-	switch typed := obj.(type) {
-	case *appsv1.Deployment:
-		typed.TypeMeta = metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"}
-	case *autoscalingv2.HorizontalPodAutoscaler:
-		typed.TypeMeta = metav1.TypeMeta{APIVersion: "autoscaling/v2", Kind: "HorizontalPodAutoscaler"}
-	case *batchv1.Job:
-		typed.TypeMeta = metav1.TypeMeta{APIVersion: "batch/v1", Kind: "Job"}
-	case *corev1.ConfigMap:
-		typed.TypeMeta = metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"}
-	case *corev1.PersistentVolumeClaim:
-		typed.TypeMeta = metav1.TypeMeta{APIVersion: "v1", Kind: "PersistentVolumeClaim"}
-	case *corev1.Service:
-		typed.TypeMeta = metav1.TypeMeta{APIVersion: "v1", Kind: "Service"}
-	case *corev1.ServiceAccount:
-		typed.TypeMeta = metav1.TypeMeta{APIVersion: "v1", Kind: "ServiceAccount"}
-	case *networkingv1.Ingress:
-		typed.TypeMeta = metav1.TypeMeta{APIVersion: "networking.k8s.io/v1", Kind: "Ingress"}
-	case *networkingv1.NetworkPolicy:
-		typed.TypeMeta = metav1.TypeMeta{APIVersion: "networking.k8s.io/v1", Kind: "NetworkPolicy"}
-	case *policyv1.PodDisruptionBudget:
-		typed.TypeMeta = metav1.TypeMeta{APIVersion: "policy/v1", Kind: "PodDisruptionBudget"}
-	case *gatewayv1.HTTPRoute:
-		typed.TypeMeta = metav1.TypeMeta{APIVersion: gatewayv1.GroupVersion.String(), Kind: "HTTPRoute"}
-	case *cnpgv1.Cluster:
-		typed.TypeMeta = metav1.TypeMeta{APIVersion: cnpgv1.GroupVersion.String(), Kind: "Cluster"}
-	case *cnpgv1.ScheduledBackup:
-		typed.TypeMeta = metav1.TypeMeta{APIVersion: cnpgv1.GroupVersion.String(), Kind: "ScheduledBackup"}
-	case *tamossv1alpha1.StorageBackend:
-		typed.TypeMeta = metav1.TypeMeta{APIVersion: tamossv1alpha1.GroupVersion.String(), Kind: "StorageBackend"}
-	}
+	obj.GetObjectKind().SetGroupVersionKind(canonicalObjectGVK(obj))
 }
 
 func copyCanonicalFields(live, desired client.Object) bool {

--- a/operator/internal/controller/events_test.go
+++ b/operator/internal/controller/events_test.go
@@ -19,9 +19,9 @@ func TestTamossLifecycleEventsFromConditionTransitions(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "media"},
 	}
 	updated := original.DeepCopy()
-	operatorstatus.SetConditionBool(&updated.Status.Conditions, operatorstatus.ConditionReady, true, operatorstatus.ReasonAllComponentsReady, "ready")
-	operatorstatus.SetConditionBool(&updated.Status.Conditions, operatorstatus.ConditionSchemaMigrated, true, operatorstatus.ReasonSchemaApplied, "schema ready")
-	operatorstatus.SetConditionBool(&updated.Status.Conditions, operatorstatus.ConditionIdentityBlueprintSubmitted, true, operatorstatus.ReasonManagedBlueprintApplied, "blueprint applied")
+	operatorstatus.SetConditionBool(&updated.Status.Conditions, updated.Generation, operatorstatus.ConditionReady, true, operatorstatus.ReasonAllComponentsReady, "ready")
+	operatorstatus.SetConditionBool(&updated.Status.Conditions, updated.Generation, operatorstatus.ConditionSchemaMigrated, true, operatorstatus.ReasonSchemaApplied, "schema ready")
+	operatorstatus.SetConditionBool(&updated.Status.Conditions, updated.Generation, operatorstatus.ConditionIdentityBlueprintSubmitted, true, operatorstatus.ReasonManagedBlueprintApplied, "blueprint applied")
 
 	reconciler.recordTamossLifecycleEvents(original, updated)
 
@@ -38,9 +38,9 @@ func TestTamossWarningEventsFromConditionTransitions(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "media"},
 	}
 	updated := original.DeepCopy()
-	operatorstatus.SetConditionBool(&updated.Status.Conditions, operatorstatus.ConditionBackendsReady, false, operatorstatus.ReasonMissingDependencyOperator, "CNPG is not installed")
-	operatorstatus.SetConditionBool(&updated.Status.Conditions, operatorstatus.ConditionRoutingReady, false, operatorstatus.ReasonRouteRejected, "HTTPRoute was rejected")
-	operatorstatus.SetConditionBool(&updated.Status.Conditions, operatorstatus.ConditionBackupPolicyReady, false, operatorstatus.ReasonBackupArchivingFailed, "CNPG archiving failed")
+	operatorstatus.SetConditionBool(&updated.Status.Conditions, updated.Generation, operatorstatus.ConditionBackendsReady, false, operatorstatus.ReasonMissingDependencyOperator, "CNPG is not installed")
+	operatorstatus.SetConditionBool(&updated.Status.Conditions, updated.Generation, operatorstatus.ConditionRoutingReady, false, operatorstatus.ReasonRouteRejected, "HTTPRoute was rejected")
+	operatorstatus.SetConditionBool(&updated.Status.Conditions, updated.Generation, operatorstatus.ConditionBackupPolicyReady, false, operatorstatus.ReasonBackupArchivingFailed, "CNPG archiving failed")
 
 	reconciler.recordTamossLifecycleEvents(original, updated)
 
@@ -60,9 +60,9 @@ func TestTamossWarningEventsIgnoreProgressReasons(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "media"},
 	}
 	updated := original.DeepCopy()
-	operatorstatus.SetConditionBool(&updated.Status.Conditions, operatorstatus.ConditionReady, false, operatorstatus.ReasonComponentsProgressing, "Components are still rolling out")
-	operatorstatus.SetConditionBool(&updated.Status.Conditions, operatorstatus.ConditionSchemaMigrated, false, operatorstatus.ReasonWaitingForSchema, "Schema migration is still running")
-	operatorstatus.SetConditionBool(&updated.Status.Conditions, operatorstatus.ConditionRoutingReady, false, operatorstatus.ReasonRoutePending, "Route has not reported status yet")
+	operatorstatus.SetConditionBool(&updated.Status.Conditions, updated.Generation, operatorstatus.ConditionReady, false, operatorstatus.ReasonComponentsProgressing, "Components are still rolling out")
+	operatorstatus.SetConditionBool(&updated.Status.Conditions, updated.Generation, operatorstatus.ConditionSchemaMigrated, false, operatorstatus.ReasonWaitingForSchema, "Schema migration is still running")
+	operatorstatus.SetConditionBool(&updated.Status.Conditions, updated.Generation, operatorstatus.ConditionRoutingReady, false, operatorstatus.ReasonRoutePending, "Route has not reported status yet")
 
 	reconciler.recordTamossLifecycleEvents(original, updated)
 
@@ -104,7 +104,7 @@ func TestDriftCorrectedSuppressesInitialConvergence(t *testing.T) {
 		t.Fatalf("expected no drift event before Ready=True, got %#v", events)
 	}
 
-	operatorstatus.SetConditionBool(&tamoss.Status.Conditions, operatorstatus.ConditionReady, true, operatorstatus.ReasonAllComponentsReady, "ready")
+	operatorstatus.SetConditionBool(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionReady, true, operatorstatus.ReasonAllComponentsReady, "ready")
 	reconciler.recordDriftCorrected(tamoss, deployment, []string{"spec"})
 
 	events := drainRecorder(recorder)

--- a/operator/internal/controller/httproute_input.go
+++ b/operator/internal/controller/httproute_input.go
@@ -28,11 +28,11 @@ func (r *TamossReconciler) reconcileHTTPRouteInputGate(ctx context.Context, tamo
 func (r *TamossReconciler) updateHTTPRouteInputStatus(ctx context.Context, tamoss *tamossv1alpha1.Tamoss, message string) error {
 	return r.patchTamossStatusInput(ctx, tamoss, tamossStatusPatchInput{Apply: func(tamoss *tamossv1alpha1.Tamoss) error {
 		tamoss.Status.Phase = operatorstatus.PhaseDegraded
-		operatorstatus.SetConditionStatus(&tamoss.Status.Conditions, operatorstatus.ConditionSchemaMigrated, metav1.ConditionUnknown, operatorstatus.ReasonUnsupportedHTTPRouteFilter, "Schema reconciliation is blocked by routing configuration")
-		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, operatorstatus.ConditionBackendsReady, true, operatorstatus.ReasonBackendReferencesConfigured, "Backend secret references are configured")
-		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, operatorstatus.ConditionRoutingReady, false, operatorstatus.ReasonUnsupportedHTTPRouteFilter, message)
-		operatorstatus.SetConditionStatus(&tamoss.Status.Conditions, operatorstatus.ConditionHostnamesReady, metav1.ConditionUnknown, operatorstatus.ReasonUnsupportedHTTPRouteFilter, message)
-		setActiveBlockedConditions(&tamoss.Status.Conditions, operatorstatus.ReasonUnsupportedHTTPRouteFilter, message, "Reconciliation is blocked by routing configuration")
+		operatorstatus.SetConditionStatus(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionSchemaMigrated, metav1.ConditionUnknown, operatorstatus.ReasonUnsupportedHTTPRouteFilter, "Schema reconciliation is blocked by routing configuration")
+		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionBackendsReady, true, operatorstatus.ReasonBackendReferencesConfigured, "Backend secret references are configured")
+		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionRoutingReady, false, operatorstatus.ReasonUnsupportedHTTPRouteFilter, message)
+		operatorstatus.SetConditionStatus(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionHostnamesReady, metav1.ConditionUnknown, operatorstatus.ReasonUnsupportedHTTPRouteFilter, message)
+		setActiveBlockedConditions(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ReasonUnsupportedHTTPRouteFilter, message, "Reconciliation is blocked by routing configuration")
 		return nil
 	}})
 }

--- a/operator/internal/controller/indexes.go
+++ b/operator/internal/controller/indexes.go
@@ -27,20 +27,22 @@ func listStorageBackendsForTamoss(ctx context.Context, c client.Client, namespac
 	return nil
 }
 
-func listStorageBackendsByCredentialSecret(ctx context.Context, c client.Client, namespace, secretName string, list *tamossv1alpha1.StorageBackendList) error {
-	if err := c.List(ctx, list, client.InNamespace(namespace)); err != nil {
-		return err
+// storageBackendCredentialsSecretIndex is a field index on the resolved
+// credentials Secret name so Secret events map to StorageBackends with an
+// indexed lookup instead of listing and filtering every StorageBackend.
+const storageBackendCredentialsSecretIndex = ".spec.credentials.existingSecret"
+
+func storageBackendCredentialsSecretIndexValue(obj client.Object) []string {
+	storageBackend, ok := obj.(*tamossv1alpha1.StorageBackend)
+	if !ok {
+		return nil
 	}
-	filtered := list.Items[:0]
-	for _, storageBackend := range list.Items {
-		spec := storageBackend.Spec
-		spec.ApplyDefaults(storageBackend.Namespace, storageBackend.Name)
-		if spec.Credentials.ExistingSecret == secretName {
-			filtered = append(filtered, storageBackend)
-		}
+	spec := storageBackend.Spec
+	spec.ApplyDefaults(storageBackend.Namespace, storageBackend.Name)
+	if spec.Credentials.ExistingSecret == "" {
+		return nil
 	}
-	list.Items = filtered
-	return nil
+	return []string{spec.Credentials.ExistingSecret}
 }
 
 func tamossManagedLabelSelector(tamoss *tamossv1alpha1.Tamoss) client.MatchingLabels {

--- a/operator/internal/controller/indexes_test.go
+++ b/operator/internal/controller/indexes_test.go
@@ -25,6 +25,7 @@ func TestStorageBackendCredentialSecretRequestsFilterReferencingBackends(t *test
 		Client: fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithObjects(storageBackend, other).
+			WithIndex(&tamossv1alpha1.StorageBackend{}, storageBackendCredentialsSecretIndex, storageBackendCredentialsSecretIndexValue).
 			Build(),
 		Scheme: scheme,
 	}

--- a/operator/internal/controller/predicates.go
+++ b/operator/internal/controller/predicates.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"reflect"
 
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -16,6 +17,25 @@ func tamossPrimaryPredicate() predicate.Predicate {
 
 func storageBackendPrimaryPredicate() predicate.Predicate {
 	return primaryResourcePredicate(storageBackendFinalizer, nil)
+}
+
+// credentialSecretPredicate passes Secret create and delete events but only
+// forwards updates whose data actually changed, so metadata-only churn does
+// not fan out into StorageBackend reconciles.
+func credentialSecretPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(evt event.UpdateEvent) bool {
+			oldSecret, oldOK := evt.ObjectOld.(*corev1.Secret)
+			newSecret, newOK := evt.ObjectNew.(*corev1.Secret)
+			if !oldOK || !newOK {
+				return true
+			}
+			if oldSecret.ResourceVersion == newSecret.ResourceVersion {
+				return false
+			}
+			return !reflect.DeepEqual(oldSecret.Data, newSecret.Data)
+		},
+	}
 }
 
 func primaryResourcePredicate(finalizer string, actionAnnotations []string) predicate.Predicate {

--- a/operator/internal/controller/provider_prune_test.go
+++ b/operator/internal/controller/provider_prune_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	fakediscovery "k8s.io/client-go/discovery/fake"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	k8stesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -39,13 +40,7 @@ func TestOptionalOwnedPruneDeletesNoLongerDesiredObjects(t *testing.T) {
 		Scheme: scheme,
 	}
 
-	err := reconciler.pruneOptionalOwnedObjects(
-		ctx,
-		tamoss,
-		map[string]struct{}{},
-		client.InNamespace(tamoss.Namespace),
-		tamossManagedLabelSelector(tamoss),
-	)
+	err := reconciler.pruneOwnedObjects(ctx, tamoss, map[string]struct{}{})
 	if err != nil {
 		t.Fatalf("expected provider prune to succeed: %v", err)
 	}
@@ -79,13 +74,7 @@ func TestOptionalOwnedPruneDeletesDisabledBackupPolicy(t *testing.T) {
 		Scheme: scheme,
 	}
 
-	err := reconciler.pruneOptionalOwnedObjects(
-		ctx,
-		tamoss,
-		desired,
-		client.InNamespace(tamoss.Namespace),
-		tamossManagedLabelSelector(tamoss),
-	)
+	err := reconciler.pruneOwnedObjects(ctx, tamoss, desired)
 	if err != nil {
 		t.Fatalf("expected provider prune to succeed: %v", err)
 	}
@@ -121,13 +110,7 @@ func TestOptionalOwnedPruneKeepsDesiredObjects(t *testing.T) {
 		Scheme: scheme,
 	}
 
-	err := reconciler.pruneOptionalOwnedObjects(
-		ctx,
-		tamoss,
-		desired,
-		client.InNamespace(tamoss.Namespace),
-		tamossManagedLabelSelector(tamoss),
-	)
+	err := reconciler.pruneOwnedObjects(ctx, tamoss, desired)
 	if err != nil {
 		t.Fatalf("expected provider prune to succeed: %v", err)
 	}
@@ -157,13 +140,7 @@ func TestOptionalOwnedPruneCleansUpManagedResourcesAfterExternalProviderSwitch(t
 		Scheme: scheme,
 	}
 
-	err := reconciler.pruneOptionalOwnedObjects(
-		ctx,
-		current,
-		map[string]struct{}{},
-		client.InNamespace(current.Namespace),
-		tamossManagedLabelSelector(current),
-	)
+	err := reconciler.pruneOwnedObjects(ctx, current, map[string]struct{}{})
 	if err != nil {
 		t.Fatalf("expected provider prune to succeed: %v", err)
 	}
@@ -199,6 +176,9 @@ func TestOptionalOwnedObjectListsSkipKnownAbsentOptionalCRDs(t *testing.T) {
 func providerPruneScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
 	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("add client-go scheme: %v", err)
+	}
 	if err := tamossv1alpha1.AddToScheme(scheme); err != nil {
 		t.Fatalf("add tamoss scheme: %v", err)
 	}

--- a/operator/internal/controller/reconcile_metrics.go
+++ b/operator/internal/controller/reconcile_metrics.go
@@ -13,7 +13,7 @@ func recordControllerReconcile(controller string, result ctrl.Result, err error,
 		operatormetrics.RecordReconcile(controller, "error", duration)
 		return
 	}
-	if result.Requeue || result.RequeueAfter > 0 {
+	if result.RequeueAfter > 0 {
 		operatormetrics.RecordReconcile(controller, "requeue", duration)
 		return
 	}

--- a/operator/internal/controller/routing_status.go
+++ b/operator/internal/controller/routing_status.go
@@ -232,9 +232,9 @@ func gatewayAPIUnavailableResult() routingStatusResult {
 	}
 }
 
-func setRoutingConditions(conditions *[]metav1.Condition, result routingStatusResult) {
-	operatorstatus.SetConditionBool(conditions, operatorstatus.ConditionRoutingReady, result.Ready, result.Reason, result.Message)
-	operatorstatus.SetConditionStatus(conditions, operatorstatus.ConditionHostnamesReady, result.HostnameStatus, result.HostnameReason, result.HostnameMessage)
+func setRoutingConditions(conditions *[]metav1.Condition, generation int64, result routingStatusResult) {
+	operatorstatus.SetConditionBool(conditions, generation, operatorstatus.ConditionRoutingReady, result.Ready, result.Reason, result.Message)
+	operatorstatus.SetConditionStatus(conditions, generation, operatorstatus.ConditionHostnamesReady, result.HostnameStatus, result.HostnameReason, result.HostnameMessage)
 }
 
 func isKubernetesNoMatchError(err error) bool {

--- a/operator/internal/controller/storagebackend_authority_test.go
+++ b/operator/internal/controller/storagebackend_authority_test.go
@@ -20,6 +20,7 @@ func TestDefaultStorageBackendReadyRequiresDatabaseRegistration(t *testing.T) {
 	storageBackend := defaultStorageBackend(tamoss)
 	operatorstatus.SetConditionBool(
 		&storageBackend.Status.Conditions,
+		storageBackend.Generation,
 		operatorstatus.ConditionBucketReady,
 		true,
 		operatorstatus.ReasonBucketReady,
@@ -27,6 +28,7 @@ func TestDefaultStorageBackendReadyRequiresDatabaseRegistration(t *testing.T) {
 	)
 	operatorstatus.SetConditionBool(
 		&storageBackend.Status.Conditions,
+		storageBackend.Generation,
 		operatorstatus.ConditionDatabaseReady,
 		false,
 		operatorstatus.ReasonDatabaseRegistrationInProgress,
@@ -34,6 +36,7 @@ func TestDefaultStorageBackendReadyRequiresDatabaseRegistration(t *testing.T) {
 	)
 	operatorstatus.SetConditionBool(
 		&storageBackend.Status.Conditions,
+		storageBackend.Generation,
 		operatorstatus.ConditionReady,
 		false,
 		operatorstatus.ReasonDatabaseRegistrationInProgress,
@@ -73,6 +76,7 @@ func TestDefaultStorageBackendReadyAfterBucketAndDatabaseRegistration(t *testing
 	storageBackend := defaultStorageBackend(tamoss)
 	operatorstatus.SetConditionBool(
 		&storageBackend.Status.Conditions,
+		storageBackend.Generation,
 		operatorstatus.ConditionBucketReady,
 		true,
 		operatorstatus.ReasonBucketReady,
@@ -80,6 +84,7 @@ func TestDefaultStorageBackendReadyAfterBucketAndDatabaseRegistration(t *testing
 	)
 	operatorstatus.SetConditionBool(
 		&storageBackend.Status.Conditions,
+		storageBackend.Generation,
 		operatorstatus.ConditionDatabaseReady,
 		true,
 		operatorstatus.ReasonDatabaseRegistered,
@@ -87,6 +92,7 @@ func TestDefaultStorageBackendReadyAfterBucketAndDatabaseRegistration(t *testing
 	)
 	operatorstatus.SetConditionBool(
 		&storageBackend.Status.Conditions,
+		storageBackend.Generation,
 		operatorstatus.ConditionReady,
 		true,
 		operatorstatus.ReasonStorageBackendReady,

--- a/operator/internal/controller/storagebackend_bucket.go
+++ b/operator/internal/controller/storagebackend_bucket.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	tamossv1alpha1 "github.com/livewyer-ops/tamoss/operator/api/v1alpha1"
 	"github.com/livewyer-ops/tamoss/operator/internal/controller/backend/rustfs"
@@ -80,6 +81,14 @@ func (r *StorageBackendReconciler) reconcileStorageBackendBucketDeletion(ctx con
 	target := storageBackendBucketDeleteTarget(spec)
 	credentials, err := r.storageBackendBucketCredentials(ctx, storageBackend.Namespace, spec)
 	if err != nil {
+		// Bucket deletion is best effort: a credentials Secret that was
+		// deleted before the StorageBackend must not block finalisation.
+		if apierrors.IsNotFound(err) {
+			message := fmt.Sprintf("Credentials Secret %s was not found; skipping best-effort bucket deletion for %s", spec.Credentials.ExistingSecret, spec.BucketName)
+			log.FromContext(ctx).Info("skipping StorageBackend bucket deletion during finalisation", "secret", spec.Credentials.ExistingSecret, "bucket", spec.BucketName)
+			operatorstatus.EmitWarningEvent(r.Recorder, &r.WarningEvents, storageBackend, operatorstatus.ReasonBucketDeletionSkipped, message)
+			return storageBackendReconcileResult{Ready: true, Reason: operatorstatus.ReasonBucketDeletionSkipped, Message: message}, nil
+		}
 		return storageBackendReconcileResult{}, err
 	}
 	if err := r.bucketClient().Delete(ctx, target, credentials); err != nil {

--- a/operator/internal/controller/storagebackend_controller.go
+++ b/operator/internal/controller/storagebackend_controller.go
@@ -126,7 +126,10 @@ func (r *StorageBackendReconciler) prepareStorageBackendLifecycle(ctx context.Co
 		if err := r.Client.Patch(ctx, storageBackend, client.MergeFrom(original)); err != nil {
 			return stopReconcileNow(), err
 		}
-		return stopReconcile(ctrl.Result{Requeue: true}), nil
+		// The finalizer patch emits an Update event whose finalizer diff
+		// passes storageBackendPrimaryPredicate, so the controller is
+		// re-enqueued without the deprecated Result.Requeue flag.
+		return stopReconcileNow(), nil
 	}
 	return continueReconcile(), nil
 }

--- a/operator/internal/controller/storagebackend_controller.go
+++ b/operator/internal/controller/storagebackend_controller.go
@@ -41,7 +41,7 @@ type StorageBackendReconciler struct {
 	Client          client.Client
 	Scheme          *runtime.Scheme
 	Recorder        record.EventRecorder
-	WatchNamespaces map[string]struct{}
+	WatchNamespaces WatchNamespaceSet
 	WarningEvents   operatorstatus.WarningEventDeduper
 	HTTPClient      *http.Client
 	BucketClient    rustfs.BucketClient
@@ -113,7 +113,7 @@ func (r *StorageBackendReconciler) loadStorageBackend(ctx context.Context, key c
 }
 
 func (r *StorageBackendReconciler) prepareStorageBackendLifecycle(ctx context.Context, storageBackend *tamossv1alpha1.StorageBackend) (reconcileControl, error) {
-	if !r.namespaceAllowed(storageBackend.Namespace) {
+	if !r.WatchNamespaces.Allows(storageBackend.Namespace) {
 		log.FromContext(ctx).Info("ignoring StorageBackend outside configured watch scope", "namespace", storageBackend.Namespace)
 		return stopReconcileNow(), nil
 	}
@@ -138,29 +138,19 @@ func (r *StorageBackendReconciler) resolveStorageBackendSpec(ctx context.Context
 	spec := storageBackend.Spec
 	spec.ApplyDefaults(storageBackend.Namespace, storageBackend.Name)
 	if spec.Provider != tamossv1alpha1.StorageBackendProviderRustFS && !spec.IsExternalObjectStore() {
-		result, err := r.updateStorageBackendStatus(ctx, storageBackend, storageBackendStatusInput{
-			Ready:         false,
-			BucketReady:   false,
-			DatabaseReady: false,
-			Reason:        operatorstatus.ReasonUnsupportedProvider,
-			Message:       fmt.Sprintf("StorageBackend provider %q is not supported", spec.Provider),
-			Degraded:      true,
-			BackendID:     spec.ID,
-			BucketName:    spec.BucketName,
-		})
+		result, err := r.updateStorageBackendStatus(ctx, storageBackend, storageBackendStageStatusInput(spec, false, storageBackendReconcileResult{
+			Reason:   operatorstatus.ReasonUnsupportedProvider,
+			Message:  fmt.Sprintf("StorageBackend provider %q is not supported", spec.Provider),
+			Degraded: true,
+		}))
 		return tamossv1alpha1.StorageBackendSpec{}, stopReconcile(result), err
 	}
 	if missing := missingStorageBackendFields(spec); len(missing) > 0 {
-		result, err := r.updateStorageBackendStatus(ctx, storageBackend, storageBackendStatusInput{
-			Ready:         false,
-			BucketReady:   false,
-			DatabaseReady: false,
-			Reason:        operatorstatus.ReasonMissingProviderConfiguration,
-			Message:       fmt.Sprintf("Required StorageBackend fields are missing: %s", strings.Join(missing, ", ")),
-			Degraded:      true,
-			BackendID:     spec.ID,
-			BucketName:    spec.BucketName,
-		})
+		result, err := r.updateStorageBackendStatus(ctx, storageBackend, storageBackendStageStatusInput(spec, false, storageBackendReconcileResult{
+			Reason:   operatorstatus.ReasonMissingProviderConfiguration,
+			Message:  fmt.Sprintf("Required StorageBackend fields are missing: %s", strings.Join(missing, ", ")),
+			Degraded: true,
+		}))
 		return tamossv1alpha1.StorageBackendSpec{}, stopReconcile(result), err
 	}
 	return spec, continueReconcile(), nil
@@ -171,15 +161,10 @@ func (r *StorageBackendReconciler) loadStorageBackendTamossStage(ctx context.Con
 	tamossKey := types.NamespacedName{Name: spec.TamossRef.Name, Namespace: storageBackend.Namespace}
 	if err := r.Client.Get(ctx, tamossKey, tamoss); err != nil {
 		if apierrors.IsNotFound(err) {
-			result, statusErr := r.updateStorageBackendStatus(ctx, storageBackend, storageBackendStatusInput{
-				Ready:         false,
-				BucketReady:   false,
-				DatabaseReady: false,
-				Reason:        operatorstatus.ReasonTamossNotFound,
-				Message:       fmt.Sprintf("Referenced Tamoss %s was not found", tamossKey.Name),
-				BackendID:     spec.ID,
-				BucketName:    spec.BucketName,
-			})
+			result, statusErr := r.updateStorageBackendStatus(ctx, storageBackend, storageBackendStageStatusInput(spec, false, storageBackendReconcileResult{
+				Reason:  operatorstatus.ReasonTamossNotFound,
+				Message: fmt.Sprintf("Referenced Tamoss %s was not found", tamossKey.Name),
+			}))
 			return nil, stopReconcile(result), statusErr
 		}
 		return nil, stopReconcileNow(), err
@@ -200,15 +185,10 @@ func (r *StorageBackendReconciler) reconcileStorageBackendCredentialsStage(ctx c
 	if err := r.reconcileRuntimeCredentialsSecret(ctx, tamoss); err != nil {
 		return stopReconcileNow(), err
 	}
-	result, err := r.updateStorageBackendStatus(ctx, storageBackend, storageBackendStatusInput{
-		Ready:         false,
-		BucketReady:   false,
-		DatabaseReady: false,
-		Reason:        reason,
-		Message:       message,
-		BackendID:     spec.ID,
-		BucketName:    spec.BucketName,
-	})
+	result, err := r.updateStorageBackendStatus(ctx, storageBackend, storageBackendStageStatusInput(spec, false, storageBackendReconcileResult{
+		Reason:  reason,
+		Message: message,
+	}))
 	return stopReconcile(result), err
 }
 
@@ -220,30 +200,16 @@ func (r *StorageBackendReconciler) reconcileStorageBackendBucketStage(ctx contex
 	if bucketResult.Ready {
 		return continueReconcile(), nil
 	}
-	result, err := r.updateStorageBackendStatus(ctx, storageBackend, storageBackendStatusInput{
-		Ready:         false,
-		BucketReady:   false,
-		DatabaseReady: false,
-		Reason:        bucketResult.Reason,
-		Message:       bucketResult.Message,
-		Degraded:      bucketResult.Degraded,
-		BackendID:     spec.ID,
-		BucketName:    spec.BucketName,
-	})
+	result, err := r.updateStorageBackendStatus(ctx, storageBackend, storageBackendStageStatusInput(spec, false, bucketResult))
 	return stopReconcile(result), err
 }
 
 func (r *StorageBackendReconciler) reconcileStorageBackendDatabaseStage(ctx context.Context, storageBackend *tamossv1alpha1.StorageBackend, tamoss *tamossv1alpha1.Tamoss, spec tamossv1alpha1.StorageBackendSpec) (reconcileControl, error) {
 	if !r.schemaStateReady(ctx, tamoss) {
-		result, err := r.updateStorageBackendStatus(ctx, storageBackend, storageBackendStatusInput{
-			Ready:         false,
-			BucketReady:   true,
-			DatabaseReady: false,
-			Reason:        operatorstatus.ReasonSchemaNotReady,
-			Message:       fmt.Sprintf("Tamoss %s schema state is not ready", tamoss.Name),
-			BackendID:     spec.ID,
-			BucketName:    spec.BucketName,
-		})
+		result, err := r.updateStorageBackendStatus(ctx, storageBackend, storageBackendStageStatusInput(spec, true, storageBackendReconcileResult{
+			Reason:  operatorstatus.ReasonSchemaNotReady,
+			Message: fmt.Sprintf("Tamoss %s schema state is not ready", tamoss.Name),
+		}))
 		return stopReconcile(result), err
 	}
 	dbResult, err := r.reconcileStorageBackendDatabase(ctx, storageBackend, tamoss, spec)
@@ -253,23 +219,6 @@ func (r *StorageBackendReconciler) reconcileStorageBackendDatabaseStage(ctx cont
 	if dbResult.Ready {
 		return continueReconcile(), nil
 	}
-	result, err := r.updateStorageBackendStatus(ctx, storageBackend, storageBackendStatusInput{
-		Ready:         false,
-		BucketReady:   true,
-		DatabaseReady: false,
-		Reason:        dbResult.Reason,
-		Message:       dbResult.Message,
-		Degraded:      dbResult.Degraded,
-		BackendID:     spec.ID,
-		BucketName:    spec.BucketName,
-	})
+	result, err := r.updateStorageBackendStatus(ctx, storageBackend, storageBackendStageStatusInput(spec, true, dbResult))
 	return stopReconcile(result), err
-}
-
-func (r *StorageBackendReconciler) namespaceAllowed(namespace string) bool {
-	if len(r.WatchNamespaces) == 0 {
-		return true
-	}
-	_, ok := r.WatchNamespaces[namespace]
-	return ok
 }

--- a/operator/internal/controller/storagebackend_controller_unit_test.go
+++ b/operator/internal/controller/storagebackend_controller_unit_test.go
@@ -279,7 +279,7 @@ func TestStorageBackendEventsAreEmittedAndDeduped(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "archive", Namespace: "media"},
 	}
 	updated := original.DeepCopy()
-	operatorstatus.SetConditionBool(&updated.Status.Conditions, operatorstatus.ConditionReady, false, operatorstatus.ReasonMissingSecret, "Required credentials Secret archive-s3 was not found")
+	operatorstatus.SetConditionBool(&updated.Status.Conditions, updated.Generation, operatorstatus.ConditionReady, false, operatorstatus.ReasonMissingSecret, "Required credentials Secret archive-s3 was not found")
 
 	reconciler.recordStorageBackendEvents(original, updated)
 	reconciler.recordStorageBackendEvents(original, updated)
@@ -300,7 +300,7 @@ func TestStorageBackendBucketCreatedEvent(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "archive", Namespace: "media"},
 	}
 	updated := original.DeepCopy()
-	operatorstatus.SetConditionBool(&updated.Status.Conditions, operatorstatus.ConditionBucketReady, true, operatorstatus.ReasonBucketReady, "StorageBackend bucket is ready")
+	operatorstatus.SetConditionBool(&updated.Status.Conditions, updated.Generation, operatorstatus.ConditionBucketReady, true, operatorstatus.ReasonBucketReady, "StorageBackend bucket is ready")
 
 	reconciler.recordStorageBackendEvents(original, updated)
 

--- a/operator/internal/controller/storagebackend_controller_unit_test.go
+++ b/operator/internal/controller/storagebackend_controller_unit_test.go
@@ -358,7 +358,7 @@ func TestStorageBackendCredentialSecretWatchMapsToReferencingBackends(t *testing
 	scheme := storageBackendTestScheme(t)
 	storageBackend := storageBackendFixture()
 	reconciler := StorageBackendReconciler{
-		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(storageBackend).Build(),
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(storageBackend).WithIndex(&tamossv1alpha1.StorageBackend{}, storageBackendCredentialsSecretIndex, storageBackendCredentialsSecretIndexValue).Build(),
 		Scheme: scheme,
 	}
 	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "archive-s3", Namespace: "media"}}
@@ -375,7 +375,7 @@ func TestStorageBackendCredentialSecretWatchIgnoresUnreferencedSecrets(t *testin
 	scheme := storageBackendTestScheme(t)
 	storageBackend := storageBackendFixture()
 	reconciler := StorageBackendReconciler{
-		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(storageBackend).Build(),
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(storageBackend).WithIndex(&tamossv1alpha1.StorageBackend{}, storageBackendCredentialsSecretIndex, storageBackendCredentialsSecretIndexValue).Build(),
 		Scheme: scheme,
 	}
 	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "unreferenced", Namespace: "media"}}

--- a/operator/internal/controller/storagebackend_setup.go
+++ b/operator/internal/controller/storagebackend_setup.go
@@ -15,6 +15,14 @@ import (
 )
 
 func (r *StorageBackendReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(),
+		&tamossv1alpha1.StorageBackend{},
+		storageBackendCredentialsSecretIndex,
+		storageBackendCredentialsSecretIndexValue,
+	); err != nil {
+		return err
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&tamossv1alpha1.StorageBackend{}, builder.WithPredicates(storageBackendPrimaryPredicate())).
 		Owns(&batchv1.Job{}).
@@ -22,25 +30,23 @@ func (r *StorageBackendReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.storageBackendCredentialSecretRequests),
+			builder.WithPredicates(credentialSecretPredicate()),
 		).
 		Complete(r)
 }
 
 func (r *StorageBackendReconciler) storageBackendCredentialSecretRequests(ctx context.Context, obj client.Object) []reconcile.Request {
 	list := &tamossv1alpha1.StorageBackendList{}
-	if err := listStorageBackendsByCredentialSecret(ctx, r.Client, obj.GetNamespace(), obj.GetName(), list); err != nil {
+	if err := r.Client.List(ctx, list,
+		client.InNamespace(obj.GetNamespace()),
+		client.MatchingFields{storageBackendCredentialsSecretIndex: obj.GetName()},
+	); err != nil {
 		return nil
 	}
 	requests := make([]reconcile.Request, 0, len(list.Items))
 	for i := range list.Items {
-		storageBackend := list.Items[i]
-		spec := storageBackend.Spec
-		spec.ApplyDefaults(storageBackend.Namespace, storageBackend.Name)
-		if spec.Credentials.ExistingSecret != obj.GetName() {
-			continue
-		}
 		requests = append(requests, reconcile.Request{
-			NamespacedName: storageBackendRequest(storageBackend),
+			NamespacedName: storageBackendRequest(list.Items[i]),
 		})
 	}
 	return requests

--- a/operator/internal/controller/storagebackend_status.go
+++ b/operator/internal/controller/storagebackend_status.go
@@ -30,6 +30,20 @@ type storageBackendStatusInput struct {
 	Diagnostic    *storageBackendDiagnosticResult
 }
 
+// storageBackendStageStatusInput fills the fields that are constant for a
+// not-yet-ready stage so call sites only describe bucket readiness and the
+// stage outcome.
+func storageBackendStageStatusInput(spec tamossv1alpha1.StorageBackendSpec, bucketReady bool, result storageBackendReconcileResult) storageBackendStatusInput {
+	return storageBackendStatusInput{
+		BucketReady: bucketReady,
+		Reason:      result.Reason,
+		Message:     result.Message,
+		Degraded:    result.Degraded,
+		BackendID:   spec.ID,
+		BucketName:  spec.BucketName,
+	}
+}
+
 func (r *StorageBackendReconciler) updateStorageBackendStatus(ctx context.Context, storageBackend *tamossv1alpha1.StorageBackend, input storageBackendStatusInput) (ctrl.Result, error) {
 	original := storageBackend.DeepCopy()
 	storageBackend.Status.ObservedGeneration = storageBackend.Generation

--- a/operator/internal/controller/storagebackend_status.go
+++ b/operator/internal/controller/storagebackend_status.go
@@ -43,12 +43,12 @@ func (r *StorageBackendReconciler) updateStorageBackendStatus(ctx context.Contex
 	if input.Degraded {
 		storageBackend.Status.Phase = operatorstatus.PhaseDegraded
 	}
-	operatorstatus.SetConditionBool(&storageBackend.Status.Conditions, operatorstatus.ConditionBucketReady, input.BucketReady, bucketReadyReason(input), bucketReadyMessage(input))
-	operatorstatus.SetConditionBool(&storageBackend.Status.Conditions, operatorstatus.ConditionDatabaseReady, input.DatabaseReady, databaseReadyReason(input), databaseReadyMessage(input))
+	operatorstatus.SetConditionBool(&storageBackend.Status.Conditions, storageBackend.Generation, operatorstatus.ConditionBucketReady, input.BucketReady, bucketReadyReason(input), bucketReadyMessage(input))
+	operatorstatus.SetConditionBool(&storageBackend.Status.Conditions, storageBackend.Generation, operatorstatus.ConditionDatabaseReady, input.DatabaseReady, databaseReadyReason(input), databaseReadyMessage(input))
 	if input.Diagnostic != nil {
-		operatorstatus.SetConditionStatus(&storageBackend.Status.Conditions, operatorstatus.ConditionExternalS3DiagnosticReady, input.Diagnostic.Status, input.Diagnostic.Reason, input.Diagnostic.Message)
+		operatorstatus.SetConditionStatus(&storageBackend.Status.Conditions, storageBackend.Generation, operatorstatus.ConditionExternalS3DiagnosticReady, input.Diagnostic.Status, input.Diagnostic.Reason, input.Diagnostic.Message)
 	}
-	operatorstatus.SetConditionBool(&storageBackend.Status.Conditions, operatorstatus.ConditionReady, input.Ready, input.Reason, input.Message)
+	operatorstatus.SetConditionBool(&storageBackend.Status.Conditions, storageBackend.Generation, operatorstatus.ConditionReady, input.Ready, input.Reason, input.Message)
 	if err := r.patchStorageBackendStatus(ctx, storageBackend, original); err != nil {
 		return ctrl.Result{}, err
 	}

--- a/operator/internal/controller/tamoss_controller.go
+++ b/operator/internal/controller/tamoss_controller.go
@@ -47,7 +47,7 @@ type TamossReconciler struct {
 	Client                      client.Client
 	Scheme                      *runtime.Scheme
 	Recorder                    record.EventRecorder
-	WatchNamespaces             map[string]struct{}
+	WatchNamespaces             WatchNamespaceSet
 	Discovery                   *operatordiscovery.Manager
 	AuthentikPlatformNamespaces *authentik.PlatformNamespacePolicy
 	AuthentikProbeInterval      time.Duration
@@ -159,7 +159,7 @@ func (r *TamossReconciler) loadTamoss(ctx context.Context, key client.ObjectKey)
 }
 
 func (r *TamossReconciler) prepareTamossLifecycle(ctx context.Context, tamoss *tamossv1alpha1.Tamoss, recordPhase func(string)) (*tamossv1alpha1.Tamoss, reconcileControl, error) {
-	if !r.namespaceAllowed(tamoss.Namespace) {
+	if !r.WatchNamespaces.Allows(tamoss.Namespace) {
 		log.FromContext(ctx).Info("ignoring Tamoss outside configured watch scope", "namespace", tamoss.Namespace)
 		recordPhase(operatorstatus.PhaseIgnored)
 		return nil, stopReconcile(ctrl.Result{}), nil
@@ -391,14 +391,6 @@ func shortestPositiveDuration(current, candidate time.Duration) time.Duration {
 		return candidate
 	}
 	return current
-}
-
-func (r *TamossReconciler) namespaceAllowed(namespace string) bool {
-	if len(r.WatchNamespaces) == 0 {
-		return true
-	}
-	_, ok := r.WatchNamespaces[namespace]
-	return ok
 }
 
 func (r *TamossReconciler) recordDriftCorrected(tamoss *tamossv1alpha1.Tamoss, obj client.Object, paths []string) {

--- a/operator/internal/controller/tamoss_controller.go
+++ b/operator/internal/controller/tamoss_controller.go
@@ -8,23 +8,22 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2 "k8s.io/api/autoscaling/v2"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
-	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	tamossv1alpha1 "github.com/livewyer-ops/tamoss/operator/api/v1alpha1"
 	"github.com/livewyer-ops/tamoss/operator/internal/controller/auth/authentik"
 	"github.com/livewyer-ops/tamoss/operator/internal/controller/defaults"
@@ -522,50 +521,38 @@ func schemaMessage(schemaResult SchemaResult) string {
 	return "Schema controller completed for this reconcile"
 }
 
+// canonicalKindScheme resolves GroupVersionKinds for every type the operator
+// manages. It mirrors the registrations performed for the manager scheme in
+// cmd/main.go so that kind resolution never depends on hand-maintained lists.
+var canonicalKindScheme = newCanonicalKindScheme()
+
+func newCanonicalKindScheme() *runtime.Scheme {
+	kindScheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(kindScheme))
+	utilruntime.Must(tamossv1alpha1.AddToScheme(kindScheme))
+	utilruntime.Must(cnpgv1.AddToScheme(kindScheme))
+	utilruntime.Must(gatewayv1.Install(kindScheme))
+	return kindScheme
+}
+
 func canonicalObjectKey(obj client.Object) string {
 	return fmt.Sprintf("%s/%s/%s", canonicalObjectKind(obj), obj.GetNamespace(), obj.GetName())
 }
 
 func canonicalObjectKind(obj client.Object) string {
-	if kind := obj.GetObjectKind().GroupVersionKind().Kind; kind != "" {
-		return kind
+	return canonicalObjectGVK(obj).Kind
+}
+
+// canonicalObjectGVK resolves the GVK from the scheme rather than a
+// hand-maintained switch. An unresolvable type is a programming error: a
+// silent empty kind would corrupt desired-object keys and make the pruner
+// delete still-desired objects, so fail loudly instead.
+func canonicalObjectGVK(obj client.Object) schema.GroupVersionKind {
+	gvk, err := apiutil.GVKForObject(obj, canonicalKindScheme)
+	if err != nil {
+		panic(fmt.Errorf("resolve GVK for %T: %w", obj, err))
 	}
-	ensureTypeMeta(obj)
-	if kind := obj.GetObjectKind().GroupVersionKind().Kind; kind != "" {
-		return kind
-	}
-	switch obj := obj.(type) {
-	case *appsv1.Deployment:
-		return "Deployment"
-	case *autoscalingv2.HorizontalPodAutoscaler:
-		return "HorizontalPodAutoscaler"
-	case *batchv1.Job:
-		return "Job"
-	case *corev1.ConfigMap:
-		return "ConfigMap"
-	case *corev1.PersistentVolumeClaim:
-		return "PersistentVolumeClaim"
-	case *corev1.Secret:
-		return "Secret"
-	case *corev1.Service:
-		return "Service"
-	case *corev1.ServiceAccount:
-		return "ServiceAccount"
-	case *networkingv1.Ingress:
-		return "Ingress"
-	case *networkingv1.NetworkPolicy:
-		return "NetworkPolicy"
-	case *policyv1.PodDisruptionBudget:
-		return "PodDisruptionBudget"
-	case *gatewayv1.HTTPRoute:
-		return "HTTPRoute"
-	case *tamossv1alpha1.StorageBackend:
-		return "StorageBackend"
-	case *unstructured.Unstructured:
-		return obj.GetKind()
-	default:
-		return ""
-	}
+	return gvk
 }
 
 func tamossResourceName(tamoss *tamossv1alpha1.Tamoss, suffix string) string {

--- a/operator/internal/controller/tamoss_controller_test.go
+++ b/operator/internal/controller/tamoss_controller_test.go
@@ -897,7 +897,7 @@ var _ = Describe("Tamoss Controller", func() {
 			makeSchemaReady(ctx, controllerReconciler, typeNamespacedName, resourceName)
 			instance = &tamossv1alpha1.Tamoss{}
 			Expect(k8sClient.Get(ctx, typeNamespacedName, instance)).To(Succeed())
-			operatorstatus.SetConditionBool(&instance.Status.Conditions, operatorstatus.ConditionReady, true, "AllComponentsReady", "All components are ready")
+			operatorstatus.SetConditionBool(&instance.Status.Conditions, instance.Generation, operatorstatus.ConditionReady, true, "AllComponentsReady", "All components are ready")
 			Expect(k8sClient.Status().Update(ctx, instance)).To(Succeed())
 
 			apiDeployment := &appsv1.Deployment{}
@@ -1140,7 +1140,6 @@ var _ = Describe("Tamoss Controller", func() {
 			Expect(state.Data[schemaStateFixturesKey]).To(Equal("true"))
 		})
 	})
-
 })
 
 func minimalTamossSpec() tamossv1alpha1.TamossSpec {

--- a/operator/internal/controller/tamoss_identity.go
+++ b/operator/internal/controller/tamoss_identity.go
@@ -86,11 +86,11 @@ func (r *TamossReconciler) deleteAuthentikProxyOutpost(ctx context.Context, tamo
 func (r *TamossReconciler) updateIdentityBlockedStatus(ctx context.Context, tamoss *tamossv1alpha1.Tamoss, reason, message string) error {
 	return r.patchTamossStatusInput(ctx, tamoss, tamossStatusPatchInput{Apply: func(tamoss *tamossv1alpha1.Tamoss) error {
 		tamoss.Status.Phase = operatorstatus.PhaseDegraded
-		operatorstatus.SetConditionStatus(&tamoss.Status.Conditions, operatorstatus.ConditionSchemaMigrated, metav1.ConditionUnknown, reason, "Schema reconciliation is blocked by identity configuration")
-		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, operatorstatus.ConditionBackendsReady, true, operatorstatus.ReasonBackendReferencesConfigured, "Backend secret references are configured")
-		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, operatorstatus.ConditionIdentityBlueprintSubmitted, false, reason, message)
-		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, operatorstatus.ConditionIdentityReady, false, reason, message)
-		setActiveBlockedConditions(&tamoss.Status.Conditions, reason, message, "Reconciliation is blocked by identity configuration")
+		operatorstatus.SetConditionStatus(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionSchemaMigrated, metav1.ConditionUnknown, reason, "Schema reconciliation is blocked by identity configuration")
+		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionBackendsReady, true, operatorstatus.ReasonBackendReferencesConfigured, "Backend secret references are configured")
+		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionIdentityBlueprintSubmitted, false, reason, message)
+		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionIdentityReady, false, reason, message)
+		setActiveBlockedConditions(&tamoss.Status.Conditions, tamoss.Generation, reason, message, "Reconciliation is blocked by identity configuration")
 		return nil
 	}})
 }

--- a/operator/internal/controller/tamoss_lifecycle.go
+++ b/operator/internal/controller/tamoss_lifecycle.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	batchv1 "k8s.io/api/batch/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -220,13 +219,6 @@ func pruneLoadedList(ctx context.Context, c client.Client, tamoss *tamossv1alpha
 		}
 		if _, keep := desired[canonicalObjectKey(obj)]; keep {
 			continue
-		}
-		if job, ok := obj.(*batchv1.Job); ok && len(job.Finalizers) > 0 {
-			original := job.DeepCopy()
-			job.Finalizers = nil
-			if err := c.Patch(ctx, job, client.MergeFrom(original)); err != nil && !apierrors.IsNotFound(err) {
-				return err
-			}
 		}
 		propagation := metav1.DeletePropagationBackground
 		if err := c.Delete(ctx, obj, client.PropagationPolicy(propagation)); err != nil && !apierrors.IsNotFound(err) {

--- a/operator/internal/controller/tamoss_lifecycle.go
+++ b/operator/internal/controller/tamoss_lifecycle.go
@@ -19,22 +19,42 @@ import (
 	operatorstatus "github.com/livewyer-ops/tamoss/operator/internal/status"
 )
 
-func (r *TamossReconciler) pruneOwnedObjects(ctx context.Context, tamoss *tamossv1alpha1.Tamoss, desired map[string]struct{}) error {
-	match := tamossManagedLabelSelector(tamoss)
-	listOptions := []client.ListOption{client.InNamespace(tamoss.Namespace), match}
+// tamossOwnedList pairs a managed-object list with whether its CRD may be
+// absent from the cluster, in which case no-match errors are tolerated.
+type tamossOwnedList struct {
+	list            client.ObjectList
+	tolerateNoMatch bool
+}
 
+// tamossOwnedLists enumerates every list of objects the operator manages for
+// a Tamoss: the built-in kinds, the Traefik Middleware CRD, and any optional
+// provider CRDs that are installed.
+func (r *TamossReconciler) tamossOwnedLists(ctx context.Context) []tamossOwnedList {
+	lists := []tamossOwnedList{}
 	for _, policy := range tamossManagedResourcePolicies() {
-		if err := pruneTamossOwnedList(ctx, r.Client, tamoss, desired, policy.list); err != nil {
-			return err
-		}
+		lists = append(lists, tamossOwnedList{list: policy.list})
 	}
+	lists = append(lists, tamossOwnedList{list: traefikMiddlewareList(), tolerateNoMatch: true})
+	for _, list := range r.optionalOwnedObjectLists(ctx) {
+		lists = append(lists, tamossOwnedList{list: list, tolerateNoMatch: true})
+	}
+	return lists
+}
+
+func traefikMiddlewareList() *unstructured.UnstructuredList {
 	middlewares := &unstructured.UnstructuredList{}
 	middlewares.SetGroupVersionKind(schema.GroupVersionKind{Group: "traefik.io", Version: "v1alpha1", Kind: "MiddlewareList"})
-	if err := pruneList(ctx, r.Client, tamoss, desired, middlewares, listOptions...); err != nil && !meta.IsNoMatchError(err) {
-		return err
-	}
-	if err := r.pruneOptionalOwnedObjects(ctx, tamoss, desired, listOptions...); err != nil {
-		return err
+	return middlewares
+}
+
+func (r *TamossReconciler) pruneOwnedObjects(ctx context.Context, tamoss *tamossv1alpha1.Tamoss, desired map[string]struct{}) error {
+	for _, owned := range r.tamossOwnedLists(ctx) {
+		if err := pruneTamossOwnedList(ctx, r.Client, tamoss, desired, owned.list); err != nil {
+			if owned.tolerateNoMatch && isKubernetesNoMatchError(err) {
+				continue
+			}
+			return err
+		}
 	}
 	return nil
 }
@@ -98,43 +118,10 @@ func (r *TamossReconciler) deleteOwnedStorageBackends(ctx context.Context, tamos
 }
 
 func (r *TamossReconciler) ownedObjectsRemain(ctx context.Context, tamoss *tamossv1alpha1.Tamoss) (bool, error) {
-	match := tamossManagedLabelSelector(tamoss)
-	listOptions := []client.ListOption{client.InNamespace(tamoss.Namespace), match}
-	for _, policy := range tamossManagedResourcePolicies() {
-		remaining, err := ownedObjectsRemainInTamossOwnedList(ctx, r.Client, tamoss, policy.list)
-		if err != nil || remaining {
-			return remaining, err
-		}
-	}
-	middlewares := &unstructured.UnstructuredList{}
-	middlewares.SetGroupVersionKind(schema.GroupVersionKind{Group: "traefik.io", Version: "v1alpha1", Kind: "MiddlewareList"})
-	remaining, err := ownedObjectsRemainInList(ctx, r.Client, tamoss, middlewares, listOptions...)
-	if err != nil && meta.IsNoMatchError(err) {
-		return false, nil
-	}
-	if err != nil || remaining {
-		return remaining, err
-	}
-	return r.optionalOwnedObjectsRemain(ctx, tamoss, listOptions...)
-}
-
-func (r *TamossReconciler) pruneOptionalOwnedObjects(ctx context.Context, tamoss *tamossv1alpha1.Tamoss, desired map[string]struct{}, listOptions ...client.ListOption) error {
-	for _, list := range r.optionalOwnedObjectLists(ctx) {
-		if err := pruneList(ctx, r.Client, tamoss, desired, list, listOptions...); err != nil {
-			if isKubernetesNoMatchError(err) {
-				continue
-			}
-			return err
-		}
-	}
-	return nil
-}
-
-func (r *TamossReconciler) optionalOwnedObjectsRemain(ctx context.Context, tamoss *tamossv1alpha1.Tamoss, listOptions ...client.ListOption) (bool, error) {
-	for _, list := range r.optionalOwnedObjectLists(ctx) {
-		remaining, err := ownedObjectsRemainInList(ctx, r.Client, tamoss, list, listOptions...)
+	for _, owned := range r.tamossOwnedLists(ctx) {
+		remaining, err := ownedObjectsRemainInTamossOwnedList(ctx, r.Client, tamoss, owned.list)
 		if err != nil {
-			if isKubernetesNoMatchError(err) {
+			if owned.tolerateNoMatch && isKubernetesNoMatchError(err) {
 				continue
 			}
 			return false, err
@@ -165,13 +152,6 @@ func (r *TamossReconciler) optionalResourceCRDPresent(ctx context.Context, gvr s
 	return known && present
 }
 
-func ownedObjectsRemainInList(ctx context.Context, c client.Client, tamoss *tamossv1alpha1.Tamoss, list client.ObjectList, opts ...client.ListOption) (bool, error) {
-	if err := c.List(ctx, list, opts...); err != nil {
-		return false, err
-	}
-	return ownedObjectsRemainInLoadedList(tamoss, list)
-}
-
 func ownedObjectsRemainInTamossOwnedList(ctx context.Context, c client.Client, tamoss *tamossv1alpha1.Tamoss, list client.ObjectList) (bool, error) {
 	if err := listTamossOwnedObjects(ctx, c, tamoss, list); err != nil {
 		return false, err
@@ -191,13 +171,6 @@ func ownedObjectsRemainInLoadedList(tamoss *tamossv1alpha1.Tamoss, list client.O
 		}
 	}
 	return false, nil
-}
-
-func pruneList(ctx context.Context, c client.Client, tamoss *tamossv1alpha1.Tamoss, desired map[string]struct{}, list client.ObjectList, opts ...client.ListOption) error {
-	if err := c.List(ctx, list, opts...); err != nil {
-		return err
-	}
-	return pruneLoadedList(ctx, c, tamoss, desired, list)
 }
 
 func pruneTamossOwnedList(ctx context.Context, c client.Client, tamoss *tamossv1alpha1.Tamoss, desired map[string]struct{}, list client.ObjectList) error {

--- a/operator/internal/controller/tamoss_status.go
+++ b/operator/internal/controller/tamoss_status.go
@@ -45,15 +45,15 @@ func (r *TamossReconciler) updateStatus(ctx context.Context, tamoss *tamossv1alp
 			if schemaResult.Degraded {
 				tamoss.Status.Phase = operatorstatus.PhaseDegraded
 			}
-			operatorstatus.SetConditionBool(&tamoss.Status.Conditions, operatorstatus.ConditionSchemaMigrated, schemaResult.Ready, schemaReason(schemaResult), schemaMessage(schemaResult))
-			operatorstatus.SetConditionBool(&tamoss.Status.Conditions, operatorstatus.ConditionBackendsReady, true, operatorstatus.ReasonBackendReferencesConfigured, "Backend secret references are configured")
-			operatorstatus.SetConditionBool(&tamoss.Status.Conditions, operatorstatus.ConditionIdentityBlueprintSubmitted, identityResult.BlueprintSubmitted, identityBlueprintReason(identityResult), identityBlueprintMessage(identityResult))
-			operatorstatus.SetConditionBool(&tamoss.Status.Conditions, operatorstatus.ConditionIdentityReady, identityResult.Ready, identityResult.Reason, identityResult.Message)
-			setRoutingConditions(&tamoss.Status.Conditions, routingResult)
-			operatorstatus.SetConditionBool(&tamoss.Status.Conditions, operatorstatus.ConditionDegraded, schemaResult.Degraded, degradedReason(schemaResult), degradedMessage(schemaResult))
-			operatorstatus.SetReconciliationActive(&tamoss.Status.Conditions)
-			operatorstatus.SetConditionBool(&tamoss.Status.Conditions, operatorstatus.ConditionProgressing, !ready && !schemaResult.Degraded, operatorstatus.ReasonReconciling, "Waiting for managed workloads to become available")
-			operatorstatus.SetConditionBool(&tamoss.Status.Conditions, operatorstatus.ConditionReady, ready, readyReason(ready, schemaResult, identityResult, routingResult), readyMessage(ready, schemaResult, identityResult, routingResult))
+			operatorstatus.SetConditionBool(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionSchemaMigrated, schemaResult.Ready, schemaReason(schemaResult), schemaMessage(schemaResult))
+			operatorstatus.SetConditionBool(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionBackendsReady, true, operatorstatus.ReasonBackendReferencesConfigured, "Backend secret references are configured")
+			operatorstatus.SetConditionBool(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionIdentityBlueprintSubmitted, identityResult.BlueprintSubmitted, identityBlueprintReason(identityResult), identityBlueprintMessage(identityResult))
+			operatorstatus.SetConditionBool(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionIdentityReady, identityResult.Ready, identityResult.Reason, identityResult.Message)
+			setRoutingConditions(&tamoss.Status.Conditions, tamoss.Generation, routingResult)
+			operatorstatus.SetConditionBool(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionDegraded, schemaResult.Degraded, degradedReason(schemaResult), degradedMessage(schemaResult))
+			operatorstatus.SetReconciliationActive(&tamoss.Status.Conditions, tamoss.Generation)
+			operatorstatus.SetConditionBool(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionProgressing, !ready && !schemaResult.Degraded, operatorstatus.ReasonReconciling, "Waiting for managed workloads to become available")
+			operatorstatus.SetConditionBool(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionReady, ready, readyReason(ready, schemaResult, identityResult, routingResult), readyMessage(ready, schemaResult, identityResult, routingResult))
 			return nil
 		},
 	})
@@ -62,9 +62,9 @@ func (r *TamossReconciler) updateStatus(ctx context.Context, tamoss *tamossv1alp
 func (r *TamossReconciler) updateBlockedBackendStatus(ctx context.Context, tamoss *tamossv1alpha1.Tamoss, input backendBlockedStatusInput) error {
 	return r.patchTamossStatusInput(ctx, tamoss, tamossStatusPatchInput{Apply: func(tamoss *tamossv1alpha1.Tamoss) error {
 		tamoss.Status.Phase = operatorstatus.PhaseDegraded
-		operatorstatus.SetConditionStatus(&tamoss.Status.Conditions, operatorstatus.ConditionSchemaMigrated, metav1.ConditionUnknown, input.Reason, input.SchemaMessage)
-		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, operatorstatus.ConditionBackendsReady, false, input.Reason, input.Message)
-		setActiveBlockedConditions(&tamoss.Status.Conditions, input.Reason, input.Message, input.ProgressingMessage)
+		operatorstatus.SetConditionStatus(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionSchemaMigrated, metav1.ConditionUnknown, input.Reason, input.SchemaMessage)
+		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionBackendsReady, false, input.Reason, input.Message)
+		setActiveBlockedConditions(&tamoss.Status.Conditions, tamoss.Generation, input.Reason, input.Message, input.ProgressingMessage)
 		return nil
 	}})
 }
@@ -82,12 +82,12 @@ func (r *TamossReconciler) updateProviderBackendStatus(ctx context.Context, tamo
 				tamoss.Status.Phase = operatorstatus.PhaseDegraded
 			}
 			if schemaResult == nil {
-				operatorstatus.SetConditionStatus(&tamoss.Status.Conditions, operatorstatus.ConditionSchemaMigrated, metav1.ConditionUnknown, backendResult.Reason, "Schema reconciliation is blocked by backend readiness")
+				operatorstatus.SetConditionStatus(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionSchemaMigrated, metav1.ConditionUnknown, backendResult.Reason, "Schema reconciliation is blocked by backend readiness")
 			} else {
-				operatorstatus.SetConditionBool(&tamoss.Status.Conditions, operatorstatus.ConditionSchemaMigrated, schemaResult.Ready, schemaReason(*schemaResult), schemaMessage(*schemaResult))
+				operatorstatus.SetConditionBool(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionSchemaMigrated, schemaResult.Ready, schemaReason(*schemaResult), schemaMessage(*schemaResult))
 			}
-			operatorstatus.SetConditionBool(&tamoss.Status.Conditions, operatorstatus.ConditionBackendsReady, false, backendResult.Reason, backendResult.Message)
-			setProviderBackendConditions(&tamoss.Status.Conditions, backendResult)
+			operatorstatus.SetConditionBool(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionBackendsReady, false, backendResult.Reason, backendResult.Message)
+			setProviderBackendConditions(&tamoss.Status.Conditions, tamoss.Generation, backendResult)
 			return nil
 		},
 	})
@@ -97,13 +97,13 @@ func (r *TamossReconciler) updateGatewayAPIUnavailableStatus(ctx context.Context
 	return r.patchTamossStatusInput(ctx, tamoss, tamossStatusPatchInput{Apply: func(tamoss *tamossv1alpha1.Tamoss) error {
 		routingResult := gatewayAPIUnavailableResult()
 		tamoss.Status.Phase = operatorstatus.PhaseProgressing
-		operatorstatus.SetConditionStatus(&tamoss.Status.Conditions, operatorstatus.ConditionSchemaMigrated, metav1.ConditionUnknown, routingResult.Reason, "Schema migration status is unchanged while Gateway API routing is unavailable")
-		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, operatorstatus.ConditionBackendsReady, true, operatorstatus.ReasonBackendReferencesConfigured, "Backend secret references are configured")
-		setRoutingConditions(&tamoss.Status.Conditions, routingResult)
-		operatorstatus.SetReconciliationActive(&tamoss.Status.Conditions)
-		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, operatorstatus.ConditionReady, false, routingResult.Reason, routingResult.Message)
-		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, operatorstatus.ConditionProgressing, true, routingResult.Reason, routingResult.Message)
-		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, operatorstatus.ConditionDegraded, false, operatorstatus.ReasonNoError, "No terminal reconcile error has been observed")
+		operatorstatus.SetConditionStatus(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionSchemaMigrated, metav1.ConditionUnknown, routingResult.Reason, "Schema migration status is unchanged while Gateway API routing is unavailable")
+		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionBackendsReady, true, operatorstatus.ReasonBackendReferencesConfigured, "Backend secret references are configured")
+		setRoutingConditions(&tamoss.Status.Conditions, tamoss.Generation, routingResult)
+		operatorstatus.SetReconciliationActive(&tamoss.Status.Conditions, tamoss.Generation)
+		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionReady, false, routingResult.Reason, routingResult.Message)
+		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionProgressing, true, routingResult.Reason, routingResult.Message)
+		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionDegraded, false, operatorstatus.ReasonNoError, "No terminal reconcile error has been observed")
 		return nil
 	}})
 }
@@ -111,28 +111,28 @@ func (r *TamossReconciler) updateGatewayAPIUnavailableStatus(ctx context.Context
 func (r *TamossReconciler) updatePausedStatus(ctx context.Context, tamoss *tamossv1alpha1.Tamoss) error {
 	return r.patchTamossStatusInput(ctx, tamoss, tamossStatusPatchInput{Apply: func(tamoss *tamossv1alpha1.Tamoss) error {
 		tamoss.Status.Phase = operatorstatus.PhasePaused
-		operatorstatus.SetConditionStatus(&tamoss.Status.Conditions, operatorstatus.ConditionSchemaMigrated, metav1.ConditionUnknown, operatorstatus.ReasonPaused, "Schema reconciliation is paused")
-		operatorstatus.SetConditionStatus(&tamoss.Status.Conditions, operatorstatus.ConditionBackendsReady, metav1.ConditionUnknown, operatorstatus.ReasonPaused, "Backend checks are paused")
-		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, operatorstatus.ConditionPaused, true, operatorstatus.ReasonReconciliationPaused, "Reconciliation is paused by spec.paused")
-		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, operatorstatus.ConditionReady, false, operatorstatus.ReasonPaused, "Reconciliation is paused")
-		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, operatorstatus.ConditionProgressing, false, operatorstatus.ReasonPaused, "Reconciliation is paused")
-		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, operatorstatus.ConditionDegraded, false, operatorstatus.ReasonNoError, "No terminal reconcile error has been observed")
+		operatorstatus.SetConditionStatus(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionSchemaMigrated, metav1.ConditionUnknown, operatorstatus.ReasonPaused, "Schema reconciliation is paused")
+		operatorstatus.SetConditionStatus(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionBackendsReady, metav1.ConditionUnknown, operatorstatus.ReasonPaused, "Backend checks are paused")
+		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionPaused, true, operatorstatus.ReasonReconciliationPaused, "Reconciliation is paused by spec.paused")
+		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionReady, false, operatorstatus.ReasonPaused, "Reconciliation is paused")
+		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionProgressing, false, operatorstatus.ReasonPaused, "Reconciliation is paused")
+		operatorstatus.SetConditionBool(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionDegraded, false, operatorstatus.ReasonNoError, "No terminal reconcile error has been observed")
 		return nil
 	}})
 }
 
-func setActiveBlockedConditions(conditions *[]metav1.Condition, reason, message, progressingMessage string) {
-	operatorstatus.SetReconciliationActive(conditions)
-	operatorstatus.SetConditionBool(conditions, operatorstatus.ConditionReady, false, reason, message)
-	operatorstatus.SetConditionBool(conditions, operatorstatus.ConditionProgressing, false, reason, progressingMessage)
-	operatorstatus.SetConditionBool(conditions, operatorstatus.ConditionDegraded, true, reason, message)
+func setActiveBlockedConditions(conditions *[]metav1.Condition, generation int64, reason, message, progressingMessage string) {
+	operatorstatus.SetReconciliationActive(conditions, generation)
+	operatorstatus.SetConditionBool(conditions, generation, operatorstatus.ConditionReady, false, reason, message)
+	operatorstatus.SetConditionBool(conditions, generation, operatorstatus.ConditionProgressing, false, reason, progressingMessage)
+	operatorstatus.SetConditionBool(conditions, generation, operatorstatus.ConditionDegraded, true, reason, message)
 }
 
-func setProviderBackendConditions(conditions *[]metav1.Condition, backendResult providerBackendResult) {
-	operatorstatus.SetReconciliationActive(conditions)
-	operatorstatus.SetConditionBool(conditions, operatorstatus.ConditionReady, false, backendResult.Reason, backendResult.Message)
-	operatorstatus.SetConditionBool(conditions, operatorstatus.ConditionProgressing, !backendResult.Degraded, backendResult.Reason, backendResult.Message)
-	operatorstatus.SetConditionBool(conditions, operatorstatus.ConditionDegraded, backendResult.Degraded, backendResult.Reason, backendResult.Message)
+func setProviderBackendConditions(conditions *[]metav1.Condition, generation int64, backendResult providerBackendResult) {
+	operatorstatus.SetReconciliationActive(conditions, generation)
+	operatorstatus.SetConditionBool(conditions, generation, operatorstatus.ConditionReady, false, backendResult.Reason, backendResult.Message)
+	operatorstatus.SetConditionBool(conditions, generation, operatorstatus.ConditionProgressing, !backendResult.Degraded, backendResult.Reason, backendResult.Message)
+	operatorstatus.SetConditionBool(conditions, generation, operatorstatus.ConditionDegraded, backendResult.Degraded, backendResult.Reason, backendResult.Message)
 }
 
 func (r *TamossReconciler) patchTamossStatusInput(ctx context.Context, tamoss *tamossv1alpha1.Tamoss, input tamossStatusPatchInput) error {

--- a/operator/internal/controller/tamoss_status_backup.go
+++ b/operator/internal/controller/tamoss_status_backup.go
@@ -19,24 +19,24 @@ import (
 func setBackupPolicyCondition(conditions *[]metav1.Condition, tamoss *tamossv1alpha1.Tamoss) {
 	var condition metav1.Condition
 	if tamoss.Spec.Backends.DB.Provider() != tamossv1alpha1.BackendProvidedByCNPG {
-		condition = backupPolicyCondition(metav1.ConditionUnknown, operatorstatus.ReasonBackupPolicyNotManaged, "Database backup policy is owned outside TAMOSS for this provider")
+		condition = backupPolicyCondition(tamoss.Generation, metav1.ConditionUnknown, operatorstatus.ReasonBackupPolicyNotManaged, "Database backup policy is owned outside TAMOSS for this provider")
 		meta.SetStatusCondition(conditions, condition)
 		tamoss.Status.BackupPolicy = backupPolicyStatus(tamoss, condition)
 		return
 	}
 	if tamoss.Spec.Backends.DB.CNPG == nil || !tamoss.Spec.Backends.DB.CNPG.Backup.Enabled {
-		condition = backupPolicyCondition(metav1.ConditionTrue, operatorstatus.ReasonBackupPolicyDisabled, "Managed CNPG backup policy is disabled")
+		condition = backupPolicyCondition(tamoss.Generation, metav1.ConditionTrue, operatorstatus.ReasonBackupPolicyDisabled, "Managed CNPG backup policy is disabled")
 		meta.SetStatusCondition(conditions, condition)
 		tamoss.Status.BackupPolicy = backupPolicyStatus(tamoss, condition)
 		return
 	}
 	if missing := cnpgBackupPolicyMissingFields(tamoss); len(missing) > 0 {
-		condition = backupPolicyCondition(metav1.ConditionFalse, operatorstatus.ReasonBackupPolicyIncomplete, fmt.Sprintf("CNPG backup policy is missing required fields: %s", strings.Join(missing, ", ")))
+		condition = backupPolicyCondition(tamoss.Generation, metav1.ConditionFalse, operatorstatus.ReasonBackupPolicyIncomplete, fmt.Sprintf("CNPG backup policy is missing required fields: %s", strings.Join(missing, ", ")))
 		meta.SetStatusCondition(conditions, condition)
 		tamoss.Status.BackupPolicy = backupPolicyStatus(tamoss, condition)
 		return
 	}
-	condition = backupPolicyCondition(metav1.ConditionTrue, operatorstatus.ReasonBackupPolicyConfigured, "Managed CNPG backup policy is configured")
+	condition = backupPolicyCondition(tamoss.Generation, metav1.ConditionTrue, operatorstatus.ReasonBackupPolicyConfigured, "Managed CNPG backup policy is configured")
 	meta.SetStatusCondition(conditions, condition)
 	tamoss.Status.BackupPolicy = backupPolicyStatus(tamoss, condition)
 }
@@ -62,7 +62,7 @@ func (r *TamossReconciler) observedBackupPolicy(ctx context.Context, tamoss *tam
 	scheduledKey := types.NamespacedName{Name: tamoss.ResourceName("db-backup"), Namespace: tamoss.Namespace}
 	if err := r.Client.Get(ctx, scheduledKey, scheduled); err != nil {
 		if apierrors.IsNotFound(err) {
-			condition := backupPolicyCondition(metav1.ConditionFalse, operatorstatus.ReasonBackupPolicyMissing, fmt.Sprintf("CNPG ScheduledBackup %s has not been observed", scheduledKey.Name))
+			condition := backupPolicyCondition(tamoss.Generation, metav1.ConditionFalse, operatorstatus.ReasonBackupPolicyMissing, fmt.Sprintf("CNPG ScheduledBackup %s has not been observed", scheduledKey.Name))
 			return condition, backupPolicyStatus(tamoss, condition), nil
 		}
 		return metav1.Condition{}, tamossv1alpha1.BackupPolicyStatus{}, err
@@ -72,7 +72,7 @@ func (r *TamossReconciler) observedBackupPolicy(ctx context.Context, tamoss *tam
 	clusterKey := types.NamespacedName{Name: tamoss.ResourceName("db"), Namespace: tamoss.Namespace}
 	if err := r.Client.Get(ctx, clusterKey, cluster); err != nil {
 		if apierrors.IsNotFound(err) {
-			condition := backupPolicyCondition(metav1.ConditionFalse, operatorstatus.ReasonBackupPolicyPending, fmt.Sprintf("CNPG Cluster %s has not been observed for backup status", clusterKey.Name))
+			condition := backupPolicyCondition(tamoss.Generation, metav1.ConditionFalse, operatorstatus.ReasonBackupPolicyPending, fmt.Sprintf("CNPG Cluster %s has not been observed for backup status", clusterKey.Name))
 			return condition, backupPolicyStatus(tamoss, condition), nil
 		}
 		return metav1.Condition{}, tamossv1alpha1.BackupPolicyStatus{}, err
@@ -80,41 +80,42 @@ func (r *TamossReconciler) observedBackupPolicy(ctx context.Context, tamoss *tam
 
 	continuousArchiving := meta.FindStatusCondition(cluster.Status.Conditions, string(cnpgv1.ConditionContinuousArchiving))
 	if continuousArchiving == nil {
-		condition := backupPolicyCondition(metav1.ConditionFalse, operatorstatus.ReasonBackupArchivingUnknown, fmt.Sprintf("CNPG Cluster %s has no ContinuousArchiving condition yet", cluster.Name))
+		condition := backupPolicyCondition(tamoss.Generation, metav1.ConditionFalse, operatorstatus.ReasonBackupArchivingUnknown, fmt.Sprintf("CNPG Cluster %s has no ContinuousArchiving condition yet", cluster.Name))
 		status := backupPolicyStatus(tamoss, condition)
 		status = backupPolicyStatusWithCluster(status, cluster)
 		return condition, status, nil
 	}
 	if continuousArchiving.Status == metav1.ConditionFalse {
-		condition := backupPolicyCondition(metav1.ConditionFalse, operatorstatus.ReasonBackupArchivingFailed, fmt.Sprintf("CNPG ContinuousArchiving is %s: %s", continuousArchiving.Reason, continuousArchiving.Message))
+		condition := backupPolicyCondition(tamoss.Generation, metav1.ConditionFalse, operatorstatus.ReasonBackupArchivingFailed, fmt.Sprintf("CNPG ContinuousArchiving is %s: %s", continuousArchiving.Reason, continuousArchiving.Message))
 		status := backupPolicyStatus(tamoss, condition)
 		status = backupPolicyStatusWithCluster(status, cluster)
 		return condition, status, nil
 	}
 	if backupFailureNewerThanSuccess(cluster.Status.LastFailedBackup, cluster.Status.LastSuccessfulBackup) {
-		condition := backupPolicyCondition(metav1.ConditionFalse, operatorstatus.ReasonBackupPolicyFailed, fmt.Sprintf("CNPG Cluster %s reports a backup failure newer than the latest successful backup", cluster.Name))
+		condition := backupPolicyCondition(tamoss.Generation, metav1.ConditionFalse, operatorstatus.ReasonBackupPolicyFailed, fmt.Sprintf("CNPG Cluster %s reports a backup failure newer than the latest successful backup", cluster.Name))
 		status := backupPolicyStatus(tamoss, condition)
 		status = backupPolicyStatusWithCluster(status, cluster)
 		return condition, status, nil
 	}
 	if cluster.Status.LastSuccessfulBackup == "" && cluster.Status.FirstRecoverabilityPoint == "" && scheduled.Status.LastScheduleTime == nil {
-		condition := backupPolicyCondition(metav1.ConditionFalse, operatorstatus.ReasonBackupPolicyPending, fmt.Sprintf("CNPG ScheduledBackup %s exists but no successful backup has been observed yet", scheduled.Name))
+		condition := backupPolicyCondition(tamoss.Generation, metav1.ConditionFalse, operatorstatus.ReasonBackupPolicyPending, fmt.Sprintf("CNPG ScheduledBackup %s exists but no successful backup has been observed yet", scheduled.Name))
 		status := backupPolicyStatus(tamoss, condition)
 		status = backupPolicyStatusWithCluster(status, cluster)
 		return condition, status, nil
 	}
-	condition := backupPolicyCondition(metav1.ConditionTrue, operatorstatus.ReasonBackupPolicyHealthy, fmt.Sprintf("CNPG ScheduledBackup %s and Cluster %s report backup health", scheduled.Name, cluster.Name))
+	condition := backupPolicyCondition(tamoss.Generation, metav1.ConditionTrue, operatorstatus.ReasonBackupPolicyHealthy, fmt.Sprintf("CNPG ScheduledBackup %s and Cluster %s report backup health", scheduled.Name, cluster.Name))
 	status := backupPolicyStatus(tamoss, condition)
 	status = backupPolicyStatusWithCluster(status, cluster)
 	return condition, status, nil
 }
 
-func backupPolicyCondition(status metav1.ConditionStatus, reason, message string) metav1.Condition {
+func backupPolicyCondition(generation int64, status metav1.ConditionStatus, reason, message string) metav1.Condition {
 	return metav1.Condition{
-		Type:    operatorstatus.ConditionBackupPolicyReady,
-		Status:  status,
-		Reason:  reason,
-		Message: message,
+		Type:               operatorstatus.ConditionBackupPolicyReady,
+		Status:             status,
+		ObservedGeneration: generation,
+		Reason:             reason,
+		Message:            message,
 	}
 }
 

--- a/operator/internal/controller/tamoss_status_conditions.go
+++ b/operator/internal/controller/tamoss_status_conditions.go
@@ -47,5 +47,5 @@ func setUpgradeStatus(tamoss *tamossv1alpha1.Tamoss, phase string, upgradeable m
 		Reason:  reason,
 		Message: message,
 	}
-	operatorstatus.SetConditionStatus(&tamoss.Status.Conditions, operatorstatus.ConditionUpgradeable, upgradeable, reason, message)
+	operatorstatus.SetConditionStatus(&tamoss.Status.Conditions, tamoss.Generation, operatorstatus.ConditionUpgradeable, upgradeable, reason, message)
 }

--- a/operator/internal/controller/tenant_model_test.go
+++ b/operator/internal/controller/tenant_model_test.go
@@ -18,11 +18,11 @@ func TestNamespaceAllowedSupportsMultipleTenantNamespaces(t *testing.T) {
 	reconciler := TamossReconciler{WatchNamespaces: watchNamespaces}
 
 	for _, namespace := range []string{"tams-team-a", "tams-team-b"} {
-		if !reconciler.namespaceAllowed(namespace) {
+		if !reconciler.WatchNamespaces.Allows(namespace) {
 			t.Fatalf("expected namespace %q to be watched", namespace)
 		}
 	}
-	if reconciler.namespaceAllowed("tams-team-c") {
+	if reconciler.WatchNamespaces.Allows("tams-team-c") {
 		t.Fatalf("expected unwatched namespace to be ignored")
 	}
 }

--- a/operator/internal/controller/watch_namespaces.go
+++ b/operator/internal/controller/watch_namespaces.go
@@ -2,8 +2,20 @@ package controller
 
 import "strings"
 
-func ParseWatchNamespaces(raw string) map[string]struct{} {
-	namespaces := map[string]struct{}{}
+// WatchNamespaceSet restricts reconciliation to an allow-list of namespaces.
+// An empty set allows every namespace.
+type WatchNamespaceSet map[string]struct{}
+
+func (s WatchNamespaceSet) Allows(namespace string) bool {
+	if len(s) == 0 {
+		return true
+	}
+	_, ok := s[namespace]
+	return ok
+}
+
+func ParseWatchNamespaces(raw string) WatchNamespaceSet {
+	namespaces := WatchNamespaceSet{}
 	for _, item := range strings.Split(raw, ",") {
 		namespace := strings.TrimSpace(item)
 		if namespace == "" {

--- a/operator/internal/controller/workload_renderer/ingress.go
+++ b/operator/internal/controller/workload_renderer/ingress.go
@@ -6,6 +6,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	tamossv1alpha1 "github.com/livewyer-ops/tamoss/operator/api/v1alpha1"
@@ -37,7 +38,7 @@ func ingressFor(tamoss *tamossv1alpha1.Tamoss, component, serviceName string, sp
 	if len(paths) == 0 {
 		paths = []networkingv1.HTTPIngressPath{{
 			Path:     "/",
-			PathType: pathTypePtr(networkingv1.PathTypePrefix),
+			PathType: ptr.To(networkingv1.PathTypePrefix),
 		}}
 	}
 	for i := range paths {
@@ -53,7 +54,7 @@ func ingressFor(tamoss *tamossv1alpha1.Tamoss, component, serviceName string, sp
 			paths[i].Backend.Service.Port.Number = defaultPort
 		}
 		if paths[i].PathType == nil {
-			paths[i].PathType = pathTypePtr(networkingv1.PathTypePrefix)
+			paths[i].PathType = ptr.To(networkingv1.PathTypePrefix)
 		}
 	}
 	ingress := &networkingv1.Ingress{
@@ -145,7 +146,7 @@ func authentikOutpostIngress(tamoss *tamossv1alpha1.Tamoss) client.Object {
 	servicePort := authentik.OutpostServicePort(port)
 	path := networkingv1.HTTPIngressPath{
 		Path:     "/outpost.goauthentik.io/",
-		PathType: pathTypePtr(networkingv1.PathTypePrefix),
+		PathType: ptr.To(networkingv1.PathTypePrefix),
 		Backend: networkingv1.IngressBackend{Service: &networkingv1.IngressServiceBackend{
 			Name: tamoss.ResourceName("authentik-outpost"),
 			Port: networkingv1.ServiceBackendPort{Name: servicePort.Name},
@@ -190,10 +191,6 @@ func appendAnnotationValue(existing, value string) string {
 		}
 	}
 	return existing + "," + value
-}
-
-func pathTypePtr(pathType networkingv1.PathType) *networkingv1.PathType {
-	return &pathType
 }
 
 func emptyStringNil(value string) *string {

--- a/operator/internal/controller/workload_renderer/s3_ingress.go
+++ b/operator/internal/controller/workload_renderer/s3_ingress.go
@@ -7,6 +7,7 @@ import (
 
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	tamossv1alpha1 "github.com/livewyer-ops/tamoss/operator/api/v1alpha1"
@@ -62,7 +63,7 @@ func s3PublicIngress(tamoss *tamossv1alpha1.Tamoss, endpoint tamossv1alpha1.S3Pu
 	paths := []networkingv1.HTTPIngressPath{
 		{
 			Path:     rustFSConsolePath,
-			PathType: pathTypePtr(networkingv1.PathTypePrefix),
+			PathType: ptr.To(networkingv1.PathTypePrefix),
 			Backend: networkingv1.IngressBackend{Service: &networkingv1.IngressServiceBackend{
 				Name: serviceName + "-console",
 				Port: networkingv1.ServiceBackendPort{Name: rustFSConsoleServicePort},
@@ -70,7 +71,7 @@ func s3PublicIngress(tamoss *tamossv1alpha1.Tamoss, endpoint tamossv1alpha1.S3Pu
 		},
 		{
 			Path:     "/",
-			PathType: pathTypePtr(networkingv1.PathTypePrefix),
+			PathType: ptr.To(networkingv1.PathTypePrefix),
 			Backend: networkingv1.IngressBackend{Service: &networkingv1.IngressServiceBackend{
 				Name: serviceName,
 				Port: networkingv1.ServiceBackendPort{Name: s3ServicePort},

--- a/operator/internal/status/conditions.go
+++ b/operator/internal/status/conditions.go
@@ -7,26 +7,28 @@ import (
 
 const MessageReconciliationActive = "Reconciliation is active"
 
-func SetConditionBool(conditions *[]metav1.Condition, conditionType string, ok bool, reason, message string) {
+func SetConditionBool(conditions *[]metav1.Condition, generation int64, conditionType string, ok bool, reason, message string) {
 	status := metav1.ConditionFalse
 	if ok {
 		status = metav1.ConditionTrue
 	}
-	SetConditionStatus(conditions, conditionType, status, reason, message)
+	SetConditionStatus(conditions, generation, conditionType, status, reason, message)
 }
 
-func SetConditionStatus(conditions *[]metav1.Condition, conditionType string, status metav1.ConditionStatus, reason, message string) {
+func SetConditionStatus(conditions *[]metav1.Condition, generation int64, conditionType string, status metav1.ConditionStatus, reason, message string) {
 	meta.SetStatusCondition(conditions, metav1.Condition{
-		Type:    conditionType,
-		Status:  status,
-		Reason:  reason,
-		Message: message,
+		Type:               conditionType,
+		Status:             status,
+		ObservedGeneration: generation,
+		Reason:             reason,
+		Message:            message,
 	})
 }
 
-func SetReconciliationActive(conditions *[]metav1.Condition) {
+func SetReconciliationActive(conditions *[]metav1.Condition, generation int64) {
 	SetConditionBool(
 		conditions,
+		generation,
 		ConditionPaused,
 		false,
 		ReasonReconciliationActive,

--- a/operator/internal/status/reasons.go
+++ b/operator/internal/status/reasons.go
@@ -51,6 +51,7 @@ const (
 	ReasonBucketCreationFailed                  = "BucketCreationFailed"
 	ReasonBucketDeletionComplete                = "BucketDeletionComplete"
 	ReasonBucketDeletionRetrying                = "BucketDeletionRetrying"
+	ReasonBucketDeletionSkipped                 = "BucketDeletionSkipped"
 	ReasonBucketReady                           = "BucketReady"
 	ReasonCNPGClusterReady                      = "CNPGClusterReady"
 	ReasonCNPGSecretKeyMissing                  = "CNPGSecretKeyMissing"

--- a/operator/test/chainsaw/storagebackend-reconciliation/credentials-deleted-before-storagebackend/assert/archive-storagebackend-ready.yaml
+++ b/operator/test/chainsaw/storagebackend-reconciliation/credentials-deleted-before-storagebackend/assert/archive-storagebackend-ready.yaml
@@ -1,0 +1,11 @@
+apiVersion: tamoss.livewyer.io/v1alpha1
+kind: StorageBackend
+metadata:
+  name: archive
+(spec.tamossRef.name): tamoss
+(status.phase): Ready
+(status.conditions[?type == 'Ready'] | [0].status): "True"
+(status.conditions[?type == 'BucketReady'] | [0].status): "True"
+(status.conditions[?type == 'DatabaseReady'] | [0].status): "True"
+(status.backendID): 33333333-3333-5333-8333-333333333333
+(status.bucketName): archive

--- a/operator/test/chainsaw/storagebackend-reconciliation/credentials-deleted-before-storagebackend/assert/bucket-deletion-skipped-event.yaml
+++ b/operator/test/chainsaw/storagebackend-reconciliation/credentials-deleted-before-storagebackend/assert/bucket-deletion-skipped-event.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Event
+metadata:
+  namespace: ($namespace)
+involvedObject:
+  name: archive
+reason: BucketDeletionSkipped

--- a/operator/test/chainsaw/storagebackend-reconciliation/credentials-deleted-before-storagebackend/chainsaw-test.yaml
+++ b/operator/test/chainsaw/storagebackend-reconciliation/credentials-deleted-before-storagebackend/chainsaw-test.yaml
@@ -1,0 +1,55 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: credentials-deleted-before-storagebackend
+  labels:
+    test.tamoss.io/target: kind
+    test.tamoss.io/tier: standard
+    test.tamoss.io/domain: storage
+    test.tamoss.io/lifecycle: destructive
+    test.tamoss.io/provider: rustfs
+    test.tamoss.io/profile: none
+spec:
+  steps:
+    - name: apply storage backend with credentials secret
+      try:
+        - apply:
+            file: ../../fixtures/operator-namespace-rbac.yaml
+        - apply:
+            file: ../../fixtures/postgres.yaml
+        - apply:
+            file: ../../fixtures/rustfs.yaml
+        - assert:
+            file: ../../fixtures/assert/postgresql-available.yaml
+        - assert:
+            file: ../../fixtures/assert/rustfs-available.yaml
+        - assert:
+            file: ../../fixtures/assert/rustfs-bucket-ready.yaml
+        - apply:
+            file: ../../fixtures/tamoss-external.yaml
+        - apply:
+            file: resources/doomed-rustfs-auth-secret.yaml
+        - apply:
+            file: resources/archive-storagebackend.yaml
+        - assert:
+            file: assert/archive-storagebackend-ready.yaml
+            timeout: 5m
+    # Deleting the credentials Secret BEFORE the StorageBackend must not
+    # error-loop the finalizer: bucket deprovisioning is best effort and the
+    # finalizer has to come off promptly without the Secret.
+    - name: delete credentials secret then storage backend
+      try:
+        - delete:
+            ref:
+              apiVersion: v1
+              kind: Secret
+              name: doomed-rustfs-auth
+        - delete:
+            ref:
+              apiVersion: tamoss.livewyer.io/v1alpha1
+              kind: StorageBackend
+              name: archive
+            timeout: 30s
+        - assert:
+            file: assert/bucket-deletion-skipped-event.yaml
+            timeout: 1m

--- a/operator/test/chainsaw/storagebackend-reconciliation/credentials-deleted-before-storagebackend/resources/archive-storagebackend.yaml
+++ b/operator/test/chainsaw/storagebackend-reconciliation/credentials-deleted-before-storagebackend/resources/archive-storagebackend.yaml
@@ -1,0 +1,24 @@
+apiVersion: tamoss.livewyer.io/v1alpha1
+kind: StorageBackend
+metadata:
+  name: archive
+  annotations:
+    confirmation.tamoss.livewyer.io/deletion: "true"
+spec:
+  id: 33333333-3333-5333-8333-333333333333
+  tamossRef:
+    name: tamoss
+  provider: rustfs
+  label: tamoss.us-east-1:s3:archive
+  region: us-east-1
+  bucketName: archive
+  endpoint:
+    default:
+      url: (join('', ['http://rustfs-svc.', $namespace, '.svc:9000']))
+    public:
+      url: (join('', ['http://rustfs-svc.', $namespace, '.svc:9000']))
+  credentials:
+    existingSecret: doomed-rustfs-auth
+    secretKeys:
+      accessKey: RUSTFS_ACCESS_KEY
+      secretKey: RUSTFS_SECRET_KEY

--- a/operator/test/chainsaw/storagebackend-reconciliation/credentials-deleted-before-storagebackend/resources/doomed-rustfs-auth-secret.yaml
+++ b/operator/test/chainsaw/storagebackend-reconciliation/credentials-deleted-before-storagebackend/resources/doomed-rustfs-auth-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: doomed-rustfs-auth
+type: Opaque
+stringData:
+  RUSTFS_ACCESS_KEY: rustfsadmin
+  RUSTFS_SECRET_KEY: rustfsadmin


### PR DESCRIPTION
## Summary

Resolves owned-object kinds from the scheme, stops stripping Job finalizers, indexes the credentials-Secret watch, lets StorageBackend finalisation complete when its Secret is already gone, stamps condition generations and folds duplicated controller helpers.

## Validation

- [x] Lint and the full envtest suite pass; 17/17 focused Chainsaw cases pass on a fresh kind cluster.