### PR TITLE
fix: preflight the bucket URL in the external S3 CORS diagnostic

### DIFF
--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -261,7 +261,9 @@ external `StorageBackend` resources. `CORSMisconfigured`,
 `EndpointUnreachable`, and `TLSValidationFailed` are diagnostic warnings; they
 do not mutate external buckets and can be false positives or false negatives
 because browser behavior, presigned URL shape, and provider CORS evaluation are
-owned by the external service.
+owned by the external service. The diagnostic sends its preflight to
+`<endpoint>/<bucketName>` because S3 providers evaluate CORS rules per bucket,
+and the probed URL is included in the condition message.
 
 Browser clients usually cross two CORS boundaries:
 

--- a/operator/internal/controller/health_status_test.go
+++ b/operator/internal/controller/health_status_test.go
@@ -136,7 +136,9 @@ func TestObservedBackupPolicyFailureAndHealthy(t *testing.T) {
 }
 
 func TestExternalS3DiagnosticSuccessFailureAndSkipped(t *testing.T) {
+	var probedPath string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		probedPath = r.URL.Path
 		w.Header().Set("Access-Control-Allow-Origin", "https://app.tamoss.example.com")
 		w.Header().Set("Access-Control-Allow-Methods", "PUT, OPTIONS")
 		w.WriteHeader(http.StatusNoContent)
@@ -146,12 +148,16 @@ func TestExternalS3DiagnosticSuccessFailureAndSkipped(t *testing.T) {
 	tamoss := recoveryTamoss()
 	tamoss.Spec.PublicEndpoint.BaseDomain = "tamoss.example.com"
 	spec := externalStorageBackendSpecFixture()
+	spec.BucketName = "archive"
 	spec.Endpoint.Public.URL = server.URL
 	reconciler := &StorageBackendReconciler{HTTPClient: server.Client()}
 
 	diagnostic := reconciler.externalS3Diagnostic(context.Background(), tamoss, spec)
 	if diagnostic.Status != metav1.ConditionTrue || diagnostic.Reason != operatorstatus.ReasonExternalS3DiagnosticReady {
 		t.Fatalf("expected successful diagnostic, got %#v", diagnostic)
+	}
+	if probedPath != "/archive" {
+		t.Fatalf("expected preflight against the bucket URL, got path %q", probedPath)
 	}
 
 	blockedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -169,6 +175,13 @@ func TestExternalS3DiagnosticSuccessFailureAndSkipped(t *testing.T) {
 	diagnostic = reconciler.externalS3Diagnostic(context.Background(), tamoss, spec)
 	if diagnostic.Status != metav1.ConditionUnknown || diagnostic.Reason != operatorstatus.ReasonExternalS3DiagnosticSkipped {
 		t.Fatalf("expected skipped diagnostic, got %#v", diagnostic)
+	}
+
+	tamoss.Spec.PublicEndpoint.BaseDomain = "tamoss.example.com"
+	spec.BucketName = ""
+	diagnostic = reconciler.externalS3Diagnostic(context.Background(), tamoss, spec)
+	if diagnostic.Status != metav1.ConditionUnknown || diagnostic.Reason != operatorstatus.ReasonExternalS3DiagnosticSkipped {
+		t.Fatalf("expected skipped diagnostic without a bucket name, got %#v", diagnostic)
 	}
 }
 

--- a/operator/internal/controller/storagebackend_diagnostics.go
+++ b/operator/internal/controller/storagebackend_diagnostics.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -38,6 +39,18 @@ func (r *StorageBackendReconciler) externalS3Diagnostic(ctx context.Context, tam
 			Message: "External S3 diagnostic skipped because no endpoint URL is configured",
 		}
 	}
+	bucket := strings.TrimSpace(spec.BucketName)
+	if bucket == "" {
+		return &storageBackendDiagnosticResult{
+			Status:  metav1.ConditionUnknown,
+			Reason:  operatorstatus.ReasonExternalS3DiagnosticSkipped,
+			Message: "External S3 diagnostic skipped because no bucket name is configured",
+		}
+	}
+	// S3 CORS rules are evaluated per bucket, so the preflight must target the
+	// bucket URL; probing the bare service endpoint yields false negatives on
+	// stores such as AWS S3 and Backblaze B2.
+	probeURL := strings.TrimRight(endpoint, "/") + "/" + url.PathEscape(bucket)
 	originBase := strings.TrimSpace(tamoss.Spec.PublicEndpoint.BaseDomain)
 	if originBase == "" {
 		return &storageBackendDiagnosticResult{
@@ -47,12 +60,12 @@ func (r *StorageBackendReconciler) externalS3Diagnostic(ctx context.Context, tam
 		}
 	}
 	origin := "https://app." + originBase
-	request, err := http.NewRequestWithContext(ctx, http.MethodOptions, endpoint, nil)
+	request, err := http.NewRequestWithContext(ctx, http.MethodOptions, probeURL, nil)
 	if err != nil {
 		return &storageBackendDiagnosticResult{
 			Status:  metav1.ConditionFalse,
 			Reason:  operatorstatus.ReasonEndpointUnreachable,
-			Message: fmt.Sprintf("External S3 diagnostic could not build request for %s: %v", endpoint, err),
+			Message: fmt.Sprintf("External S3 diagnostic could not build request for %s: %v", probeURL, err),
 		}
 	}
 	request.Header.Set("Origin", origin)
@@ -67,7 +80,7 @@ func (r *StorageBackendReconciler) externalS3Diagnostic(ctx context.Context, tam
 		return &storageBackendDiagnosticResult{
 			Status:  metav1.ConditionFalse,
 			Reason:  reason,
-			Message: fmt.Sprintf("External S3 diagnostic failed for %s from origin %s: %v", endpoint, origin, err),
+			Message: fmt.Sprintf("External S3 diagnostic failed for %s from origin %s: %v", probeURL, origin, err),
 		}
 	}
 	defer func() { _ = response.Body.Close() }()
@@ -75,13 +88,13 @@ func (r *StorageBackendReconciler) externalS3Diagnostic(ctx context.Context, tam
 		return &storageBackendDiagnosticResult{
 			Status:  metav1.ConditionTrue,
 			Reason:  operatorstatus.ReasonExternalS3DiagnosticReady,
-			Message: fmt.Sprintf("External S3 diagnostic accepted browser upload preflight from origin %s", origin),
+			Message: fmt.Sprintf("External S3 diagnostic accepted browser upload preflight for %s from origin %s", probeURL, origin),
 		}
 	}
 	return &storageBackendDiagnosticResult{
 		Status:  metav1.ConditionFalse,
 		Reason:  operatorstatus.ReasonCORSMisconfigured,
-		Message: fmt.Sprintf("External S3 diagnostic did not observe CORS headers allowing PUT from origin %s", origin),
+		Message: fmt.Sprintf("External S3 diagnostic did not observe CORS headers allowing PUT for %s from origin %s", probeURL, origin),
 	}
 }
 


### PR DESCRIPTION
The external S3 diagnostic sent its CORS preflight to the bare endpoint URL, which providers such as Backblaze B2 and AWS S3 answer without bucket CORS rules, leaving `ExternalS3DiagnosticReady` stuck on `CORSMisconfigured` even when browser uploads work. The preflight now targets `<endpoint>/<bucketName>` to match the presigned URL shape browsers actually use, and the probed URL is included in the condition messages.