### PR TITLE
docs: clarify aqua installation and optional media tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ backend integrations.
 
 ## Quickstart
 
-**Prerequisites:** Docker, `curl`, `openssl`, and `git`. The rest of the toolchain
-(`task`, `kind`, `kubectl`, `helm`, `helmfile`, `chainsaw`, …) is provisioned by `aqua install`.
+**Prerequisites:** Docker, `curl`, `openssl`, `git`, and
+[aqua](https://aquaproj.github.io/docs/install) — a single-binary CLI version
+manager. With aqua installed, the rest of the toolchain (`task`, `kind`,
+`kubectl`, `helm`, `helmfile`, `chainsaw`, …) is provisioned by `aqua install`.
 
 Use the local Kind profile first:
 

--- a/aqua.yml
+++ b/aqua.yml
@@ -70,8 +70,10 @@ packages:
     - name: jqlang/jq@jq-1.8.1 # k6 summary parsing in .github/workflows/*-e2e,
     # nightly-slo, and src/scripts/
 
-# Notes: these OS/system tools are still required outside aqua:
+# Notes: aqua cannot provide these OS/system tools.
+# Required to build, test, and deploy:
 # - Docker or Podman (and docker compose) — container build + compose stack
 # - curl, openssl, git                    — setup and local scripts
-# - ffmpeg                                — ingest helper and k6 media seeding
-# - uuidgen (util-linux)                  — k6 media seeding helper
+# Optional, only for the ingest helper (src/scripts/ingest_video.sh):
+# - ffmpeg                                — segments local video files for ingest
+# - uuidgen (util-linux)                  — generates flow and source identifiers


### PR DESCRIPTION
Lists aqua itself (with its install link) as a README prerequisite so the quickstart's `aqua install` step is self-explanatory, and rewords the `aqua.yml` footnote so ffmpeg and uuidgen are clearly optional, needed only for the ingest helper. Prompted by user feedback that the toolchain requirements were unclear.