### PR TITLE
docs: clarify browser CORS configuration

### DIFF
--- a/docs/concepts/storage-backends.md
+++ b/docs/concepts/storage-backends.md
@@ -126,6 +126,20 @@ TAMOSS API CORS and bucket CORS are separate. Configure API CORS with
 `.spec.api.cors.allowedOrigins` when browser tools call the TAMOSS API. TAMOSS
 does not configure bucket CORS for `external-s3` backends.
 
+## Managed RustFS Browser Access
+
+For managed RustFS backends the operator configures bucket CORS automatically,
+but only for a single origin: the UI web host from `.spec.ingress.ui.web.host`
+(`https` when `.spec.ingress.tls` is set, otherwise `http`). When that host is
+unset the operator falls back to a wildcard (`*`) origin; set the UI host to
+narrow bucket CORS to that one origin.
+
+Unlike `.spec.api.cors.allowedOrigins`, which accepts a list, managed bucket CORS
+is single-origin. Browser access to a managed bucket from an additional origin
+(for example a separate review or playback tool) is not expressible on a managed
+backend. Use an `external-s3` backend and configure the provider's bucket CORS
+policy directly when you need more than the UI origin.
+
 ## Deletion
 
 Deleting a `StorageBackend` requires the confirmation annotation. Managed RustFS

--- a/docs/concepts/storage-backends.md
+++ b/docs/concepts/storage-backends.md
@@ -101,20 +101,30 @@ and object IDs by `TAMOSS_STORAGE_OBJECT_ID_MAX_LENGTH`. Clients must upload,
 finalize, and then register segments; allocated-only controlled objects are not
 referenceable by Flow Segments.
 
-## External S3 Browser Uploads
+## External S3 Browser Access
 
-Browser ingest uploads directly to the presigned S3 URL. Curl and server-side
-tests can succeed while browser uploads fail if the external bucket CORS policy
-does not allow the TAMOSS UI origin.
+Browser clients access external object storage directly through presigned URLs.
+Ingest uses `put_url`; playback and downloads use `get_urls`. Curl and
+server-side tests can succeed while browsers fail if the external bucket CORS
+policy does not allow the browser origin, method, or requested headers.
 
-External S3 buckets must allow:
+External S3 buckets must allow every browser origin that will dereference
+presigned URLs. This can include the TAMOSS UI origin and external tools such as
+review, playback, or ingest clients. At minimum, configure:
 
-- Origin: the TAMOSS UI origin, such as `https://app.tamoss.example.com`.
-- Method: `PUT`.
-- Headers: at least `content-type`; `*` is simplest where acceptable.
-- Optional read methods: `GET` and `HEAD`.
+- Origins: browser origins such as `https://app.tamoss.example.com` and
+  `https://tool.example.com`.
+- Upload methods: `PUT`.
+- Read methods: `GET` and `HEAD`.
+- Upload headers: at least `content-type`; `*` is simplest where acceptable.
+- Read/playback headers: `range` is commonly required by media clients. Some
+  XHR-based clients also preflight `authorization`, `x-requested-with`,
+  `cache-control`, or `pragma` even when the presigned URL itself carries the
+  storage credentials.
 
-TAMOSS does not configure CORS for `external-s3` backends.
+TAMOSS API CORS and bucket CORS are separate. Configure API CORS with
+`.spec.api.cors.allowedOrigins` when browser tools call the TAMOSS API. TAMOSS
+does not configure bucket CORS for `external-s3` backends.
 
 ## Deletion
 

--- a/docs/getting-started/multi-server.md
+++ b/docs/getting-started/multi-server.md
@@ -65,8 +65,8 @@ Use the multi-server profile as the baseline for production choices:
   ACME email before applying.
 - Keep internal service URLs separate from public OAuth issuer and public S3
   URLs.
-- Confirm browser-facing S3 CORS permits the UI origin, `PUT`, and required
-  headers.
+- Confirm API CORS and browser-facing S3 CORS permit every browser origin that
+  will call the API or dereference presigned object URLs.
 - Test restore for PostgreSQL and object storage before accepting production
   data.
 

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -251,7 +251,10 @@ For external S3:
 - Confirm the endpoint and region match the provider.
 - Confirm the referenced Secret and key names match the `StorageBackend`.
 - Confirm the public endpoint is reachable from browsers.
-- Confirm bucket CORS permits the TAMOSS UI origin, `PUT`, and `content-type`.
+- Confirm API CORS permits every browser origin that calls the TAMOSS API.
+- Confirm bucket CORS permits every browser origin that dereferences presigned
+  object URLs, plus the methods and request headers used by those browser
+  clients.
 
 The operator records a best-effort `ExternalS3DiagnosticReady` condition on
 external `StorageBackend` resources. `CORSMisconfigured`,
@@ -260,18 +263,91 @@ do not mutate external buckets and can be false positives or false negatives
 because browser behavior, presigned URL shape, and provider CORS evaluation are
 owned by the external service.
 
-The API can allocate storage successfully while browser ingest still fails. If
-the UI reports a CORS error, test the preflight against a fresh presigned URL
-without sharing the URL publicly:
+Browser clients usually cross two CORS boundaries:
+
+1. The TAMOSS API origin, configured by `.spec.api.cors.allowedOrigins`.
+2. The object-store origin, configured by the external bucket provider.
+
+First test the API preflight from the browser origin:
 
 ```bash
-curl -sS -o /tmp/preflight-body.txt -D /tmp/preflight-headers.txt \
+curl -sS -o /tmp/api-preflight-body.txt -D /tmp/api-preflight-headers.txt \
+  -X OPTIONS "$TAMOSS_API_URL/service/storage-backends" \
+  -H 'Origin: https://tool.example.com' \
+  -H 'Access-Control-Request-Method: GET' \
+  -H 'Access-Control-Request-Headers: authorization,content-type'
+
+grep -i '^access-control' /tmp/api-preflight-headers.txt
+```
+
+Then test object-store preflight against a fresh presigned URL without sharing
+the URL publicly. For browser uploads:
+
+```bash
+curl -sS -o /tmp/put-preflight-body.txt -D /tmp/put-preflight-headers.txt \
   -X OPTIONS "$PRESIGNED_PUT_URL" \
-  -H 'Origin: https://app.tamoss.localtest.me' \
+  -H 'Origin: https://tool.example.com' \
   -H 'Access-Control-Request-Method: PUT' \
   -H 'Access-Control-Request-Headers: content-type'
 
-grep -i '^access-control' /tmp/preflight-headers.txt
+grep -i '^access-control' /tmp/put-preflight-headers.txt
+```
+
+For browser playback or download from `get_urls`:
+
+```bash
+curl -sS -o /tmp/get-preflight-body.txt -D /tmp/get-preflight-headers.txt \
+  -X OPTIONS "$PRESIGNED_GET_URL" \
+  -H 'Origin: https://tool.example.com' \
+  -H 'Access-Control-Request-Method: GET' \
+  -H 'Access-Control-Request-Headers: range,authorization,x-requested-with,cache-control,pragma'
+
+grep -i '^access-control' /tmp/get-preflight-headers.txt
+```
+
+An `OPTIONS` response with HTTP `200` but no `Access-Control-Allow-Origin` is
+still a CORS failure. Compare the browser's `Access-Control-Request-Headers`
+value with the bucket rule; providers such as GCS only return CORS headers when
+the origin, method, and requested headers all match.
+
+For GCS-backed `external-s3` buckets, keep a JSON policy with the environment
+overlay or operator runbook and apply it with `gcloud`:
+
+```json
+[
+  {
+    "origin": [
+      "https://app.tamoss.example.com",
+      "https://tool.example.com"
+    ],
+    "method": ["GET", "HEAD", "PUT"],
+    "responseHeader": [
+      "Content-Type",
+      "Content-Length",
+      "Content-Range",
+      "Content-MD5",
+      "Accept-Ranges",
+      "Range",
+      "Authorization",
+      "X-Requested-With",
+      "Cache-Control",
+      "Pragma",
+      "ETag",
+      "x-amz-checksum-crc32",
+      "x-amz-checksum-crc32c",
+      "x-amz-checksum-sha1",
+      "x-amz-checksum-sha256",
+      "x-goog-hash",
+      "x-goog-generation",
+      "x-goog-metageneration"
+    ],
+    "maxAgeSeconds": 3600
+  }
+]
+```
+
+```bash
+gcloud storage buckets update gs://BUCKET --cors-file=cors.json
 ```
 
 For Backblaze B2, the web-console "share with every origin" setting can allow

--- a/docs/reference/tamoss-cr.md
+++ b/docs/reference/tamoss-cr.md
@@ -65,6 +65,31 @@ Use `.spec.advanced` only when a field is not represented elsewhere in the CR.
 Advanced resource patches are applied before the operator writes emitted
 resources, and advanced extra resources are owned by the `Tamoss` instance.
 
+## API CORS
+
+Use `.spec.api.cors.allowedOrigins` when a browser application hosted on a
+different origin needs to call the TAMOSS API directly:
+
+```yaml
+spec:
+  api:
+    cors:
+      allowedOrigins:
+        - https://app.tamoss.example.com
+        - https://tool.example.com
+```
+
+The operator renders these origins into `TAMOSS_CORS_ALLOWED_ORIGINS` for the
+API Deployment. The API then allows browser preflight and authenticated requests
+from those origins. Values must be absolute `http` or `https` origins without a
+path, query string, or fragment.
+
+This field only configures CORS on TAMOSS API responses. Browser uploads,
+playback, and downloads that use presigned object-store URLs are controlled by
+the object-store provider's CORS policy. For `external-s3` backends, update the
+bucket CORS policy separately for every browser origin that dereferences
+presigned `put_url` or `get_urls`.
+
 ## Immutability And Required Fields
 
 The API server rejects updates that change `.spec.fullnameOverride` after

--- a/docs/reference/tamoss-cr.md
+++ b/docs/reference/tamoss-cr.md
@@ -88,7 +88,9 @@ This field only configures CORS on TAMOSS API responses. Browser uploads,
 playback, and downloads that use presigned object-store URLs are controlled by
 the object-store provider's CORS policy. For `external-s3` backends, update the
 bucket CORS policy separately for every browser origin that dereferences
-presigned `put_url` or `get_urls`.
+presigned `put_url` or `get_urls`. Managed RustFS bucket CORS is configured
+automatically but is single-origin (the UI host); see
+[Storage Backends](../concepts/storage-backends.md).
 
 ## Immutability And Required Fields
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -86,8 +86,10 @@ task e2e:deployed PROFILE=local-kind KUBECONFIG=tams.kubeconfig
 Presigned URLs are temporary credentials. Do not paste complete URLs into public
 issues, logs, or documentation.
 
-Browser uploads to external S3-compatible buckets require provider-side CORS for
-the TAMOSS UI origin. See [Troubleshooting](operations/troubleshooting.md).
+Browser uploads and playback against external S3-compatible buckets require
+provider-side CORS for every browser origin that dereferences presigned object
+URLs. API CORS is configured separately on the `Tamoss` resource. See
+[Troubleshooting](operations/troubleshooting.md).
 
 For local Kind, browser uploads use presigned URLs on
 `https://s3.tamoss.localtest.me`. Accept or trust the local self-signed TLS


### PR DESCRIPTION
## Summary
- document API CORS via `.spec.api.cors.allowedOrigins`
- clarify that external object-store CORS is a separate provider-owned layer
- add troubleshooting checks for API and presigned URL preflights, including GCS bucket CORS guidance

## Validation
- `git diff --check -- docs/concepts/storage-backends.md docs/getting-started/multi-server.md docs/operations/troubleshooting.md docs/reference/tamoss-cr.md docs/usage.md`
- pre-commit hooks during commit/push