### PR TITLE
Fix release asset rendering after the kustomize pin bump

### DIFF
--- a/.github/workflows/operator-release.yaml
+++ b/.github/workflows/operator-release.yaml
@@ -53,9 +53,8 @@ jobs:
 
       - name: Verify release assets are current
         run: |
-          make -C operator manifests kustomize
-          operator/bin/kustomize-v5.3.0 build operator/config/default > /tmp/tamoss-operator-install.yaml
-          diff -u deploy/operator/install.yaml /tmp/tamoss-operator-install.yaml
+          make -C operator install-manifest
+          git diff --exit-code -- deploy/operator/install.yaml
           git diff --exit-code -- operator/api operator/config operator/go.mod operator/go.sum
 
       - name: Build release install manifest
@@ -73,7 +72,8 @@ jobs:
               newName: livewyer/tamoss-operator
               newTag: ${VERSION}
           EOF
-          operator/bin/kustomize-v5.3.0 build dist/operator-release > dist/operator-release/install.yaml
+          KUSTOMIZE_BIN="$(ls operator/bin/kustomize-v* | head -n 1)"
+          "$KUSTOMIZE_BIN" build dist/operator-release > dist/operator-release/install.yaml
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2


### PR DESCRIPTION
## Summary

The release workflow still invoked the old hardcoded `kustomize-v5.3.0` binary, which the toolchain upgrade no longer installs; rendering now goes through `make install-manifest` and the Makefile-resolved kustomize.

## Validation

- [x] `make -C operator install-manifest` reproduces the committed manifest byte-identically; workflow YAML parses.