### PR TITLE
chore: add 8.1.0-oss4 release metadata

### DIFF
--- a/operator/compatibility.yaml
+++ b/operator/compatibility.yaml
@@ -63,6 +63,17 @@
           "8.1.0-oss2"
         ]
       }
+    },
+    {
+      "version": "8.1.0-oss4",
+      "tamsAPI": "8.1",
+      "schemaRevision": "8.1.0-oss2",
+      "upgrade": {
+        "class": "APIOnly",
+        "from": [
+          "8.1.0-oss3"
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
Release metadata for 8.1.0-oss4: TAMS API 8.1, schema revision 8.1.0-oss2, APIOnly upgrade from 8.1.0-oss3.