### PR TITLE
Apply managed objects through first-class apply configurations

### DIFF
--- a/operator/internal/controller/backend/cnpg/cluster.go
+++ b/operator/internal/controller/backend/cnpg/cluster.go
@@ -80,14 +80,15 @@ func Reconcile(ctx context.Context, c client.Client, tamoss *tamossv1alpha1.Tamo
 	if err := mutateObject(cluster, mutators...); err != nil {
 		return err
 	}
-	if err := c.Patch(ctx, cluster, client.Apply, client.FieldOwner(resource.FieldOwner)); err != nil { //nolint:staticcheck // client.Apply patches remain supported; migrating to client.Client.Apply(ApplyConfiguration) is a wider refactor than this upgrade.
+	if _, err := resource.ApplyObject(ctx, c, cluster, client.FieldOwner(resource.FieldOwner)); err != nil {
 		return err
 	}
 	if scheduledBackup := BuildScheduledBackup(tamoss); scheduledBackup != nil {
 		if err := mutateObject(scheduledBackup, mutators...); err != nil {
 			return err
 		}
-		return c.Patch(ctx, scheduledBackup, client.Apply, client.FieldOwner(resource.FieldOwner)) //nolint:staticcheck // client.Apply patches remain supported; migrating to client.Client.Apply(ApplyConfiguration) is a wider refactor than this upgrade.
+		_, err := resource.ApplyObject(ctx, c, scheduledBackup, client.FieldOwner(resource.FieldOwner))
+		return err
 	}
 	return nil
 }

--- a/operator/internal/controller/backend/rustfs/tenant.go
+++ b/operator/internal/controller/backend/rustfs/tenant.go
@@ -72,7 +72,8 @@ func Reconcile(ctx context.Context, c client.Client, tamoss *tamossv1alpha1.Tamo
 			return err
 		}
 	}
-	return c.Patch(ctx, tenant, client.Apply, client.FieldOwner(resource.FieldOwner)) //nolint:staticcheck // client.Apply patches remain supported; migrating to client.Client.Apply(ApplyConfiguration) is a wider refactor than this upgrade.
+	_, err = resource.ApplyObject(ctx, c, tenant, client.FieldOwner(resource.FieldOwner))
+	return err
 }
 
 func rustfsOperatorSpec(tamoss *tamossv1alpha1.Tamoss) tamossv1alpha1.S3RustFSOperatorSpec {

--- a/operator/internal/controller/fake_apply_test.go
+++ b/operator/internal/controller/fake_apply_test.go
@@ -2,34 +2,62 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 // fakeApplyInterceptor emulates server-side apply for the controller-runtime
-// fake client, which does not support apply patches on this controller-runtime
-// release. The emulation is a whole-object upsert: good enough for unit tests
-// that assert resulting content, while field-ownership semantics are covered
-// by the envtest specs in managed_apply_test.go.
+// fake client. The fake client's own apply support cannot honour the
+// managed-fields reclamation step — its update path silently discards
+// managedFields sent by the client (fake.fakeClient.update retains the stored
+// entries unconditionally) — so foreign claims could never be transferred and
+// pruned. The emulation is therefore a whole-object upsert: good enough for
+// unit tests that assert resulting content, while field-ownership semantics
+// are covered by the envtest specs in managed_apply_test.go.
 func fakeApplyInterceptor() interceptor.Funcs {
 	return interceptor.Funcs{
-		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-			if patch != client.Apply { //nolint:staticcheck // client.Apply patches remain supported; migrating to client.Client.Apply(ApplyConfiguration) is a wider refactor than this upgrade.
-				return c.Patch(ctx, obj, patch, opts...)
-			}
-			live := obj.DeepCopyObject().(client.Object)
-			err := c.Get(ctx, client.ObjectKeyFromObject(obj), live)
-			if apierrors.IsNotFound(err) {
-				obj.SetResourceVersion("")
-				return c.Create(ctx, obj)
-			}
+		Apply: func(ctx context.Context, c client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+			raw, err := json.Marshal(obj)
 			if err != nil {
 				return err
 			}
-			obj.SetResourceVersion(live.GetResourceVersion())
-			return c.Update(ctx, obj)
+			desired := &unstructured.Unstructured{}
+			if err := desired.UnmarshalJSON(raw); err != nil {
+				return err
+			}
+			live := desired.DeepCopy()
+			err = c.Get(ctx, client.ObjectKeyFromObject(desired), live)
+			switch {
+			case apierrors.IsNotFound(err):
+				desired.SetResourceVersion("")
+				if err := c.Create(ctx, desired); err != nil {
+					return err
+				}
+			case err != nil:
+				return err
+			default:
+				desired.SetResourceVersion(live.GetResourceVersion())
+				if err := c.Update(ctx, desired); err != nil {
+					return err
+				}
+			}
+			// Write the upsert result back into the apply configuration so
+			// callers observe the server response, as the real client does.
+			applied, err := desired.MarshalJSON()
+			if err != nil {
+				return err
+			}
+			into, ok := obj.(json.Unmarshaler)
+			if !ok {
+				return fmt.Errorf("apply configuration %T cannot receive the apply response", obj)
+			}
+			return into.UnmarshalJSON(applied)
 		},
 	}
 }

--- a/operator/internal/controller/managed_apply.go
+++ b/operator/internal/controller/managed_apply.go
@@ -37,21 +37,26 @@ func applyManagedObject(ctx context.Context, c client.Client, desired client.Obj
 			// Creating through apply keeps a single write mechanism and
 			// records a clean apply entry from the start, so the next
 			// reconcile is a no-op instead of a field-ownership migration.
-			return applyResult{Changed: true, Created: true}, applyObjectPatch(ctx, c, desired)
+			_, applyErr := applyDesiredObject(ctx, c, desired)
+			return applyResult{Changed: true, Created: true}, applyErr
 		}
 		return applyResult{}, err
 	}
 	if err := reclaimAuthoritativeFields(ctx, c, live); err != nil {
 		return applyResult{}, err
 	}
-	if err := applyObjectPatch(ctx, c, desired); err != nil {
+	applied, err := applyDesiredObject(ctx, c, desired)
+	if err != nil {
 		return applyResult{}, err
 	}
-	return applyResult{Changed: managedObjectChanged(live, desired)}, nil
+	return applyResult{Changed: managedObjectChanged(live, applied)}, nil
 }
 
-func applyObjectPatch(ctx context.Context, c client.Client, desired client.Object) error {
-	return c.Patch(ctx, desired, client.Apply, client.FieldOwner(resource.FieldOwner), client.ForceOwnership) //nolint:staticcheck // client.Apply patches remain supported; migrating to client.Client.Apply(ApplyConfiguration) is a wider refactor than this upgrade.
+// applyDesiredObject submits desired with the operator as a forcing field
+// owner and returns the object as the server applied it, whose revision
+// drives the drift verdict.
+func applyDesiredObject(ctx context.Context, c client.Client, desired client.Object) (client.Object, error) {
+	return resource.ApplyObject(ctx, c, desired, client.FieldOwner(resource.FieldOwner), client.ForceOwnership)
 }
 
 // managedObjectChanged reports whether the apply produced a new revision of

--- a/operator/internal/controller/resource/apply.go
+++ b/operator/internal/controller/resource/apply.go
@@ -1,0 +1,52 @@
+package resource
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ApplyObject writes obj with server-side apply through the first-class
+// client.Client.Apply API that controller-runtime v0.22 introduced as the
+// replacement for the deprecated client.Apply patch type. The desired object
+// is converted to an unstructured apply configuration with the same plain
+// JSON encoding the deprecated patch used for its request body (json.Marshal
+// in both controller-runtime's applyPatch.Data and client-go's
+// apply.NewRequest), so the request — and with it every field-ownership
+// claim — is exactly what the patch-based mechanism sent. Zero-value
+// sections a typed desired object cannot omit (creationTimestamp, empty
+// status structs) marshal as null or empty maps just as before and claim no
+// fields under server-side apply. The returned object carries the server's
+// response, including resourceVersion and generation.
+func ApplyObject(ctx context.Context, c client.Client, obj client.Object, opts ...client.ApplyOption) (*unstructured.Unstructured, error) {
+	desired, err := applyConfigurationForObject(obj)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.Apply(ctx, client.ApplyConfigurationFromUnstructured(desired), opts...); err != nil {
+		return nil, err
+	}
+	return desired, nil
+}
+
+// applyConfigurationForObject converts a desired object into the unstructured
+// form client.ApplyConfigurationFromUnstructured accepts. The object must
+// already carry apiVersion and kind: server-side apply requests are rejected
+// without them, exactly as with the deprecated apply patch.
+func applyConfigurationForObject(obj client.Object) (*unstructured.Unstructured, error) {
+	if u, ok := obj.(*unstructured.Unstructured); ok {
+		return u.DeepCopy(), nil
+	}
+	raw, err := json.Marshal(obj)
+	if err != nil {
+		return nil, fmt.Errorf("encode %T as apply configuration: %w", obj, err)
+	}
+	u := &unstructured.Unstructured{}
+	if err := u.UnmarshalJSON(raw); err != nil {
+		return nil, fmt.Errorf("decode %T apply configuration: %w", obj, err)
+	}
+	return u, nil
+}


### PR DESCRIPTION
## Summary

Migrates the server-side apply path from the deprecated `client.Apply` patch type to controller-runtime's first-class `Apply` API, converting desired objects with the identical JSON encoding so field-ownership claims are unchanged, and removes the deprecation nolints.

## Validation

- [x] Lint (no deprecated-apply suppressions remain) and the full envtest suite pass; 10/10 apply-sensitive Chainsaw cases pass on a fresh kind cluster (field ownership, both drift variants, idempotent reapply, prune, cascades, secret rotation).