### PR TITLE
feat: add edge profile for single-node ARM installs

### DIFF
--- a/.tasks/lib/env.sh
+++ b/.tasks/lib/env.sh
@@ -104,9 +104,9 @@ task_init_env() {
       ;;
   esac
   case "$profile" in
-    single-server|multi-server) ;;
+    single-server|multi-server|edge) ;;
     *)
-      echo "PROFILE must be single-server or multi-server for remote Kubernetes environments." >&2
+      echo "PROFILE must be single-server, multi-server, or edge for remote Kubernetes environments." >&2
       return 2
       ;;
   esac
@@ -129,6 +129,9 @@ task_init_env() {
       "$file" > "$tmp_file"
     mv "$tmp_file" "$file"
   done
+  if [ "$profile" = "edge" ]; then
+    cp deploy/platform/values/edge-reference.yaml "$environment_dir/platform-values.yaml"
+  fi
 
   printf 'Created %s\n' "$environment_dir"
   printf 'Edit the YAML files there, then run:\n'
@@ -366,7 +369,7 @@ task_apply_env() {
   namespace="${namespace:-tams}"
 
   case "$profile" in
-    local-kind|single-server|multi-server) ;;
+    local-kind|single-server|multi-server|edge) ;;
     *)
       echo "Unable to infer a supported Tamoss spec.profile from $environment_dir." >&2
       return 1
@@ -852,21 +855,29 @@ task_print_env_summary() {
   task_condition_summary "$kubeconfig" "$api_namespace" "Routes" tamoss "$tamoss_name" "RoutingReady"
   printf '\nAccess\n'
   printf '  App URL:          %s\n' "$app_url"
-  printf '  Auth Admin URL:   %s/if/admin/\n' "${auth_url%/}"
-  if [ -n "$app_username" ] || [ -n "$app_password" ]; then
-    printf '  App/Auth User:    %s\n' "${app_username:-<not configured>}"
-    printf '  App/Auth Pass:    %s\n' "${app_password:-<not available>}"
+  printf '  Auth Provider:    %s\n' "${auth_provider:-<not available>}"
+  if [ "$auth_provider" = "authentik-blueprints" ]; then
+    printf '  Auth Admin URL:   %s/if/admin/\n' "${auth_url%/}"
+    if [ -n "$app_username" ] || [ -n "$app_password" ]; then
+      printf '  App/Auth User:    %s\n' "${app_username:-<not configured>}"
+      printf '  App/Auth Pass:    %s\n' "${app_password:-<not available>}"
+    fi
   fi
   printf '\n'
   printf '  API URL:          %s\n' "${api_url%/}"
   printf '  API Token:        %s\n' "${bearer_token:-<not available>}"
   printf '\n'
-  printf 'OAuth2\n'
-  printf '  Client ID:        %s\n' "${oauth_client_id:-<not available>}"
-  printf '  Client Secret:    %s\n' "${oauth_client_secret:-<not available>}"
-  printf '  Issuer URL:       %s\n' "${oauth_issuer:-<not available>}"
-  printf '  Token URL:        %s\n' "${oauth_token_endpoint:-<not available>}"
-  printf '\n'
+  if [ -n "$oauth_client_id" ] ||
+    [ -n "$oauth_client_secret" ] ||
+    [ -n "$oauth_issuer" ] ||
+    [ -n "$oauth_token_endpoint" ]; then
+    printf 'OAuth2\n'
+    printf '  Client ID:        %s\n' "${oauth_client_id:-<not available>}"
+    printf '  Client Secret:    %s\n' "${oauth_client_secret:-<not available>}"
+    printf '  Issuer URL:       %s\n' "${oauth_issuer:-<not available>}"
+    printf '  Token URL:        %s\n' "${oauth_token_endpoint:-<not available>}"
+    printf '\n'
+  fi
   printf '  RustFS Admin URL: %s/rustfs/console/\n' "${s3_url%/}"
   printf '  RustFS Username:  %s\n' "${rustfs_username:-<not available>}"
   printf '  RustFS Password:  %s\n\n' "${rustfs_password:-<not available>}"

--- a/deploy/environments/kind-edge/kustomization.yaml
+++ b/deploy/environments/kind-edge/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../instances/edge
+
+patches:
+  - path: tamoss-patch.yaml

--- a/deploy/environments/kind-edge/platform-values.yaml
+++ b/deploy/environments/kind-edge/platform-values.yaml
@@ -1,0 +1,29 @@
+certManager:
+  enabled: true
+
+cnpg:
+  enabled: true
+
+rustfsOperator:
+  enabled: true
+
+authentik:
+  enabled: false
+
+traefik:
+  enabled: true
+  deployment:
+    replicas: 1
+  service:
+    spec:
+      type: NodePort
+  ports:
+    web:
+      expose:
+        default: false
+    websecure:
+      nodePort: 30443
+
+tls:
+  mode: selfSigned
+  issuerName: tamoss-edge-selfsigned

--- a/deploy/environments/kind-edge/tamoss-patch.yaml
+++ b/deploy/environments/kind-edge/tamoss-patch.yaml
@@ -1,0 +1,24 @@
+apiVersion: tamoss.livewyer.io/v1alpha1
+kind: Tamoss
+metadata:
+  name: tamoss-edge
+  namespace: tams
+spec:
+  publicEndpoint:
+    baseDomain: tamoss.localtest.me
+    tlsSecretName: tamoss-edge-tls
+    s3TLSSecretName: tamoss-edge-s3-tls
+  ingress:
+    annotations:
+      cert-manager.io/cluster-issuer: tamoss-edge-selfsigned
+  api:
+    env:
+      TAMOSS_WEBHOOK_ALLOWED_HOSTS: .svc.cluster.local
+    image:
+      tag: dev
+  worker:
+    env:
+      TAMOSS_WEBHOOK_ALLOWED_HOSTS: .svc.cluster.local
+  ui:
+    image:
+      tag: dev

--- a/deploy/instances/edge/kustomization.yaml
+++ b/deploy/instances/edge/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - tamoss.yaml
+
+components:
+  - ../components/shared-defaults

--- a/deploy/instances/edge/tamoss.yaml
+++ b/deploy/instances/edge/tamoss.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tams
+---
+apiVersion: tamoss.livewyer.io/v1alpha1
+kind: Tamoss
+metadata:
+  name: tamoss-edge
+  namespace: tams
+spec:
+  profile: edge

--- a/deploy/operator/install.yaml
+++ b/deploy/operator/install.yaml
@@ -6794,6 +6794,7 @@ spec:
                 - local-kind
                 - single-server
                 - multi-server
+                - edge
                 type: string
               publicEndpoint:
                 description: PublicEndpoint defines the public DNS defaults used by

--- a/deploy/platform/values/edge-reference.yaml
+++ b/deploy/platform/values/edge-reference.yaml
@@ -1,0 +1,23 @@
+certManager:
+  enabled: true
+
+cnpg:
+  enabled: true
+
+rustfsOperator:
+  enabled: true
+
+authentik:
+  enabled: false
+
+traefik:
+  enabled: true
+  deployment:
+    replicas: 1
+  service:
+    spec:
+      type: LoadBalancer
+
+tls:
+  mode: selfSigned
+  issuerName: tamoss-edge-selfsigned

--- a/deploy/profiles.yaml
+++ b/deploy/profiles.yaml
@@ -27,3 +27,12 @@ profiles:
     tamossName: tamoss-multi-server
     targetEnv: tests/targets/multi-server.env
     remoteEnvironment: true
+  - id: edge
+    # Edge validates on a single-node Kind harness, but the target install shape
+    # is a single ARM64 K3s node with local persistent storage.
+    kindConfig: deploy/kind.yaml
+    kindEnvironmentDir: deploy/environments/kind-edge
+    instanceKustomizeDir: deploy/instances/edge
+    tamossName: tamoss-edge
+    targetEnv: tests/targets/edge.env
+    remoteEnvironment: true

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,8 +8,8 @@ then stay on the matching install, configuration, usage, and operations path.
 | Goal | Start with | Next steps |
 | --- | --- | --- |
 | Validate TAMOSS locally | [Local Kind](getting-started/local-kind.md) | [Usage](usage.md), [Troubleshooting](operations/troubleshooting.md), [Task Commands](reference/task-commands.md) |
-| Install on an existing cluster | [Install](operations/install.md) | [Single Server](getting-started/single-server.md) or [Multi Server](getting-started/multi-server.md), then [Configuration](configuration.md) |
-| Choose a deployment shape | [Profiles](concepts/profiles.md) | `local-kind`, `single-server`, or `multi-server` |
+| Install on an existing cluster | [Install](operations/install.md) | [Edge](getting-started/edge.md), [Single Server](getting-started/single-server.md), or [Multi Server](getting-started/multi-server.md), then [Configuration](configuration.md) |
+| Choose a deployment shape | [Profiles](concepts/profiles.md) | `local-kind`, `edge`, `single-server`, or `multi-server` |
 | Configure providers and endpoints | [Configuration](configuration.md) | [Provider Ownership](concepts/provider-ownership.md), [Runtime Configuration](reference/runtime-configuration.md), [Tamoss CR](reference/tamoss-cr.md), [StorageBackend CR](reference/storagebackend-cr.md) |
 | Use the UI or API | [Usage](usage.md) | [API](reference/api.md), [Storage Backends](concepts/storage-backends.md) |
 | Operate an installed cluster | [Day 2](operations/day-2.md) | [Backup and Restore](operations/backup-restore.md), [Upgrades](operations/upgrades.md), [Troubleshooting](operations/troubleshooting.md) |
@@ -18,6 +18,8 @@ then stay on the matching install, configuration, usage, and operations path.
 ## Get Started
 
 - [Local Kind](getting-started/local-kind.md) - canonical local validation path.
+- [Edge](getting-started/edge.md) - single-node ARM64 self-contained
+  Kubernetes.
 - [Single Server](getting-started/single-server.md) - run on one node or a
   small self-managed Kubernetes cluster.
 - [Multi Server](getting-started/multi-server.md) - production-shaped
@@ -30,8 +32,8 @@ then stay on the matching install, configuration, usage, and operations path.
 
 - [Architecture](concepts/architecture.md) - operator, platform, and instance
   boundaries.
-- [Profiles](concepts/profiles.md) - `local-kind`, `single-server`, and
-  `multi-server`.
+- [Profiles](concepts/profiles.md) - `local-kind`, `edge`, `single-server`,
+  and `multi-server`.
 - [Provider Ownership](concepts/provider-ownership.md) - managed and external
   PostgreSQL, S3, authentication, and HTTP.
 - [Storage Backends](concepts/storage-backends.md) - default and additional
@@ -82,7 +84,7 @@ navigation becomes a clear maintenance burden.
 | --- | --- |
 | `Tamoss` | The namespaced custom resource reconciled into API, UI, worker, database, storage, identity, and routing resources. |
 | `StorageBackend` | A namespaced custom resource that represents a registered TAMS object-store backend and its readiness. |
-| Profile | A deployment shape such as `local-kind`, `single-server`, or `multi-server` that supplies defaults. |
+| Profile | A deployment shape such as `local-kind`, `edge`, `single-server`, or `multi-server` that supplies defaults. |
 | Environment | A checked-in Kustomize overlay under `deploy/environments/<name>` used for durable cluster configuration. |
 | Managed | TAMOSS reconciles the Kubernetes-side resource lifecycle after prerequisites exist. |
 | External | TAMOSS consumes references to a service owned outside TAMOSS and does not mutate that service. |

--- a/docs/concepts/profiles.md
+++ b/docs/concepts/profiles.md
@@ -6,6 +6,7 @@ separate products and they do not change the operator install path.
 | Profile | Purpose | Backing services |
 | --- | --- | --- |
 | `local-kind` | Local evaluation and development on Kind. | CNPG and RustFS Operator with small single-node defaults, Authentik, cert-manager, and Traefik on host port 443. |
+| `edge` | Single-node ARM64 Kubernetes installs with local persistent storage, sized from a Raspberry Pi 4 Model B 4 GB floor. | CNPG and RustFS Operator with compact single-node defaults, token-only auth, cert-manager, and Traefik. |
 | `single-server` | One Kubernetes node or a small self-managed cluster. | CNPG and RustFS Operator with single-node durable defaults plus shared Authentik, cert-manager, and Traefik. |
 | `multi-server` | Production reference for multi-node Kubernetes. | Replicated workloads, CNPG, RustFS Operator, shared Authentik, cert-manager, and Traefik. |
 
@@ -16,12 +17,18 @@ those defaults.
 Profiles do not define tenant identity. In shared clusters, tenant boundaries
 come from Kubernetes namespaces and the `Tamoss` resources applied in them.
 
-All profiles default application authentication to managed Authentik. Omitting
-`spec.auth` selects `auth.providedBy: authentik-blueprints`, derives
-`https://auth.<baseDomain>` from `spec.publicEndpoint.baseDomain`, and expects
-the platform Authentik install in the `auth` namespace. Use an explicit
-`spec.auth.providedBy: external` or `spec.auth.providedBy: none` only when an
-environment intentionally opts out of the profile default.
+`local-kind`, `single-server`, and `multi-server` default application
+authentication to managed Authentik. Omitting `spec.auth` selects
+`auth.providedBy: authentik-blueprints`, derives `https://auth.<baseDomain>`
+from `spec.publicEndpoint.baseDomain`, and expects the platform Authentik
+install in the `auth` namespace. Use an explicit `spec.auth.providedBy:
+external` or `spec.auth.providedBy: none` only when an environment intentionally
+opts out of the profile default.
+
+`edge` intentionally does not default to Authentik. It selects
+`auth.providedBy: external` with OAuth2 disabled and uses the generated TAMOSS
+API token Secret for bearer-token access. Set `spec.auth.providedBy: none` only
+when the edge install should accept anonymous API requests.
 
 `deploy/profiles.yaml` is the profile registry used by Taskfile helpers. Each
 supported profile records its Kind environment composition, target environment
@@ -29,9 +36,13 @@ file, and the Kind cluster config used for local validation.
 
 `local-kind` is a local test adapter. It creates a Kind cluster, loads local
 development images, uses `localtest.me`, and exists to validate the operator
-flow quickly. `single-server` is the remote-capable single-node or small-cluster
-profile. Running `task kind:up PROFILE=single-server` validates that profile on
-Kind; it is not the remote install path.
+flow quickly. `edge` is a remote-capable single-node ARM64 profile for boards
+as small as a Raspberry Pi 4 Model B with 4 GB RAM; running
+`task kind:up PROFILE=edge` validates the profile shape on Kind, but the target
+install path is a normal ARM64 Kubernetes cluster such as K3s. `single-server`
+is the remote-capable single-node or small-cluster profile. Running
+`task kind:up PROFILE=single-server` validates that profile on Kind; it is not
+the remote install path.
 
 Running `task kind:up PROFILE=multi-server` validates the production reference
 profile on a disposable multi-node Kind cluster. That local harness exercises
@@ -40,7 +51,7 @@ remains normal Kubernetes through the `env:*` tasks.
 
 ## Security Defaults
 
-`single-server` and `multi-server` default TAMOSS application workloads to a
+`edge`, `single-server`, and `multi-server` default TAMOSS application workloads to a
 restricted-compatible security posture: non-root pods and containers, runtime
 default seccomp, no privilege escalation, and dropped Linux capabilities. The
 operator manager keeps the stricter read-only root filesystem default; API, UI,
@@ -85,7 +96,7 @@ The operator derives:
 - API: `https://api.<baseDomain>`
 - UI: `https://app.<baseDomain>`
 - S3: `https://s3.<baseDomain>`
-- Authentik: `https://auth.<baseDomain>`
+- Authentik: `https://auth.<baseDomain>` for Authentik-backed profiles
 
 Override a specific endpoint only when that endpoint must deviate from the
 standard shape.
@@ -93,10 +104,11 @@ standard shape.
 ## TLS Defaults
 
 `local-kind` defaults to `ClusterIssuer/tamoss-selfsigned` and local test TLS
-Secret names. `single-server` and `multi-server` default to
+Secret names. `edge` defaults to `ClusterIssuer/tamoss-edge-selfsigned` with
+edge TLS Secret names. `single-server` and `multi-server` default to
 `ClusterIssuer/tamoss-public` with public TLS Secret names. The matching
-platform values use `tls.mode: public` to render an ACME ClusterIssuer for
-remote environments:
+single-server and multi-server platform values use `tls.mode: public` to render
+an ACME ClusterIssuer for remote environments:
 
 ```yaml
 tls:
@@ -117,6 +129,7 @@ Run profiles one at a time on Kind:
 
 ```bash
 task kind:up PROFILE=local-kind
+task kind:up PROFILE=edge
 task kind:up PROFILE=single-server
 task kind:up PROFILE=multi-server
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@ belong in the CR references and the canonical CRD schemas under
 
 | Need | Use |
 | --- | --- |
-| Choose `local-kind`, `single-server`, or `multi-server` | [Profiles](concepts/profiles.md) |
+| Choose `local-kind`, `edge`, `single-server`, or `multi-server` | [Profiles](concepts/profiles.md) |
 | Configure managed or external providers | [Provider Ownership](concepts/provider-ownership.md) |
 | Configure storage backends and controlled storage allocation | [Storage Backends](concepts/storage-backends.md) |
 | Override runtime workload, image, and environment settings | [Runtime Configuration](reference/runtime-configuration.md) |
@@ -43,7 +43,8 @@ spec:
     baseDomain: tamoss.example.com
 ```
 
-The operator derives API, UI, S3, and Authentik endpoints from the base domain.
+The operator derives API, UI, and S3 endpoints from the base domain. Authentik
+endpoints are derived only for Authentik-backed profiles.
 
 ## Inspect Effective Configuration
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -7,6 +7,7 @@ Start here:
 
 - [Local Kind](getting-started/local-kind.md) for canonical local validation.
 - [Install](operations/install.md) for existing-cluster installation.
+- [Edge](getting-started/edge.md) for the `edge` profile.
 - [Single Server](getting-started/single-server.md) for the `single-server`
   profile.
 - [Multi Server](getting-started/multi-server.md) for the `multi-server`

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -4,6 +4,7 @@ Start with the deployment shape that matches the environment you want to
 validate.
 
 - [Local Kind](local-kind.md) - disposable local validation on Kind.
+- [Edge](edge.md) - single-node ARM64, self-contained Kubernetes profile.
 - [Single Server](single-server.md) - small self-managed Kubernetes profile.
 - [Multi Server](multi-server.md) - production-shaped self-managed profile.
 

--- a/docs/getting-started/edge.md
+++ b/docs/getting-started/edge.md
@@ -1,0 +1,105 @@
+# Edge
+
+`edge` is the single-node ARM64 profile for self-contained TAMOSS installs. It
+uses the normal operator install path, disables Authentik, and keeps API access
+token-only through the TAMOSS API token Secret.
+
+## Cluster Requirements
+
+- A 64-bit ARM Kubernetes node. Raspberry Pi 4 Model B with 4 GB RAM is the
+  minimum target; larger Raspberry Pi 4/5 boards give more headroom.
+- Raspberry Pi OS Lite 64-bit with K3s is the reference software shape.
+- Persistent storage backed by an SSD. Avoid SD-card-backed database and object
+  storage.
+- Active cooling, a stable power supply, and wired Ethernet.
+- Swap configured on SSD-backed storage for constrained 4 GB nodes.
+- A default StorageClass, or explicit CNPG and RustFS storage classes in the
+  `Tamoss` CR.
+- cert-manager, Traefik, CNPG, and RustFS Operator installed by the TAMOSS
+  platform layer unless the cluster already owns those services.
+- Local DNS or host entries for API, UI, and S3 hostnames.
+
+K3s should be installed without its bundled Traefik when the TAMOSS platform
+installs the pinned Traefik release for this profile.
+
+## Install
+
+For local profile validation on Kind:
+
+```bash
+task kind:up PROFILE=edge
+```
+
+For an existing ARM64 cluster:
+
+```bash
+export KUBECONFIG=/path/to/kubeconfig
+
+task env:init NAME=my-edge PROFILE=edge DOMAIN=tamoss.edge
+$EDITOR deploy/environments/my-edge/platform-values.yaml
+$EDITOR deploy/environments/my-edge/tamoss-patch.yaml
+task env:apply ENV=my-edge KUBECONFIG="$KUBECONFIG"
+task env:wait ENV=my-edge KUBECONFIG="$KUBECONFIG"
+task env:summary ENV=my-edge KUBECONFIG="$KUBECONFIG"
+```
+
+The generated edge platform values disable Authentik and use self-signed TLS by
+default. Keep `authentik.enabled: false` unless the install intentionally moves
+to an identity-backed profile.
+
+## Defaults
+
+The operator defaults for `edge` are intentionally smaller than `single-server`
+and sized to fit a Raspberry Pi 4 Model B with 4 GB RAM:
+
+- API, worker, and UI run as one replica each.
+- Authentik is not selected by default.
+- Runtime auth is token-only with OAuth2 disabled.
+- CNPG runs one PostgreSQL instance with a 10 GiB volume and bounded resources.
+- RustFS Operator runs one server with four 10 GiB volumes.
+- RustFS disk checks are bypassed for single-node local storage.
+- API and worker runtime pools are reduced for small ARM systems.
+- Worker health probes use longer timeouts for ARM startup and import latency.
+- TLS defaults to `ClusterIssuer/tamoss-edge-selfsigned`.
+
+The API token is stored in the generated `<fullname>-api-token` Secret. Use
+`task env:summary` to print the resolved Secret value after the instance is
+ready.
+
+## Configure
+
+Use `tamoss-patch.yaml` for durable overrides:
+
+```yaml
+apiVersion: tamoss.livewyer.io/v1alpha1
+kind: Tamoss
+metadata:
+  name: tamoss-edge
+  namespace: tams
+spec:
+  profile: edge
+  publicEndpoint:
+    baseDomain: tamoss.edge
+  backends:
+    db:
+      cnpg:
+        storage:
+          size: 20Gi
+    s3:
+      rustfsOperator:
+        pools:
+          - name: pool-0
+            servers: 1
+            volumesPerServer: 4
+            storage:
+              size: 20Gi
+```
+
+Use larger PVC sizes on 128 GB or larger SSDs, and make backup ownership
+explicit before accepting durable data.
+
+See also:
+
+- [Profiles](../concepts/profiles.md)
+- [Install](../operations/install.md)
+- [Provider Ownership](../concepts/provider-ownership.md)

--- a/docs/operations/install.md
+++ b/docs/operations/install.md
@@ -53,14 +53,16 @@ task kind:up PROFILE=local-kind
 Supported profiles are:
 
 - `local-kind`
+- `edge`
 - `single-server`
 - `multi-server`
 
-When `PROFILE=single-server` or `PROFILE=multi-server` is used with `task kind:up`,
-the task uses the matching Kind environment under `deploy/environments/` while
-keeping the public instance profile name. `PROFILE=multi-server` also uses the
-checked-in multi-node Kind configuration so local validation has separate worker
-nodes; the remote install path still uses normal environment compositions.
+When `PROFILE=edge`, `PROFILE=single-server`, or `PROFILE=multi-server` is used
+with `task kind:up`, the task uses the matching Kind environment under
+`deploy/environments/` while keeping the public instance profile name.
+`PROFILE=multi-server` also uses the checked-in multi-node Kind configuration so
+local validation has separate worker nodes; the remote install path still uses
+normal environment compositions.
 
 ## Existing Cluster
 
@@ -85,6 +87,17 @@ Use `tls.mode: existing` when cert-manager and the ClusterIssuer are managed
 outside the TAMOSS platform layer. Use `tls.mode: disabled` when TLS Secrets are
 pre-created and cert-manager annotations should be omitted from explicit
 `Tamoss` ingress overrides.
+
+`PROFILE=edge` generates a self-signed, Authentik-free platform composition from
+`deploy/platform/values/edge-reference.yaml`:
+
+```bash
+task env:init NAME=my-edge PROFILE=edge DOMAIN=tamoss.edge
+task env:apply ENV=my-edge KUBECONFIG="$KUBECONFIG"
+```
+
+Review the generated storage sizes and hostnames before applying to an ARM64
+single-node cluster.
 
 If automation cannot call Task, keep the same checked-in inputs and apply the
 same layers in order:

--- a/docs/reference/crd-versioning.md
+++ b/docs/reference/crd-versioning.md
@@ -58,7 +58,7 @@ complete schema:
 
 | Field area | Classification | Notes |
 | --- | --- | --- |
-| `.spec.profile` | Stable candidate | Profile names are core user-facing install shapes: `local-kind`, `single-server`, `multi-server`. Any rename is breaking. |
+| `.spec.profile` | Stable candidate | Profile names are core user-facing install shapes: `local-kind`, `edge`, `single-server`, `multi-server`. Any rename is breaking. |
 | `.spec.publicEndpoint` | Stable candidate | Base-domain driven endpoint derivation is the preferred low-boilerplate path. |
 | `.spec.backends.db.providedBy` | Stable candidate | `cnpg` and `external` are the supported product modes. |
 | `.spec.backends.db.cnpg` | Stable candidate | CNPG is the managed PostgreSQL provider. Backup, monitoring, storage, resources, and instance count are provider-native settings. |

--- a/docs/reference/tamoss-cr.md
+++ b/docs/reference/tamoss-cr.md
@@ -39,8 +39,8 @@ spec:
 
 | Field | Purpose |
 | --- | --- |
-| `.spec.profile` | Selects `local-kind`, `single-server`, or `multi-server` defaults. |
-| `.spec.publicEndpoint` | Derives public API, UI, S3, and Authentik endpoint defaults. |
+| `.spec.profile` | Selects `local-kind`, `edge`, `single-server`, or `multi-server` defaults. |
+| `.spec.publicEndpoint` | Derives public API, UI, S3, and Authentik endpoint defaults when the selected auth mode uses Authentik. |
 | `.spec.backends.db` | Selects managed CNPG or external PostgreSQL and configures database backup/restore when CNPG is used. |
 | `.spec.backends.s3` | Selects managed RustFS Operator or external S3-compatible storage for the default backend. |
 | `.spec.auth` | Selects Authentik Blueprints, external OAuth/OIDC, or no authentication. |

--- a/docs/reference/task-commands.md
+++ b/docs/reference/task-commands.md
@@ -25,7 +25,7 @@ names or descriptions change.
 
 | Command | Purpose |
 | --- | --- |
-| `task env:init NAME=my-prod PROFILE=single-server DOMAIN=tamoss.example.com` | Create a remote environment composition from checked-in templates. |
+| `task env:init NAME=my-prod PROFILE=single-server DOMAIN=tamoss.example.com` | Create a remote environment composition from checked-in templates. Use `PROFILE=edge` for the ARM64 single-node profile. |
 | `task env:apply ENV=my-prod KUBECONFIG=/path/to/kubeconfig` | Apply the Helmfile platform releases, TAMOSS operator, and selected environment overlay. |
 | `task env:diff ENV=my-prod KUBECONFIG=/path/to/kubeconfig` | Diff the Helmfile platform releases, TAMOSS operator, and selected environment overlay. |
 | `task env:wait ENV=my-prod KUBECONFIG=/path/to/kubeconfig` | Wait for the selected environment's `Tamoss` resource to report `Ready=True`. |

--- a/operator/api/v1alpha1/tamoss_spec_types.go
+++ b/operator/api/v1alpha1/tamoss_spec_types.go
@@ -15,7 +15,7 @@ type TamossSpec struct {
 
 	// Profile selects operator-owned defaults for a common installation shape.
 	// Explicit fields in the Tamoss spec override profile defaults.
-	//+kubebuilder:validation:Enum=local-kind;single-server;multi-server
+	//+kubebuilder:validation:Enum=local-kind;single-server;multi-server;edge
 	Profile TamossProfile `json:"profile,omitempty"`
 
 	// PublicEndpoint defines the public DNS defaults used by profile defaulting.
@@ -61,6 +61,7 @@ const (
 	TamossProfileLocalKind    TamossProfile = "local-kind"
 	TamossProfileSingleServer TamossProfile = "single-server"
 	TamossProfileMultiServer  TamossProfile = "multi-server"
+	TamossProfileEdge         TamossProfile = "edge"
 )
 
 type PublicEndpointSpec struct {

--- a/operator/config/crd/bases/tamoss.livewyer.io_tamosses.yaml
+++ b/operator/config/crd/bases/tamoss.livewyer.io_tamosses.yaml
@@ -6540,6 +6540,7 @@ spec:
                 - local-kind
                 - single-server
                 - multi-server
+                - edge
                 type: string
               publicEndpoint:
                 description: PublicEndpoint defines the public DNS defaults used by

--- a/operator/internal/controller/defaults/profile.go
+++ b/operator/internal/controller/defaults/profile.go
@@ -21,6 +21,9 @@ const (
 	defaultPublicIssuerName            = "tamoss-public"
 	defaultLocalKindTLSSecretName      = "tamoss-localtest-tls"
 	defaultLocalKindS3TLSSecretName    = "tamoss-localtest-s3-tls"
+	defaultEdgeIssuerName              = "tamoss-edge-selfsigned"
+	defaultEdgeTLSSecretName           = "tamoss-edge-tls"
+	defaultEdgeS3TLSSecretName         = "tamoss-edge-s3-tls"
 	defaultPublicTLSSecretName         = "tamoss-public-tls"
 	defaultPublicS3TLSSecretName       = "tamoss-s3-public-tls"
 )
@@ -38,6 +41,8 @@ func Apply(tamoss *tamossv1alpha1.Tamoss) {
 		applySingleServer(tamoss)
 	case tamossv1alpha1.TamossProfileMultiServer:
 		applyMultiServer(tamoss)
+	case tamossv1alpha1.TamossProfileEdge:
+		applyEdge(tamoss)
 	}
 	applyPublicEndpointDefaults(tamoss)
 	applyBaseComponentDefaults(tamoss)
@@ -118,6 +123,39 @@ func applySingleServer(tamoss *tamossv1alpha1.Tamoss) {
 	defaultRustFSOperator(tamoss, 1, 4, "100Gi")
 }
 
+func applyEdge(tamoss *tamossv1alpha1.Tamoss) {
+	defaultPlatformPublicEndpointWithoutAuthentik(tamoss, publicEndpointProfileDefaults{
+		BaseDomain:      "tamoss.edge",
+		IssuerName:      defaultEdgeIssuerName,
+		TLSSecretName:   defaultEdgeTLSSecretName,
+		S3TLSSecretName: defaultEdgeS3TLSSecretName,
+	})
+	defaultTokenOnlyAuth(tamoss)
+	setBool(&tamoss.Spec.Worker.Enabled, true)
+	setEnvDefault(&tamoss.Spec.API.Env, "TAMOSS_DATABASE_POOL_MAX_SIZE", "3")
+	setEnvDefault(&tamoss.Spec.API.Env, "TAMOSS_API_THREAD_POOL_TOKENS", "16")
+	setEnvDefault(&tamoss.Spec.API.Env, "TAMOSS_S3_CONNECT_TIMEOUT_SECONDS", "2")
+	setEnvDefault(&tamoss.Spec.API.Env, "TAMOSS_S3_READ_TIMEOUT_SECONDS", "5")
+	setEnvDefault(&tamoss.Spec.API.Env, "TAMOSS_WEBHOOK_ALLOWED_HOSTS", ".svc.cluster.local")
+	setEnvDefault(&tamoss.Spec.Worker.Env, "TAMOSS_WORKER_POLL_INTERVAL_SECONDS", "5")
+	setEnvDefault(&tamoss.Spec.Worker.Env, "TAMOSS_WORKER_MAX_REQUESTS", "5")
+	setEnvDefault(&tamoss.Spec.Worker.Env, "TAMOSS_DATABASE_POOL_MAX_SIZE", "3")
+	setEnvDefault(&tamoss.Spec.Worker.Env, "TAMOSS_WEBHOOK_ALLOWED_HOSTS", ".svc.cluster.local")
+	setEnvDefault(&tamoss.Spec.UI.Env, "TAMOSS_API_URL", "/api")
+	defaultEdgeWorkerProbes(&tamoss.Spec.Worker.WorkloadCommonSpec)
+	defaultWorkloadResources(&tamoss.Spec.API.WorkloadCommonSpec, "100m", "192Mi", "600m", "384Mi")
+	defaultWorkloadResources(&tamoss.Spec.Worker.WorkloadCommonSpec, "100m", "128Mi", "500m", "384Mi")
+	defaultWorkloadResources(&tamoss.Spec.UI.WorkloadCommonSpec, "25m", "32Mi", "150m", "96Mi")
+	defaultRestrictedWorkloadSecurity(&tamoss.Spec.API.WorkloadCommonSpec)
+	defaultRestrictedWorkloadSecurity(&tamoss.Spec.Worker.WorkloadCommonSpec)
+	defaultRestrictedWorkloadSecurity(&tamoss.Spec.UI.WorkloadCommonSpec)
+
+	defaultCNPG(tamoss, 1, "10Gi", false, false)
+	defaultCNPGResources(tamoss, "100m", "256Mi", "800m", "768Mi")
+	defaultRustFSOperator(tamoss, 1, 4, "10Gi")
+	setRustFSEnvDefault(tamoss, "RUSTFS_UNSAFE_BYPASS_DISK_CHECK", "true")
+}
+
 func applyMultiServer(tamoss *tamossv1alpha1.Tamoss) {
 	defaultPlatformPublicEndpoint(tamoss, publicEndpointProfileDefaults{
 		IssuerName:      defaultPublicIssuerName,
@@ -155,6 +193,11 @@ type publicEndpointProfileDefaults struct {
 }
 
 func defaultPlatformPublicEndpoint(tamoss *tamossv1alpha1.Tamoss, defaults publicEndpointProfileDefaults) {
+	defaultPlatformPublicEndpointWithoutAuthentik(tamoss, defaults)
+	defaultAuthentikBlueprints(tamoss)
+}
+
+func defaultPlatformPublicEndpointWithoutAuthentik(tamoss *tamossv1alpha1.Tamoss, defaults publicEndpointProfileDefaults) {
 	if tamoss.Spec.PublicEndpoint.BaseDomain == "" {
 		tamoss.Spec.PublicEndpoint.BaseDomain = defaults.BaseDomain
 	}
@@ -173,7 +216,23 @@ func defaultPlatformPublicEndpoint(tamoss *tamossv1alpha1.Tamoss, defaults publi
 			defaultCertManagerIssuerAnnotation: defaults.IssuerName,
 		}
 	}
-	defaultAuthentikBlueprints(tamoss)
+}
+
+func defaultTokenOnlyAuth(tamoss *tamossv1alpha1.Tamoss) {
+	if tamoss.Spec.Auth.Provider() == tamossv1alpha1.AuthProvidedByNone {
+		return
+	}
+	if tamoss.Spec.Auth.Provider() == tamossv1alpha1.AuthProvidedByAuthentikBlueprints {
+		return
+	}
+	tamoss.Spec.Auth.ProvidedBy = tamossv1alpha1.AuthProvidedByExternal
+	tamoss.Spec.Auth.Required = true
+	if tamoss.Spec.Auth.External == nil {
+		tamoss.Spec.Auth.External = &tamossv1alpha1.AuthExternalSpec{}
+	}
+	if len(tamoss.Spec.Auth.External.OAuth2.Algorithms) == 0 {
+		tamoss.Spec.Auth.External.OAuth2.Algorithms = []string{"RS256"}
+	}
 }
 
 func defaultAuthentikBlueprints(tamoss *tamossv1alpha1.Tamoss) {
@@ -354,6 +413,18 @@ func defaultCNPG(tamoss *tamossv1alpha1.Tamoss, instances int32, storageSize str
 	setBool(&cnpg.Monitoring.EnablePodMonitor, enablePodMonitor)
 }
 
+func defaultCNPGResources(tamoss *tamossv1alpha1.Tamoss, requestCPU, requestMemory, limitCPU, limitMemory string) {
+	if tamoss.Spec.Backends.DB.Provider() != tamossv1alpha1.BackendProvidedByCNPG ||
+		tamoss.Spec.Backends.DB.CNPG == nil {
+		return
+	}
+	resources := &tamoss.Spec.Backends.DB.CNPG.Resources
+	setResourceDefault(&resources.Requests, corev1.ResourceCPU, requestCPU)
+	setResourceDefault(&resources.Requests, corev1.ResourceMemory, requestMemory)
+	setResourceDefault(&resources.Limits, corev1.ResourceCPU, limitCPU)
+	setResourceDefault(&resources.Limits, corev1.ResourceMemory, limitMemory)
+}
+
 func defaultRustFSOperator(tamoss *tamossv1alpha1.Tamoss, servers, volumesPerServer int32, storageSize string) {
 	if tamoss.Spec.Backends.S3.ProvidedBy == "" {
 		tamoss.Spec.Backends.S3.ProvidedBy = tamossv1alpha1.S3BackendProvidedByRustFSOperator
@@ -400,6 +471,19 @@ func defaultWorkerProbes(spec *tamossv1alpha1.WorkloadCommonSpec) {
 	}
 	if spec.StartupProbe == nil {
 		spec.StartupProbe = execProbe(command, 10, 5, 12)
+	}
+}
+
+func defaultEdgeWorkerProbes(spec *tamossv1alpha1.WorkloadCommonSpec) {
+	command := []string{"/bin/uv", "run", "python", "-m", "tamoss.worker", "health"}
+	if spec.ReadinessProbe == nil {
+		spec.ReadinessProbe = execProbe(command, 30, 30, 3)
+	}
+	if spec.LivenessProbe == nil {
+		spec.LivenessProbe = execProbe(command, 60, 30, 3)
+	}
+	if spec.StartupProbe == nil {
+		spec.StartupProbe = execProbe(command, 30, 30, 12)
 	}
 }
 

--- a/operator/internal/controller/defaults/profile_test.go
+++ b/operator/internal/controller/defaults/profile_test.go
@@ -227,6 +227,92 @@ func TestApplySingleServerManagedBackendDefaults(t *testing.T) {
 	}
 }
 
+func TestApplyEdgeDefaults(t *testing.T) {
+	tamoss := &tamossv1alpha1.Tamoss{
+		ObjectMeta: metav1.ObjectMeta{Name: "tamoss-edge", Namespace: "tams"},
+		Spec: tamossv1alpha1.TamossSpec{
+			Profile: tamossv1alpha1.TamossProfileEdge,
+		},
+	}
+
+	Apply(tamoss)
+
+	if got := tamoss.Spec.PublicEndpoint.BaseDomain; got != "tamoss.edge" {
+		t.Fatalf("expected edge base domain, got %q", got)
+	}
+	if got := tamoss.Spec.Ingress.Annotations["cert-manager.io/cluster-issuer"]; got != "tamoss-edge-selfsigned" {
+		t.Fatalf("expected edge cert issuer annotation, got %q", got)
+	}
+	if got := tamoss.Spec.Auth.Provider(); got != tamossv1alpha1.AuthProvidedByExternal {
+		t.Fatalf("expected edge token auth to use external provider mode, got %s", got)
+	}
+	if !tamoss.Spec.Auth.RequiredForRuntime() {
+		t.Fatalf("expected edge runtime auth to be required")
+	}
+	if tamoss.Spec.Auth.AuthentikBlueprints != nil {
+		t.Fatalf("did not expect edge to default Authentik settings")
+	}
+	if tamoss.Spec.Auth.External == nil || tamoss.Spec.Auth.External.OAuth2.Enabled {
+		t.Fatalf("expected edge OAuth2 to remain disabled, got %#v", tamoss.Spec.Auth.External)
+	}
+	if got := tamoss.Spec.UI.Env["TAMOSS_API_URL"]; got != "/api" {
+		t.Fatalf("expected edge UI API URL default, got %q", got)
+	}
+	if got := tamoss.Spec.API.Env["TAMOSS_DATABASE_POOL_MAX_SIZE"]; got != "3" {
+		t.Fatalf("expected edge API database pool default, got %q", got)
+	}
+	if got := tamoss.Spec.Worker.Env["TAMOSS_WORKER_MAX_REQUESTS"]; got != "5" {
+		t.Fatalf("expected edge worker request default, got %q", got)
+	}
+	if got := tamoss.Spec.Worker.Resources.Requests[corev1.ResourceMemory]; got.String() != "128Mi" {
+		t.Fatalf("expected edge worker memory request, got %s", got.String())
+	}
+	if got := tamoss.Spec.Worker.Resources.Limits[corev1.ResourceMemory]; got.String() != "384Mi" {
+		t.Fatalf("expected edge worker memory limit, got %s", got.String())
+	}
+	if got := tamoss.Spec.Worker.ReadinessProbe.TimeoutSeconds; got != 30 {
+		t.Fatalf("expected edge worker readiness timeout 30, got %d", got)
+	}
+	if got := tamoss.Spec.Worker.ReadinessProbe.PeriodSeconds; got != 30 {
+		t.Fatalf("expected edge worker readiness period 30, got %d", got)
+	}
+	if got := tamoss.Spec.Worker.LivenessProbe.PeriodSeconds; got != 60 {
+		t.Fatalf("expected edge worker liveness period 60, got %d", got)
+	}
+	if got := tamoss.Spec.Worker.StartupProbe.TimeoutSeconds; got != 30 {
+		t.Fatalf("expected edge worker startup timeout 30, got %d", got)
+	}
+	cnpg := tamoss.Spec.Backends.DB.CNPG
+	if cnpg == nil || cnpg.Instances != 1 || cnpg.Storage.Size != "10Gi" {
+		t.Fatalf("unexpected edge CNPG defaults: %#v", cnpg)
+	}
+	if got := cnpg.Resources.Requests[corev1.ResourceMemory]; got.String() != "256Mi" {
+		t.Fatalf("expected edge CNPG memory request, got %s", got.String())
+	}
+	if got := cnpg.Resources.Limits[corev1.ResourceMemory]; got.String() != "768Mi" {
+		t.Fatalf("expected edge CNPG memory limit, got %s", got.String())
+	}
+	rustfs := tamoss.Spec.Backends.S3.RustFSOperator
+	if rustfs == nil ||
+		rustfs.PublicEndpoint.URL != "https://s3.tamoss.edge" ||
+		rustfs.PublicEndpoint.TLSSecretName != "tamoss-edge-s3-tls" ||
+		len(rustfs.Pools) != 1 ||
+		rustfs.Pools[0].Servers != 1 ||
+		rustfs.Pools[0].VolumesPerServer != 4 ||
+		rustfs.Pools[0].Storage.Size != "10Gi" {
+		t.Fatalf("unexpected edge RustFS Operator defaults: %#v", rustfs)
+	}
+	if got := rustFSEnvValue(rustfs, "RUSTFS_UNSAFE_BYPASS_DISK_CHECK"); got != "true" {
+		t.Fatalf("expected edge RustFS disk check bypass, got %q", got)
+	}
+	assertRestrictedWorkloadSecurity(t, tamoss.Spec.API.WorkloadCommonSpec)
+	assertRestrictedWorkloadSecurity(t, tamoss.Spec.Worker.WorkloadCommonSpec)
+	assertRestrictedWorkloadSecurity(t, tamoss.Spec.UI.WorkloadCommonSpec)
+	if tamoss.Spec.NetworkPolicy.IsEnabled() {
+		t.Fatalf("did not expect edge NetworkPolicy default enabled")
+	}
+}
+
 func TestApplyRemoteProfilesDefaultToPublicTLSIssuer(t *testing.T) {
 	profiles := []tamossv1alpha1.TamossProfile{
 		tamossv1alpha1.TamossProfileSingleServer,
@@ -261,7 +347,7 @@ func TestApplyRemoteProfilesDefaultToPublicTLSIssuer(t *testing.T) {
 	}
 }
 
-func TestSupportedProfilesDefaultToManagedAuthentik(t *testing.T) {
+func TestAuthentikProfilesDefaultToManagedAuthentik(t *testing.T) {
 	profiles := []tamossv1alpha1.TamossProfile{
 		tamossv1alpha1.TamossProfileLocalKind,
 		tamossv1alpha1.TamossProfileSingleServer,
@@ -327,6 +413,7 @@ func TestManagedRustFSProfileDefaultsMeetOperatorMinimum(t *testing.T) {
 		tamossv1alpha1.TamossProfileLocalKind,
 		tamossv1alpha1.TamossProfileSingleServer,
 		tamossv1alpha1.TamossProfileMultiServer,
+		tamossv1alpha1.TamossProfileEdge,
 	}
 
 	for _, profile := range profiles {
@@ -509,6 +596,7 @@ func TestSupportedProfilesUseOperatorManagedBackends(t *testing.T) {
 		tamossv1alpha1.TamossProfileLocalKind,
 		tamossv1alpha1.TamossProfileSingleServer,
 		tamossv1alpha1.TamossProfileMultiServer,
+		tamossv1alpha1.TamossProfileEdge,
 	}
 
 	for _, profile := range profiles {

--- a/operator/test/chainsaw/README.md
+++ b/operator/test/chainsaw/README.md
@@ -127,7 +127,7 @@ is the executable source of truth for label values and selector presets.
 | `test.tamoss.io/domain` | `install`, `instance`, `storage`, `db`, `auth`, `routing`, `schema`, `profile`, `observability`, `operations` |
 | `test.tamoss.io/lifecycle` | `read-only`, `ephemeral`, `destructive` |
 | `test.tamoss.io/provider` | `none`, `cnpg`, `rustfs`, `authentik`, `external`, `mixed` |
-| `test.tamoss.io/profile` | `none`, `local-kind`, `single-server`, `multi-server` |
+| `test.tamoss.io/profile` | `none`, `local-kind`, `edge`, `single-server`, `multi-server` |
 
 | Command | Selection |
 | --- | --- |

--- a/operator/test/chainsaw/profile-rendering/rendered-profile-shape/chainsaw-test.yaml
+++ b/operator/test/chainsaw/profile-rendering/rendered-profile-shape/chainsaw-test.yaml
@@ -30,6 +30,11 @@ spec:
               printf '%s' "$multi_render" | grep -q 'profile: multi-server'
               ! printf '%s' "$multi_render" | grep -q 'tamoss.localtest.me'
 
+              edge_render="$(kubectl kustomize ../../../../../deploy/instances/edge)"
+              printf '%s' "$edge_render" | grep -q 'profile: edge'
+              printf '%s' "$edge_render" | grep -q 'name: tamoss-edge'
+              ! printf '%s' "$edge_render" | grep -q 'tamoss.localtest.me'
+
               single_kind_render="$(kubectl kustomize ../../../../../deploy/environments/kind-single-server)"
               printf '%s' "$single_kind_render" | grep -q 'profile: single-server'
               printf '%s' "$single_kind_render" | grep -q 'baseDomain: tamoss.localtest.me'
@@ -38,3 +43,7 @@ spec:
               printf '%s' "$multi_kind_render" | grep -q 'profile: multi-server'
               printf '%s' "$multi_kind_render" | grep -q 'baseDomain: tamoss.localtest.me'
               printf '%s' "$multi_kind_render" | grep -q 'RUSTFS_UNSAFE_BYPASS_DISK_CHECK'
+
+              edge_kind_render="$(kubectl kustomize ../../../../../deploy/environments/kind-edge)"
+              printf '%s' "$edge_kind_render" | grep -q 'profile: edge'
+              printf '%s' "$edge_kind_render" | grep -q 'baseDomain: tamoss.localtest.me'

--- a/tests/targets/edge.env
+++ b/tests/targets/edge.env
@@ -1,0 +1,8 @@
+TEST_TARGET=edge
+. tests/targets/common.env
+TEST_TAMOSS_CR_NAME=tamoss-edge
+TEST_TAMOSS_AUTH=https://app.tamoss.localtest.me
+TEST_TAMOSS_UI_EXPECT_STATUS=200
+TEST_TAMOSS_CERTIFICATES=tams/tamoss-edge-tls,tams/tamoss-edge-s3-tls
+TEST_TAMOSS_AUTH_PASSWORD=unused
+TEST_TAMOSS_OAUTH2_ENABLED=false

--- a/tests/test_profile_kind_config.py
+++ b/tests/test_profile_kind_config.py
@@ -19,6 +19,7 @@ def test_profile_registry_selects_kind_configurations() -> None:
     assert profiles["local-kind"]["kindConfig"] == "deploy/kind.yaml"
     assert profiles["single-server"]["kindConfig"] == "deploy/kind.yaml"
     assert profiles["multi-server"]["kindConfig"] == "deploy/kind-multi-server.yaml"
+    assert profiles["edge"]["kindConfig"] == "deploy/kind.yaml"
     assert (
         profiles["local-kind"]["kindEnvironmentDir"] == "deploy/environments/local-kind"
     )
@@ -30,6 +31,7 @@ def test_profile_registry_selects_kind_configurations() -> None:
         profiles["multi-server"]["kindEnvironmentDir"]
         == "deploy/environments/kind-multi-server"
     )
+    assert profiles["edge"]["kindEnvironmentDir"] == "deploy/environments/kind-edge"
     assert profiles["local-kind"]["instanceKustomizeDir"] == (
         "deploy/instances/local-kind"
     )
@@ -39,9 +41,11 @@ def test_profile_registry_selects_kind_configurations() -> None:
     assert profiles["multi-server"]["instanceKustomizeDir"] == (
         "deploy/instances/multi-server"
     )
+    assert profiles["edge"]["instanceKustomizeDir"] == "deploy/instances/edge"
     assert profiles["local-kind"]["targetEnv"] == "tests/targets/local-kind.env"
     assert profiles["single-server"]["targetEnv"] == "tests/targets/single-server.env"
     assert profiles["multi-server"]["targetEnv"] == "tests/targets/multi-server.env"
+    assert profiles["edge"]["targetEnv"] == "tests/targets/edge.env"
     for profile in profiles.values():
         assert "platformKustomizeDir" not in profile
         assert "remotePlatformKustomizeDir" not in profile
@@ -101,7 +105,7 @@ def test_profile_shell_validation_checks_supported_profile_paths() -> None:
     if shutil.which("bash") is None or shutil.which("yq") is None:
         pytest.skip("bash and yq are required for task profile helper checks")
 
-    for profile in ["local-kind", "single-server", "multi-server"]:
+    for profile in ["local-kind", "single-server", "multi-server", "edge"]:
         subprocess.run(
             [
                 "bash",
@@ -119,7 +123,7 @@ def test_kind_environments_allow_cluster_webhook_receiver() -> None:
     if shutil.which("kubectl") is None:
         pytest.skip("kubectl is required for Kustomize overlay checks")
 
-    for environment in ["kind-single-server", "kind-multi-server"]:
+    for environment in ["kind-single-server", "kind-multi-server", "kind-edge"]:
         tamoss = _render_tamoss(ROOT / "deploy/environments" / environment)
 
         assert (
@@ -136,7 +140,7 @@ def test_canonical_profiles_do_not_default_to_localtest_domains() -> None:
     if shutil.which("kubectl") is None:
         pytest.skip("kubectl is required for Kustomize overlay checks")
 
-    for overlay in ["single-server", "multi-server"]:
+    for overlay in ["single-server", "multi-server", "edge"]:
         rendered = subprocess.run(
             ["kubectl", "kustomize", str(ROOT / "deploy/instances" / overlay)],
             cwd=ROOT,
@@ -152,7 +156,7 @@ def test_kind_environments_keep_localtest_domains() -> None:
     if shutil.which("kubectl") is None:
         pytest.skip("kubectl is required for Kustomize overlay checks")
 
-    for environment in ["kind-single-server", "kind-multi-server"]:
+    for environment in ["kind-single-server", "kind-multi-server", "kind-edge"]:
         tamoss = _render_tamoss(ROOT / "deploy/environments" / environment)
 
         assert tamoss["spec"]["publicEndpoint"]["baseDomain"] == "tamoss.localtest.me"
@@ -186,7 +190,10 @@ def test_profile_platform_values_enable_authentik_by_default() -> None:
         values = _load_yaml(
             ROOT / profile["kindEnvironmentDir"] / "platform-values.yaml"
         )
-        assert values["authentik"]["enabled"] is True
+        if profile["id"] == "edge":
+            assert values["authentik"]["enabled"] is False
+        else:
+            assert values["authentik"]["enabled"] is True
 
     for values_file in [
         ROOT / "deploy/platform/values/local-kind.yaml",
@@ -195,6 +202,9 @@ def test_profile_platform_values_enable_authentik_by_default() -> None:
     ]:
         values = _load_yaml(values_file)
         assert values["authentik"]["enabled"] is True
+
+    values = _load_yaml(ROOT / "deploy/platform/values/edge-reference.yaml")
+    assert values["authentik"]["enabled"] is False
 
 
 def test_reference_platform_values_render_profile_authentik_host() -> None:
@@ -220,6 +230,18 @@ def test_reference_platform_values_render_profile_authentik_host() -> None:
             auth_ingresses[0]["spec"]["rules"][0]["host"] == "auth.tamoss.example.com"
         )
         assert "localtest" not in yaml.safe_dump(auth_ingresses[0])
+
+
+def test_edge_platform_values_do_not_render_authentik() -> None:
+    if shutil.which("helm") is None:
+        pytest.skip("helm is required for platform Helmfile checks")
+    if shutil.which("helmfile") is None:
+        pytest.skip("helmfile is required for platform Helmfile checks")
+
+    rendered = _render_platform(ROOT / "deploy/platform/values/edge-reference.yaml")
+    assert not [
+        item for item in rendered if item.get("metadata", {}).get("namespace") == "auth"
+    ]
 
 
 def test_multi_server_topology_guard_requires_two_ready_nodes(tmp_path: Path) -> None:


### PR DESCRIPTION
Adds the edge deployment profile for single-node ARM installs, with its instance and environment overlays, operator profile defaults, and install guide. Supersedes #107, which was merged into the already-merged browser-s3-cors branch and never reached main.