### PR TITLE
chore: add 8.1.0-oss3 release metadata

### DIFF
--- a/operator/compatibility.yaml
+++ b/operator/compatibility.yaml
@@ -52,6 +52,17 @@
           "8.1.0-oss1"
         ]
       }
+    },
+    {
+      "version": "8.1.0-oss3",
+      "tamsAPI": "8.1",
+      "schemaRevision": "8.1.0-oss2",
+      "upgrade": {
+        "class": "APIOnly",
+        "from": [
+          "8.1.0-oss2"
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
Adds the 8.1.0-oss3 operator compatibility metadata needed by release workflows.\n\nValidation run locally:\n- python3 .github/scripts/release-metadata.py --validate\n- python3 .github/scripts/release-metadata.py 8.1.0-oss3\n- uv run --project src pytest -c src/pyproject.toml -q --no-header --tb=short tests/scripts/test_release_metadata.py -ra