### PR TITLE
fix: avoid redundant Authentik reconciliation writes

### DIFF
--- a/operator/internal/controller/auth/authentik/managed_blueprint.go
+++ b/operator/internal/controller/auth/authentik/managed_blueprint.go
@@ -10,6 +10,8 @@ import (
 	"net/url"
 	"strings"
 
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	tamossv1alpha1 "github.com/livewyer-ops/tamoss/operator/api/v1alpha1"
 )
 
@@ -25,11 +27,13 @@ type ManagedBlueprintClient struct {
 }
 
 type ManagedBlueprint struct {
-	PK      string `json:"pk"`
-	Name    string `json:"name"`
-	Path    string `json:"path"`
-	Status  string `json:"status"`
-	Content string `json:"content"`
+	PK          string `json:"pk"`
+	Name        string `json:"name"`
+	Path        string `json:"path"`
+	Status      string `json:"status"`
+	LastApplied string `json:"last_applied"`
+	Enabled     bool   `json:"enabled"`
+	Content     string `json:"content"`
 }
 
 type managedBlueprintList struct {
@@ -106,9 +110,36 @@ func (c ManagedBlueprintClient) Reconcile(ctx context.Context, name, path string
 		Enabled: true,
 		Content: string(content),
 	}
+	if existing.PK != "" && managedBlueprintMatches(existing, request) {
+		// A queued apply backlog can leave an already-applied Blueprint in a
+		// transient status. Avoid adding duplicate work unless Authentik marks
+		// the instance as explicitly unhealthy.
+		if existing.Status == "successful" || (existing.LastApplied != "" && !managedBlueprintRequiresApply(existing.Status)) {
+			return existing, nil
+		}
+		log.FromContext(ctx).Info("reapplying matching Authentik managed Blueprint",
+			"name", name,
+			"status", existing.Status,
+			"previouslyApplied", existing.LastApplied != "",
+		)
+	} else if existing.PK != "" {
+		log.FromContext(ctx).Info("updating changed Authentik managed Blueprint",
+			"name", name,
+			"nameMatches", existing.Name == request.Name,
+			"pathMatches", existing.Path == request.Path,
+			"enabledMatches", existing.Enabled == request.Enabled,
+			"contentMatches", strings.TrimSpace(existing.Content) == strings.TrimSpace(request.Content),
+			"existingContentLength", len(strings.TrimSpace(existing.Content)),
+			"desiredContentLength", len(strings.TrimSpace(request.Content)),
+			"status", existing.Status,
+			"previouslyApplied", existing.LastApplied != "",
+		)
+	}
 	var blueprint ManagedBlueprint
 	if existing.PK == "" {
 		blueprint, err = c.create(ctx, request)
+	} else if managedBlueprintMatches(existing, request) {
+		blueprint = existing
 	} else {
 		blueprint, err = c.update(ctx, existing.PK, request)
 	}
@@ -123,6 +154,17 @@ func (c ManagedBlueprintClient) Reconcile(ctx context.Context, name, path string
 		return ManagedBlueprint{}, fmt.Errorf("authentik managed blueprint %q applied with status error", name)
 	}
 	return applied, nil
+}
+
+func managedBlueprintRequiresApply(status string) bool {
+	return status == "error" || status == "orphaned"
+}
+
+func managedBlueprintMatches(existing ManagedBlueprint, desired managedBlueprintRequest) bool {
+	return existing.Name == desired.Name &&
+		existing.Path == desired.Path &&
+		existing.Enabled == desired.Enabled &&
+		strings.TrimSpace(existing.Content) == strings.TrimSpace(desired.Content)
 }
 
 func (c ManagedBlueprintClient) DeleteByName(ctx context.Context, name string) error {

--- a/operator/internal/controller/auth/authentik/managed_blueprint_test.go
+++ b/operator/internal/controller/auth/authentik/managed_blueprint_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-func TestManagedBlueprintClientCreatesAppliesAndUpdates(t *testing.T) {
+func TestManagedBlueprintClientCreatesSkipsUnchangedAndUpdatesChanged(t *testing.T) {
 	var current ManagedBlueprint
 	var creates, updates, applies int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -28,7 +28,7 @@ func TestManagedBlueprintClientCreatesAppliesAndUpdates(t *testing.T) {
 			if request.Path != "" {
 				t.Fatalf("expected internal managed blueprint storage path, got %q", request.Path)
 			}
-			current = ManagedBlueprint{PK: "blueprint-id", Name: request.Name, Path: request.Path, Content: request.Content, Status: "unknown"}
+			current = ManagedBlueprint{PK: "blueprint-id", Name: request.Name, Path: request.Path, Content: strings.TrimSpace(request.Content), Status: "unknown", Enabled: request.Enabled}
 			w.WriteHeader(http.StatusCreated)
 			_ = json.NewEncoder(w).Encode(current)
 		case r.Method == http.MethodPut && r.URL.Path == "/api/v3/managed/blueprints/blueprint-id/":
@@ -37,7 +37,8 @@ func TestManagedBlueprintClientCreatesAppliesAndUpdates(t *testing.T) {
 			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 				t.Fatalf("decode update request: %v", err)
 			}
-			current.Content = request.Content
+			current.Content = strings.TrimSpace(request.Content)
+			current.Enabled = request.Enabled
 			_ = json.NewEncoder(w).Encode(current)
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v3/managed/blueprints/blueprint-id/apply/":
 			applies++
@@ -57,12 +58,93 @@ func TestManagedBlueprintClientCreatesAppliesAndUpdates(t *testing.T) {
 	if first.Status != "successful" || creates != 1 || updates != 0 || applies != 1 {
 		t.Fatalf("unexpected first reconcile result: %#v creates=%d updates=%d applies=%d", first, creates, updates, applies)
 	}
-	second, err := client.Reconcile(context.Background(), "tamoss-default-example", "", []byte("version: 1\nentries: []\n"))
+	second, err := client.Reconcile(context.Background(), "tamoss-default-example", "", []byte("version: 1\n"))
 	if err != nil {
 		t.Fatalf("second reconcile failed: %v", err)
 	}
-	if second.Content != "version: 1\nentries: []\n" || creates != 1 || updates != 1 || applies != 2 {
+	if second.Content != "version: 1" || creates != 1 || updates != 0 || applies != 1 {
 		t.Fatalf("unexpected second reconcile result: %#v creates=%d updates=%d applies=%d", second, creates, updates, applies)
+	}
+	third, err := client.Reconcile(context.Background(), "tamoss-default-example", "", []byte("version: 1\nentries: []\n"))
+	if err != nil {
+		t.Fatalf("third reconcile failed: %v", err)
+	}
+	if third.Content != "version: 1\nentries: []" || creates != 1 || updates != 1 || applies != 2 {
+		t.Fatalf("unexpected third reconcile result: %#v creates=%d updates=%d applies=%d", third, creates, updates, applies)
+	}
+}
+
+func TestManagedBlueprintClientReappliesMatchingUnhealthyBlueprintWithoutUpdate(t *testing.T) {
+	for _, status := range []string{"error", "orphaned"} {
+		t.Run(status, func(t *testing.T) {
+			current := ManagedBlueprint{
+				PK:          "blueprint-id",
+				Name:        "tamoss-default-example",
+				Status:      status,
+				LastApplied: "2026-07-21T19:19:28Z",
+				Enabled:     true,
+				Content:     "version: 1\n",
+			}
+			var updates, applies int
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/api/v3/managed/blueprints/":
+					_ = json.NewEncoder(w).Encode(managedBlueprintList{Results: []ManagedBlueprint{current}})
+				case r.Method == http.MethodPut:
+					updates++
+					t.Fatalf("matching blueprint should not be updated")
+				case r.Method == http.MethodPost && r.URL.Path == "/api/v3/managed/blueprints/blueprint-id/apply/":
+					applies++
+					current.Status = "successful"
+					_ = json.NewEncoder(w).Encode(current)
+				default:
+					t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+				}
+			}))
+			defer server.Close()
+
+			client := ManagedBlueprintClient{BaseURL: server.URL, Token: "test-token"}
+			result, err := client.Reconcile(context.Background(), current.Name, current.Path, []byte(current.Content))
+			if err != nil {
+				t.Fatalf("reconcile failed: %v", err)
+			}
+			if result.Status != "successful" || updates != 0 || applies != 1 {
+				t.Fatalf("unexpected reconcile result: %#v updates=%d applies=%d", result, updates, applies)
+			}
+		})
+	}
+}
+
+func TestManagedBlueprintClientSkipsMatchingPreviouslyAppliedBlueprintWithTransientStatus(t *testing.T) {
+	current := ManagedBlueprint{
+		PK:          "blueprint-id",
+		Name:        "tamoss-default-example",
+		Status:      "unknown",
+		LastApplied: "2026-07-21T19:19:28Z",
+		Enabled:     true,
+		Content:     "version: 1",
+	}
+	var mutations int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v3/managed/blueprints/":
+			_ = json.NewEncoder(w).Encode(managedBlueprintList{Results: []ManagedBlueprint{current}})
+		case r.Method == http.MethodPut || r.Method == http.MethodPost:
+			mutations++
+			t.Fatalf("previously applied matching blueprint should not be mutated")
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := ManagedBlueprintClient{BaseURL: server.URL, Token: "test-token"}
+	result, err := client.Reconcile(context.Background(), current.Name, current.Path, []byte("version: 1\n"))
+	if err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+	if result.LastApplied != current.LastApplied || mutations != 0 {
+		t.Fatalf("unexpected reconcile result: %#v mutations=%d", result, mutations)
 	}
 }
 

--- a/operator/internal/controller/auth/authentik/proxy_outpost.go
+++ b/operator/internal/controller/auth/authentik/proxy_outpost.go
@@ -6,11 +6,14 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"reflect"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	tamossv1alpha1 "github.com/livewyer-ops/tamoss/operator/api/v1alpha1"
 )
@@ -38,8 +41,15 @@ type oauthProviderList struct {
 }
 
 type proxyProvider struct {
-	PK   int    `json:"pk"`
-	Name string `json:"name"`
+	PK                        int      `json:"pk"`
+	Name                      string   `json:"name"`
+	AuthorizationFlow         string   `json:"authorization_flow"`
+	InvalidationFlow          string   `json:"invalidation_flow"`
+	PropertyMappings          []string `json:"property_mappings"`
+	ExternalHost              string   `json:"external_host"`
+	InternalHost              string   `json:"internal_host"`
+	InternalHostSSLValidation bool     `json:"internal_host_ssl_validation"`
+	Mode                      string   `json:"mode"`
 }
 
 type proxyProviderList struct {
@@ -58,9 +68,10 @@ type proxyProviderRequest struct {
 }
 
 type application struct {
-	PK   string `json:"pk"`
-	Name string `json:"name"`
-	Slug string `json:"slug"`
+	PK       string `json:"pk"`
+	Name     string `json:"name"`
+	Slug     string `json:"slug"`
+	Provider int    `json:"provider"`
 }
 
 type applicationList struct {
@@ -159,7 +170,7 @@ func OutpostExternalService(tamoss *tamossv1alpha1.Tamoss) (string, int32) {
 	return host, port
 }
 
-func (c ProxyOutpostClient) Reconcile(ctx context.Context, tamoss *tamossv1alpha1.Tamoss) error {
+func (c ProxyOutpostClient) Reconcile(ctx context.Context, tamoss *tamossv1alpha1.Tamoss, managedBlueprint ManagedBlueprint) error {
 	if !ForwardAuthRequired(tamoss) {
 		return nil
 	}
@@ -176,6 +187,26 @@ func (c ProxyOutpostClient) Reconcile(ctx context.Context, tamoss *tamossv1alpha
 	oauth, err := findOAuthProvider(ctx, api, slug)
 	if err != nil {
 		return err
+	}
+	// A successful Blueprint can retain its status after a managed object is
+	// deleted manually. Reapply only for that proven-drift case; transient
+	// Blueprint states remain protected from duplicate queued applies.
+	if oauth.PK == 0 && managedBlueprint.PK != "" && managedBlueprint.Status == "successful" {
+		log.FromContext(ctx).Info("reapplying Authentik managed Blueprint to repair missing OAuth2 provider",
+			"name", managedBlueprint.Name,
+			"provider", slug,
+		)
+		applied, err := api.apply(ctx, managedBlueprint.PK)
+		if err != nil {
+			return fmt.Errorf("reapply Authentik managed Blueprint %q: %w", managedBlueprint.Name, err)
+		}
+		if applied.Status == "error" {
+			return fmt.Errorf("authentik managed blueprint %q applied with status error", managedBlueprint.Name)
+		}
+		oauth, err = findOAuthProvider(ctx, api, slug)
+		if err != nil {
+			return err
+		}
 	}
 	if oauth.PK == 0 {
 		return fmt.Errorf("authentik OAuth2 provider %q was not found", slug)
@@ -291,6 +322,9 @@ func upsertProxyProvider(ctx context.Context, api ManagedBlueprintClient, tamoss
 	if err != nil {
 		return proxyProvider{}, err
 	}
+	if proxyProviderMatches(existing, request) {
+		return existing, nil
+	}
 	endpoint, err := api.apiURL("providers", "proxy")
 	if err != nil {
 		return proxyProvider{}, err
@@ -320,6 +354,9 @@ func upsertProxyApplication(ctx context.Context, api ManagedBlueprintClient, tam
 	existing, err := findApplication(ctx, api, slug)
 	if err != nil {
 		return err
+	}
+	if existing.PK != "" && existing.Name == request.Name && existing.Slug == request.Slug && existing.Provider == request.Provider {
+		return nil
 	}
 	endpoint, err := api.apiURL("core", "applications")
 	if err != nil {
@@ -355,6 +392,9 @@ func addProviderToEmbeddedOutpost(ctx context.Context, api ManagedBlueprintClien
 	publicHost := strings.TrimRight(tamoss.Spec.Auth.AuthentikBlueprints.IssuerURL, "/")
 	config["authentik_host"] = publicHost
 	config["authentik_host_browser"] = publicHost
+	if equalIntValues(outpost.Providers, providers) && reflect.DeepEqual(outpost.Config, config) {
+		return nil
+	}
 	return updateOutpost(ctx, api, outpost, providers, config)
 }
 
@@ -468,6 +508,41 @@ func copyMap(input map[string]any) map[string]any {
 		copied[key] = value
 	}
 	return copied
+}
+
+func proxyProviderMatches(existing proxyProvider, desired proxyProviderRequest) bool {
+	return existing.PK != 0 &&
+		existing.Name == desired.Name &&
+		existing.AuthorizationFlow == desired.AuthorizationFlow &&
+		existing.InvalidationFlow == desired.InvalidationFlow &&
+		containsStringValues(existing.PropertyMappings, desired.PropertyMappings) &&
+		existing.ExternalHost == desired.ExternalHost &&
+		existing.InternalHost == desired.InternalHost &&
+		existing.InternalHostSSLValidation == desired.InternalHostSSLValidation &&
+		existing.Mode == desired.Mode
+}
+
+func containsStringValues(existing, desired []string) bool {
+	// Authentik adds proxy-specific mappings, so desired values must be a
+	// subset; exact equality would cause a PUT on every reconciliation.
+	available := make(map[string]struct{}, len(existing))
+	for _, value := range existing {
+		available[value] = struct{}{}
+	}
+	for _, value := range desired {
+		if _, found := available[value]; !found {
+			return false
+		}
+	}
+	return true
+}
+
+func equalIntValues(left, right []int) bool {
+	left = append([]int(nil), left...)
+	right = append([]int(nil), right...)
+	sort.Ints(left)
+	sort.Ints(right)
+	return slices.Equal(left, right)
 }
 
 func ServicePortNameForOutpost(port int32) string {

--- a/operator/internal/controller/auth/authentik/proxy_outpost_test.go
+++ b/operator/internal/controller/auth/authentik/proxy_outpost_test.go
@@ -22,7 +22,7 @@ func TestProxyOutpostClientReconcilesAndDeletes(t *testing.T) {
 	defer server.Close()
 
 	client := ProxyOutpostClient{BaseURL: server.URL, Token: "test-token"}
-	if err := client.Reconcile(context.Background(), tamoss); err != nil {
+	if err := client.Reconcile(context.Background(), tamoss, successfulManagedBlueprint()); err != nil {
 		t.Fatalf("reconcile failed: %v", err)
 	}
 	if state.proxy.Name != "tamoss-tams-example-ui-proxy" {
@@ -44,12 +44,15 @@ func TestProxyOutpostClientReconcilesAndDeletes(t *testing.T) {
 		state.outpost.Config["authentik_host_browser"] != "https://auth.example.com" {
 		t.Fatalf("expected public Authentik host in outpost config, got %#v", state.outpost.Config)
 	}
+	if state.proxyPostCount != 1 || state.applicationPostCount != 1 || state.outpostPutCount != 1 {
+		t.Fatalf("expected one create/update per resource, got proxy POSTs=%d application POSTs=%d outpost PUTs=%d", state.proxyPostCount, state.applicationPostCount, state.outpostPutCount)
+	}
 
-	if err := client.Reconcile(context.Background(), tamoss); err != nil {
+	if err := client.Reconcile(context.Background(), tamoss, successfulManagedBlueprint()); err != nil {
 		t.Fatalf("second reconcile failed: %v", err)
 	}
-	if state.applicationPutCount != 1 {
-		t.Fatalf("expected second reconcile to update proxy application, got %d PUTs", state.applicationPutCount)
+	if state.proxyPutCount != 0 || state.applicationPutCount != 0 || state.outpostPutCount != 1 {
+		t.Fatalf("expected second reconcile to make no updates, got proxy PUTs=%d application PUTs=%d outpost PUTs=%d", state.proxyPutCount, state.applicationPutCount, state.outpostPutCount)
 	}
 
 	if err := client.Delete(context.Background(), tamoss); err != nil {
@@ -71,7 +74,7 @@ func TestProxyOutpostClientFindsExistingApplicationWithSearch(t *testing.T) {
 	state := proxyOutpostServerState{
 		oauth:                     proxyOutpostOAuth(),
 		proxy:                     proxyProvider{PK: 42, Name: "tamoss-tams-example-ui-proxy"},
-		application:               application{PK: "existing-app-id", Name: "tamoss-tams-example-ui", Slug: "tamoss-tams-example-ui"},
+		application:               application{PK: "existing-app-id", Name: "tamoss-tams-example-ui", Slug: "tamoss-tams-example-ui", Provider: 41},
 		applicationSlugQueryStale: true,
 		outpost:                   proxyOutpostEmbeddedOutpost(),
 	}
@@ -79,7 +82,7 @@ func TestProxyOutpostClientFindsExistingApplicationWithSearch(t *testing.T) {
 	defer server.Close()
 
 	client := ProxyOutpostClient{BaseURL: server.URL, Token: "test-token"}
-	if err := client.Reconcile(context.Background(), tamoss); err != nil {
+	if err := client.Reconcile(context.Background(), tamoss, successfulManagedBlueprint()); err != nil {
 		t.Fatalf("reconcile failed: %v", err)
 	}
 	if state.applicationPostCount != 0 {
@@ -93,10 +96,49 @@ func TestProxyOutpostClientFindsExistingApplicationWithSearch(t *testing.T) {
 	}
 }
 
+func TestProxyOutpostClientReappliesBlueprintWhenOAuthProviderIsMissing(t *testing.T) {
+	tamoss := proxyOutpostFixture()
+	state := proxyOutpostServerState{outpost: proxyOutpostEmbeddedOutpost()}
+	server := httptest.NewServer(http.HandlerFunc(state.handle))
+	defer server.Close()
+
+	client := ProxyOutpostClient{BaseURL: server.URL, Token: "test-token"}
+	if err := client.Reconcile(context.Background(), tamoss, successfulManagedBlueprint()); err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+	if state.blueprintApplyCount != 1 {
+		t.Fatalf("expected missing OAuth provider to force one Blueprint apply, got %d", state.blueprintApplyCount)
+	}
+	if state.proxy.PK == 0 {
+		t.Fatalf("expected proxy resources to reconcile after OAuth provider recovery")
+	}
+}
+
+func TestProxyOutpostClientDoesNotReapplyTransientBlueprintWhenOAuthProviderIsMissing(t *testing.T) {
+	tamoss := proxyOutpostFixture()
+	state := proxyOutpostServerState{outpost: proxyOutpostEmbeddedOutpost()}
+	server := httptest.NewServer(http.HandlerFunc(state.handle))
+	defer server.Close()
+
+	client := ProxyOutpostClient{BaseURL: server.URL, Token: "test-token"}
+	transient := successfulManagedBlueprint()
+	transient.Status = "unknown"
+	transient.LastApplied = "2026-07-21T19:19:28Z"
+	err := client.Reconcile(context.Background(), tamoss, transient)
+	if err == nil || !strings.Contains(err.Error(), "OAuth2 provider") {
+		t.Fatalf("expected missing OAuth provider error, got %v", err)
+	}
+	if state.blueprintApplyCount != 0 {
+		t.Fatalf("expected transient Blueprint not to be reapplied, got %d applies", state.blueprintApplyCount)
+	}
+}
+
 type proxyOutpostServerState struct {
 	oauth                     oauthProvider
 	proxy                     proxyProvider
 	proxyRequest              proxyProviderRequest
+	proxyPostCount            int
+	proxyPutCount             int
 	application               application
 	applicationRequest        applicationRequest
 	applicationSlugQueryStale bool
@@ -105,6 +147,8 @@ type proxyOutpostServerState struct {
 	applicationPutCount       int
 	applicationDeleteCount    int
 	outpost                   outpost
+	outpostPutCount           int
+	blueprintApplyCount       int
 }
 
 func (s *proxyOutpostServerState) handle(w http.ResponseWriter, r *http.Request) {
@@ -114,7 +158,11 @@ func (s *proxyOutpostServerState) handle(w http.ResponseWriter, r *http.Request)
 	}
 	switch {
 	case r.Method == http.MethodGet && r.URL.Path == "/api/v3/providers/oauth2/":
-		_ = json.NewEncoder(w).Encode(oauthProviderList{Results: []oauthProvider{s.oauth}})
+		_ = json.NewEncoder(w).Encode(oauthProviderList{Results: oauthProviderResults(s.oauth)})
+	case r.Method == http.MethodPost && r.URL.Path == "/api/v3/managed/blueprints/blueprint-id/apply/":
+		s.blueprintApplyCount++
+		s.oauth = proxyOutpostOAuth()
+		_ = json.NewEncoder(w).Encode(successfulManagedBlueprint())
 	case r.Method == http.MethodGet && r.URL.Path == "/api/v3/providers/proxy/":
 		_ = json.NewEncoder(w).Encode(proxyProviderList{Results: proxyProviderResults(s.proxy)})
 	case r.Method == http.MethodPost && r.URL.Path == "/api/v3/providers/proxy/":
@@ -122,7 +170,8 @@ func (s *proxyOutpostServerState) handle(w http.ResponseWriter, r *http.Request)
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		s.proxy = proxyProvider{PK: 42, Name: s.proxyRequest.Name}
+		s.proxyPostCount++
+		s.proxy = proxyProviderFromRequest(42, s.proxyRequest)
 		w.WriteHeader(http.StatusCreated)
 		_ = json.NewEncoder(w).Encode(s.proxy)
 	case r.Method == http.MethodPut && r.URL.Path == "/api/v3/providers/proxy/42/":
@@ -130,7 +179,8 @@ func (s *proxyOutpostServerState) handle(w http.ResponseWriter, r *http.Request)
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		s.proxy = proxyProvider{PK: 42, Name: s.proxyRequest.Name}
+		s.proxyPutCount++
+		s.proxy = proxyProviderFromRequest(42, s.proxyRequest)
 		_ = json.NewEncoder(w).Encode(s.proxy)
 	case r.Method == http.MethodDelete && r.URL.Path == "/api/v3/providers/proxy/42/":
 		s.proxy = proxyProvider{}
@@ -161,7 +211,7 @@ func (s *proxyOutpostServerState) handle(w http.ResponseWriter, r *http.Request)
 			http.Error(w, `{"slug":["Application with this slug already exists."],"provider":["Application with this provider already exists."]}`, http.StatusBadRequest)
 			return
 		}
-		s.application = application{PK: "app-id", Name: s.applicationRequest.Name, Slug: s.applicationRequest.Slug}
+		s.application = application{PK: "app-id", Name: s.applicationRequest.Name, Slug: s.applicationRequest.Slug, Provider: s.applicationRequest.Provider}
 		w.WriteHeader(http.StatusCreated)
 		_ = json.NewEncoder(w).Encode(s.application)
 	case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/api/v3/core/applications/"):
@@ -174,7 +224,7 @@ func (s *proxyOutpostServerState) handle(w http.ResponseWriter, r *http.Request)
 			return
 		}
 		s.applicationPutCount++
-		s.application = application{PK: s.application.PK, Name: s.applicationRequest.Name, Slug: s.applicationRequest.Slug}
+		s.application = application{PK: s.application.PK, Name: s.applicationRequest.Name, Slug: s.applicationRequest.Slug, Provider: s.applicationRequest.Provider}
 		_ = json.NewEncoder(w).Encode(s.application)
 	case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/v3/core/applications/"):
 		if strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/v3/core/applications/"), "/") != s.application.Slug {
@@ -197,6 +247,7 @@ func (s *proxyOutpostServerState) handle(w http.ResponseWriter, r *http.Request)
 		s.outpost.Providers = request.Providers
 		s.outpost.Config = request.Config
 		s.outpost.Managed = request.Managed
+		s.outpostPutCount++
 		_ = json.NewEncoder(w).Encode(s.outpost)
 	default:
 		http.NotFound(w, r)
@@ -229,6 +280,31 @@ func proxyProviderResults(current proxyProvider) []proxyProvider {
 		return nil
 	}
 	return []proxyProvider{current}
+}
+
+func oauthProviderResults(current oauthProvider) []oauthProvider {
+	if current.PK == 0 {
+		return nil
+	}
+	return []oauthProvider{current}
+}
+
+func successfulManagedBlueprint() ManagedBlueprint {
+	return ManagedBlueprint{PK: "blueprint-id", Name: "tamoss-tams-example", Status: "successful"}
+}
+
+func proxyProviderFromRequest(pk int, request proxyProviderRequest) proxyProvider {
+	return proxyProvider{
+		PK:                        pk,
+		Name:                      request.Name,
+		AuthorizationFlow:         request.AuthorizationFlow,
+		InvalidationFlow:          request.InvalidationFlow,
+		PropertyMappings:          append(append([]string(nil), request.PropertyMappings...), "authentik-managed"),
+		ExternalHost:              request.ExternalHost,
+		InternalHost:              request.InternalHost,
+		InternalHostSSLValidation: request.InternalHostSSLValidation,
+		Mode:                      request.Mode,
+	}
 }
 
 func applicationResults(current application) []application {

--- a/operator/internal/controller/tamoss_controller.go
+++ b/operator/internal/controller/tamoss_controller.go
@@ -323,7 +323,7 @@ func (r *TamossReconciler) reconcileTamossManagedAuthentikStage(ctx context.Cont
 		return stopReconcile(ctrl.Result{RequeueAfter: r.authentikProbeInterval()}), nil
 	}
 	log.FromContext(ctx).V(1).Info("applied Authentik managed Blueprint", "name", managedBlueprint.Name, "status", managedBlueprint.Status)
-	if err := authentik.NewProxyOutpostClient(tamoss, token.Token, r.AuthentikHTTPClient).Reconcile(ctx, tamoss); err != nil {
+	if err := authentik.NewProxyOutpostClient(tamoss, token.Token, r.AuthentikHTTPClient).Reconcile(ctx, tamoss, managedBlueprint); err != nil {
 		message := fmt.Sprintf("Authentik proxy outpost apply failed for %s: %v", authentik.ProxyProviderName(tamoss), err)
 		if err := r.updateIdentityBlockedStatus(ctx, tamoss, operatorstatus.ReasonAuthentikManagedBlueprintApplyFailed, message); err != nil {
 			return stopReconcile(ctrl.Result{}), err


### PR DESCRIPTION
Skips applying unchanged managed Blueprints and updating unchanged proxy providers, applications, and outposts, preventing periodic reconciles from generating Authentik task and event churn. Error and orphaned Blueprints still retry, while a missing OAuth2 provider triggers a Blueprint reapply for drift recovery. Includes regression coverage for the no-op, retry, normalization, and recovery paths.