### PR TITLE
docs: unify the documentation and close the install-test gaps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ repo's tools.
 Required at OS level for the local development and Kubernetes paths:
 
 - Docker or Podman (+ `docker compose`)
-- `curl`, `openssl`, `git`
+- `curl`, `git`
 
 Also install `ffmpeg` and `uuidgen` if you use the ingest helper.
 
@@ -71,7 +71,8 @@ task operator:test
 task operator:manifests
 ```
 
-Use `task operator:test` for the normal operator gate. The detailed Chainsaw
+Use `task operator:test` for the normal operator gate. The detailed
+[Chainsaw](https://kyverno.github.io/chainsaw/)
 commands are CI/operator-maintainer tools; use them when changing reconciliation
 semantics or lifecycle behaviour. The test layout and contribution workflow are
 documented in
@@ -86,7 +87,8 @@ before touching the operator so `go`, `kubeconform`, and
 Test code lives under `tests/`, organised by what it tests:
 
 - `tests/tams/conformance/` — maintained in-process TAMS contract and semantic tests.
-- `tests/tams/integration/` — focused TAMS checks that need real Postgres and S3/RustFS.
+- `tests/tams/integration/` — focused TAMS checks that need real Postgres and
+  S3/[RustFS](https://github.com/rustfs/rustfs).
 - `tests/tams/deployed/` — deployed TAMS conformance checks against Kind or a
   remote target file.
 - `tests/e2e/` — deployed product API/UI checks against Kind or a remote target
@@ -138,7 +140,7 @@ Test markers in use:
 - `worker` — asynchronous deletion and webhook processing checks.
 
 Prefer adding new TAMS-facing behaviour coverage under the contract or semantic
-task that matches the failure mode. Add deployed checks only when the behavior
+task that matches the failure mode. Add deployed checks only when the behaviour
 requires a real ingress, browser, object store, or worker deployment.
 
 ## Code organisation

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 # TAMOSS
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![Python 3.11](https://img.shields.io/badge/python-3.11-blue)](https://www.python.org/)
+[![Python 3.14](https://img.shields.io/badge/python-3.14-blue)](https://www.python.org/)
 [![BBC TAMS v8.1](https://img.shields.io/badge/BBC%20TAMS-v8.1-green)](https://github.com/bbc/tams)
 
 TAMOSS is a Kubernetes-native implementation of the
 [BBC TAMS v8.1 API specification](https://github.com/bbc/tams). It installs as
-an operator-driven product with three supported infrastructure profiles:
-`local-kind`, `single-server`, and `multi-server`.
+an operator-driven product with four supported infrastructure profiles:
+`local-kind`, `edge`, `single-server`, and `multi-server`.
 
 The operator reconciles `Tamoss` and `StorageBackend` custom resources into the
 API, worker, UI, schema migration, generated Secrets, routing, and selected
@@ -25,7 +25,7 @@ backend integrations.
 - **Operator-managed runtime**: Reconciles API, worker, UI, schema migration,
   generated Secrets, routing, and backend integration from Kubernetes custom
   resources.
-- **Deployment profiles**: Ships `local-kind`, `single-server`, and
+- **Deployment profiles**: Ships `local-kind`, `edge`, `single-server`, and
   `multi-server` profiles so the same operator path works from local evaluation
   through production-shaped clusters.
 - **Interchangeable platform services**: Supports managed or external
@@ -38,12 +38,12 @@ backend integrations.
 
 ## Quickstart
 
-**Prerequisites:** Docker, `curl`, `openssl`, `git`, and
+**Prerequisites:** Docker, `curl`, `git`, and
 [aqua](https://aquaproj.github.io/docs/install) — a single-binary CLI version
 manager. With aqua installed, the rest of the toolchain (`task`, `kind`,
 `kubectl`, `helm`, `helmfile`, `chainsaw`, …) is provisioned by `aqua install`.
 
-Use the local Kind profile first:
+Use the local [Kind](https://kind.sigs.k8s.io/) profile first:
 
 ```bash
 aqua install
@@ -66,7 +66,8 @@ Open:
 - S3 endpoint: <https://s3.tamoss.localtest.me>
 - Authentik: <https://auth.tamoss.localtest.me>
 
-The equivalent Kubernetes install shape is always:
+To install on an existing Kubernetes cluster instead of the disposable
+Kind cluster, use the environment workflow:
 
 ```bash
 task env:init NAME=my-prod PROFILE=multi-server DOMAIN=tamoss.example.com
@@ -77,12 +78,14 @@ task env:wait ENV=my-prod KUBECONFIG=/path/to/kubeconfig
 ```
 
 Remote environments are composition roots: `platform-values.yaml` configures the
-Helmfile-managed platform releases, and the Kustomize overlay applies the
+[Helmfile](https://helmfile.readthedocs.io/)-managed platform releases, and the
+[Kustomize](https://kustomize.io/) overlay applies the
 `Tamoss` resources.
 Generated remote environments default to public ACME TLS through
 `ClusterIssuer/tamoss-public`; set the ACME email in `platform-values.yaml`
 before applying. Use `tls.mode: existing` for a pre-installed ClusterIssuer or
-`tls.mode: disabled` when TLS Secrets are supplied outside cert-manager.
+`tls.mode: disabled` when TLS Secrets are supplied outside
+[cert-manager](https://cert-manager.io/).
 The raw apply sequence is:
 
 ```bash
@@ -105,7 +108,8 @@ kubectl apply -k deploy/environments/<name>
 
 | Profile | Use when | Default backing services |
 | --- | --- | --- |
-| `local-kind` | You want to evaluate or develop TAMOSS on Kind. | Local reference platform with CNPG, RustFS Operator, Authentik, cert-manager, and Traefik on host port 443. |
+| `local-kind` | You want to evaluate or develop TAMOSS on Kind. | Local reference platform with [CNPG](https://cloudnative-pg.io/), [RustFS](https://github.com/rustfs/rustfs) Operator, [Authentik](https://goauthentik.io/), cert-manager, and [Traefik](https://traefik.io/) on host port 443. |
+| `edge` | You run one ARM64 node, such as a Raspberry Pi 4 with 4 GB memory. | Compact single-node ARM64 topology; bearer-token auth by default, with optional managed Authentik. |
 | `single-server` | You run one Kubernetes node or a small self-managed cluster. | Single-node workload topology; platform services are selected by the environment. |
 | `multi-server` | You run production-shaped self-managed Kubernetes. | Replicated workload topology; platform services are selected by the environment. |
 

--- a/aqua.yml
+++ b/aqua.yml
@@ -73,7 +73,7 @@ packages:
 # Notes: aqua cannot provide these OS/system tools.
 # Required to build, test, and deploy:
 # - Docker or Podman (and docker compose) — container build + compose stack
-# - curl, openssl, git                    — setup and local scripts
+# - curl, git                             — setup and local scripts
 # Optional, only for the ingest helper (src/scripts/ingest_video.sh):
 # - ffmpeg                                — segments local video files for ingest
 # - uuidgen (util-linux)                  — generates flow and source identifiers

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -11,7 +11,8 @@ task env:apply ENV=my-prod KUBECONFIG="$KUBECONFIG"
 task env:wait ENV=my-prod KUBECONFIG="$KUBECONFIG"
 ```
 
-Those workflows apply Helmfile-managed platform releases, then the Kustomize
+Those workflows apply [Helmfile](https://helmfile.readthedocs.io/)-managed
+platform releases, then the [Kustomize](https://kustomize.io/)
 operator install, then the Kustomize environment overlay containing `Tamoss`
 resources.
 
@@ -19,12 +20,12 @@ resources.
 
 | Layer | Owns | Notes |
 | --- | --- | --- |
-| Platform | cert-manager, Traefik, Authentik, CNPG, RustFS Operator, and other shared prerequisites | Installed once per cluster or profile. Third-party components follow their upstream lifecycle. |
+| Platform | [cert-manager](https://cert-manager.io/), [Traefik](https://traefik.io/), [Authentik](https://goauthentik.io/), [CNPG](https://cloudnative-pg.io/), [RustFS](https://github.com/rustfs/rustfs) Operator, and other shared prerequisites | Installed once per cluster or profile. Third-party components follow their upstream lifecycle. |
 | Operator | TAMOSS CRDs, controller, RBAC, webhooks, and reconciliation logic | Watches `Tamoss` and `StorageBackend` resources. |
 | Instance | API, worker, UI, schema migration, generated Secrets, routes, and selected backend resources | Declared through one or more namespaced `Tamoss` CRs. |
 
 The operator hides runtime complexity behind Kubernetes custom resources. A
-client applies a `Tamoss` CR; the operator renders the API, worker, UI, schema
+client applies a `Tamoss` CR. The operator renders the API, worker, UI, schema
 migration, backend integration, and status.
 
 For multi-instance clusters, tenant boundaries are Kubernetes namespaces. A
@@ -54,4 +55,4 @@ operator:
 - API and worker pods read a mounted credentials file from that Secret.
 
 This allows non-Kubernetes runtimes to provide the same file format without
-teaching the API to call Kubernetes APIs.
+requiring the API to call Kubernetes APIs.

--- a/docs/concepts/profiles.md
+++ b/docs/concepts/profiles.md
@@ -5,12 +5,12 @@ separate products and they do not change the operator install path.
 
 | Profile | Purpose | Backing services |
 | --- | --- | --- |
-| `local-kind` | Local evaluation and development on Kind. | CNPG and RustFS Operator with small single-node defaults, Authentik, cert-manager, and Traefik on host port 443. |
-| `edge` | Single-node ARM64 Kubernetes installs with local persistent storage, sized from a Raspberry Pi 4 Model B 4 GB floor. | CNPG and RustFS Operator with compact single-node defaults, token-only auth, cert-manager, and Traefik. |
+| `local-kind` | Local evaluation and development on [Kind](https://kind.sigs.k8s.io/). | [CNPG](https://cloudnative-pg.io/) and [RustFS](https://github.com/rustfs/rustfs) Operator with small single-node defaults, [Authentik](https://goauthentik.io/), [cert-manager](https://cert-manager.io/), and [Traefik](https://traefik.io/) on host port 443. |
+| `edge` | Single-node ARM64 Kubernetes installs with local persistent storage, sized from a Raspberry Pi 4 Model B 4 GB floor. | CNPG and RustFS Operator with compact single-node defaults, bearer-token auth by default or on-node managed Authentik, cert-manager, and Traefik. |
 | `single-server` | One Kubernetes node or a small self-managed cluster. | CNPG and RustFS Operator with single-node durable defaults plus shared Authentik, cert-manager, and Traefik. |
 | `multi-server` | Production reference for multi-node Kubernetes. | Replicated workloads, CNPG, RustFS Operator, shared Authentik, cert-manager, and Traefik. |
 
-Every checked-in instance manifest sets `.spec.profile`. The operator fills sane
+Every checked-in instance manifest sets `.spec.profile`. The operator fills in
 defaults for that profile, then explicit YAML fields in the `Tamoss` CR override
 those defaults.
 
@@ -25,10 +25,13 @@ install in the `auth` namespace. Use an explicit `spec.auth.providedBy:
 external` or `spec.auth.providedBy: none` only when an environment intentionally
 opts out of the profile default.
 
-`edge` intentionally does not default to Authentik. It selects
-`auth.providedBy: external` with OAuth2 disabled and uses the generated TAMOSS
-API token Secret for bearer-token access. Set `spec.auth.providedBy: none` only
-when the edge install should accept anonymous API requests.
+`edge` does not default to Authentik. It selects `auth.providedBy: external`
+with OAuth2 disabled and uses the generated TAMOSS API token Secret for
+bearer-token access. Declaring `spec.auth.providedBy: authentik-blueprints`
+opts the install into the managed Authentik stack on the same node; measured
+on a 4 GB ARM64 node, the OAuth mode holds roughly 2.8 GiB of memory at
+steady state against 2.3 GiB for token mode. Set `spec.auth.providedBy: none`
+only when the edge install should accept anonymous API requests.
 
 `deploy/profiles.yaml` is the profile registry used by Taskfile helpers. Each
 supported profile records its Kind environment composition, target environment
@@ -36,10 +39,11 @@ file, and the Kind cluster config used for local validation.
 
 `local-kind` is a local test adapter. It creates a Kind cluster, loads local
 development images, uses `localtest.me`, and exists to validate the operator
-flow quickly. `edge` is a remote-capable single-node ARM64 profile for boards
+flow quickly. `edge` is a remote-capable single-node ARM64 profile for nodes
 as small as a Raspberry Pi 4 Model B with 4 GB RAM; running
 `task kind:up PROFILE=edge` validates the profile shape on Kind, but the target
-install path is a normal ARM64 Kubernetes cluster such as K3s. `single-server`
+install path is a normal ARM64 Kubernetes cluster such as
+[K3s](https://k3s.io/). `single-server`
 is the remote-capable single-node or small-cluster profile. Running
 `task kind:up PROFILE=single-server` validates that profile on Kind; it is not
 the remote install path.
@@ -140,13 +144,13 @@ Run the sequential profile gate:
 task kind:profiles:e2e
 ```
 
-The Kind-specific environments, such as `deploy/environments/kind-multi-server`,
+The Kind-specific environments, such as `deploy/environments/multi-server`,
 are test adapters for local validation. They are not additional public profiles.
 The `multi-server` local validation path also uses `deploy/kind-multi-server.yaml`
 so Kind creates one control-plane node and three worker nodes while keeping host
 HTTPS ingress on port 443.
 
 Both checked-in Kind configs bind host port `443` to `0.0.0.0` for local browser
-and API testing. Treat that as local development exposure: other machines on the
+and API testing. Treat that as local development exposure. Other machines on the
 same network may be able to reach the test ingress while the Kind cluster is
 running.

--- a/docs/concepts/provider-ownership.md
+++ b/docs/concepts/provider-ownership.md
@@ -6,10 +6,10 @@ authentication, and HTTP ingress.
 
 | Area | Managed option | External option | TAMOSS operator responsibility |
 | --- | --- | --- | --- |
-| PostgreSQL | `backends.db.providedBy: cnpg` | `backends.db.providedBy: external` | Create and monitor CNPG instance resources, or consume external host/database/Secret references. |
-| S3 | `backends.s3.providedBy: rustfs-operator` and `StorageBackend.provider: rustfs` | `backends.s3.providedBy: external` and `StorageBackend.provider: external-s3` | Create RustFS instance and bucket resources for managed mode, or register external endpoint/bucket/Secret metadata. |
-| Authentication | `auth.providedBy: authentik-blueprints` | `auth.providedBy: external` | Reconcile Authentik Application/OAuth provider through managed Blueprints, or consume external OIDC metadata and client Secret references. |
-| HTTP | Reference Traefik platform with Kubernetes `Ingress` or `HTTPRoute` | External ingress or Gateway implementation | Render standard routing objects from the `Tamoss` CR; do not install or mutate external controllers. |
+| PostgreSQL | `backends.db.providedBy: cnpg` | `backends.db.providedBy: external` | Create and monitor [CNPG](https://cloudnative-pg.io/) instance resources, or consume external host/database/Secret references. |
+| S3 | `backends.s3.providedBy: rustfs-operator` and `StorageBackend.provider: rustfs` | `backends.s3.providedBy: external` and `StorageBackend.provider: external-s3` | Create [RustFS](https://github.com/rustfs/rustfs) instance and bucket resources for managed mode, or register external endpoint/bucket/Secret metadata. |
+| Authentication | `auth.providedBy: authentik-blueprints` | `auth.providedBy: external` | Reconcile [Authentik](https://goauthentik.io/) Application/OAuth provider through managed Blueprints, or consume external OIDC metadata and client Secret references. |
+| HTTP | Reference [Traefik](https://traefik.io/) platform with Kubernetes `Ingress` or `HTTPRoute` | External ingress or Gateway implementation | Render standard routing objects from the `Tamoss` CR; do not install or mutate external controllers. |
 
 ## Managed Means
 
@@ -20,7 +20,8 @@ generated Secrets, and runs schema migration.
 
 Managed does not mean the `Tamoss` reconcile installs third-party platform
 operators. Cluster administrators or the checked-in platform bootstrap path
-install CNPG, RustFS Operator, Authentik, cert-manager, Traefik, Gateway API
+install CNPG, RustFS Operator, Authentik,
+[cert-manager](https://cert-manager.io/), Traefik, Gateway API
 CRDs, and Gateway API providers.
 
 Managed integrations are not all CR-driven:
@@ -56,11 +57,11 @@ Use `providedBy: external` when PostgreSQL, S3, authentication, or HTTP ingress
 is owned outside TAMOSS. In external mode, provide endpoint and Secret
 references in the CR and manage provider lifecycle outside TAMOSS.
 
-## Advanced Resource Customization
+## Advanced Resource Customisation
 
 First-class `Tamoss` fields are the preferred configuration path for common
 operational controls. For provider fields that change faster than the TAMOSS
-API should, `spec.advanced` provides explicit operator-facing escape hatches:
+API should, `spec.advanced` provides explicit operator-facing overrides:
 
 - `spec.advanced.resourcePatches` applies JSON merge patches to matching
   TAMOSS-emitted resources before server-side apply.
@@ -74,9 +75,9 @@ spec fields, but not resource identity or controller ownership fields such as
 `metadata.ownerReferences`.
 
 The operator keeps first-class fields stable where possible. Advanced provider
-YAML remains the responsibility of the operator using it: if a third-party CRD
-changes field names or semantics, update the advanced YAML alongside that
-provider upgrade.
+YAML remains the responsibility of whoever maintains the environment. If a
+third-party CRD changes field names or semantics, update the advanced YAML
+alongside that provider upgrade.
 
 ## External Means
 

--- a/docs/concepts/storage-backends.md
+++ b/docs/concepts/storage-backends.md
@@ -17,7 +17,8 @@ spec:
       providedBy: rustfs-operator
 ```
 
-The built-in profiles use CNPG and RustFS Operator by default. Use
+The built-in profiles use [CNPG](https://cloudnative-pg.io/) and
+[RustFS](https://github.com/rustfs/rustfs) Operator by default. Use
 `providedBy: external` when the default backend is an external S3-compatible
 bucket.
 
@@ -89,16 +90,16 @@ operator-managed API and worker pods set this to `false` and consume
 Controlled storage allocation has an explicit lifecycle. A `POST
 /flows/{flowId}/storage` response reserves object IDs and returns PUT upload
 requests, but those objects are not referenceable by Flow Segments until the
-client finalizes the controlled object with `POST /objects/{objectId}/instances`
+client finalises the controlled object with `POST /objects/{objectId}/instances`
 and the matching `storage_id`.
 
-Finalization verifies the object exists in the configured object store and
+Finalisation verifies the object exists in the configured object store and
 records available storage metadata such as content length, content type, ETag,
 checksum, and observation time.
 
 Allocation requests are bounded by `TAMOSS_STORAGE_ALLOCATION_MAX_OBJECTS`
 and object IDs by `TAMOSS_STORAGE_OBJECT_ID_MAX_LENGTH`. Clients must upload,
-finalize, and then register segments; allocated-only controlled objects are not
+finalise, and then register segments; allocated-only controlled objects are not
 referenceable by Flow Segments.
 
 ## External S3 Browser Access
@@ -110,13 +111,14 @@ policy does not allow the browser origin, method, or requested headers.
 
 External S3 buckets must allow every browser origin that will dereference
 presigned URLs. This can include the TAMOSS UI origin and external tools such as
-review, playback, or ingest clients. At minimum, configure:
+review, playback, or ingest clients. At minimum, configure the following:
 
 - Origins: browser origins such as `https://app.tamoss.example.com` and
   `https://tool.example.com`.
 - Upload methods: `PUT`.
 - Read methods: `GET` and `HEAD`.
-- Upload headers: at least `content-type`; `*` is simplest where acceptable.
+- Upload headers: at least `content-type`; `*` allows all headers where
+  acceptable.
 - Read/playback headers: `range` is commonly required by media clients. Some
   XHR-based clients also preflight `authorization`, `x-requested-with`,
   `cache-control`, or `pragma` even when the presigned URL itself carries the
@@ -136,10 +138,11 @@ including the UI web host from `.spec.ingress.ui.web.host` (`https` when
 operator falls back to a wildcard (`*`) bucket CORS origin.
 
 Regex origins from `.spec.api.cors.allowedOriginRegexes` are supported by the
-API and at the Traefik S3 ingress layer. They are not written to RustFS bucket
+API and at the [Traefik](https://traefik.io/) S3 ingress layer. They are not
+written to RustFS bucket
 CORS because S3-compatible bucket CORS rules are exact-origin based. Use an
 `external-s3` backend and configure the provider's bucket CORS policy directly
-when you need provider-specific CORS behavior.
+when you need provider-specific CORS behaviour.
 
 ## Deletion
 

--- a/docs/concepts/tenancy.md
+++ b/docs/concepts/tenancy.md
@@ -9,7 +9,8 @@ Use Kubernetes namespaces and standard policy resources for tenant boundaries.
 
 ## Namespace Contract
 
-Create a namespace before applying tenant-owned resources. Recommended metadata:
+Create a namespace with identifying metadata before applying tenant-owned
+resources:
 
 ```yaml
 apiVersion: v1
@@ -81,10 +82,10 @@ platform capabilities; they do not own platform lifecycle.
 
 | Area | Tenant reference | Platform owner |
 | --- | --- | --- |
-| Authentication | `spec.auth.authentikBlueprints.platformNamespace` and token Secret reference | Authentik namespace and Authentik service lifecycle |
-| Routing | `Ingress` or `HTTPRoute` fields in each `Tamoss` CR | Traefik, GatewayClass, Gateway, DNS, and certificates |
-| PostgreSQL | CNPG `Cluster` resources created in the tenant namespace when managed | CNPG operator install and upgrades |
-| S3 | RustFS `Tenant` and `StorageBackend` resources in the tenant namespace when managed | RustFS Operator install and upgrades |
+| Authentication | `spec.auth.authentikBlueprints.platformNamespace` and token Secret reference | [Authentik](https://goauthentik.io/) namespace and Authentik service lifecycle |
+| Routing | `Ingress` or `HTTPRoute` fields in each `Tamoss` CR | [Traefik](https://traefik.io/), GatewayClass, Gateway, DNS, and certificates |
+| PostgreSQL | [CNPG](https://cloudnative-pg.io/) `Cluster` resources created in the tenant namespace when managed | CNPG operator install and upgrades |
+| S3 | [RustFS](https://github.com/rustfs/rustfs) `Tenant` and `StorageBackend` resources in the tenant namespace when managed | RustFS Operator install and upgrades |
 
 External providers follow the same namespace boundary for configuration:
 tenant-local Secrets and CRs reference services that are owned outside TAMOSS.
@@ -122,9 +123,9 @@ spec:
 
 ## Watch Scope
 
-The operator can run cluster-wide or with `WATCH_NAMESPACES` set to a comma
-separated namespace list. Cluster-wide mode is the simplest shared-operator
-shape.
+The operator can run cluster-wide or with `WATCH_NAMESPACES` set to a
+comma-separated namespace list. Cluster-wide mode avoids maintaining a
+namespace list for a shared operator.
 
 When watch scope is restricted, a `Tamoss` resource outside that namespace set
 is ignored. The operator logs the ignored namespace and does not update that

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,8 +43,32 @@ spec:
     baseDomain: tamoss.example.com
 ```
 
-The operator derives API, UI, and S3 endpoints from the base domain. Authentik
+The operator derives API, UI, and S3 endpoints from the base domain.
+[Authentik](https://goauthentik.io/)
 endpoints are derived only for Authentik-backed profiles.
+
+## Browser Origin Checklist
+
+Browser clients need CORS agreement in two places, and the two are owned by
+different layers:
+
+1. `spec.api.cors.allowedOrigins` on the `Tamoss` CR for API calls.
+2. The bucket CORS rules at the S3 provider for presigned object URLs. For
+   external buckets (for example Backblaze B2) these are evaluated per bucket
+   and stay provider-owned; the operator does not write them.
+
+After changing either side, the external S3 CORS diagnostic verifies both the
+bucket URL preflight and the configured origins. See
+[Troubleshooting](operations/troubleshooting.md#s3-and-storagebackend) for the
+diagnostic conditions and manual preflight checks.
+
+## OAuth Issuer Details for Clients
+
+With the managed Authentik provider, the issuer URL is per application, not
+the Authentik root: `https://<auth-host>/application/o/<application-slug>/`.
+OpenID discovery lives beneath it at `.well-known/openid-configuration`. The
+client id and secret are held in the instance's generated OAuth Secret;
+`task env:summary` prints the resolved values.
 
 ## Inspect Effective Configuration
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,7 +1,6 @@
 # Deployment
 
-Deployment guidance now lives in the intent-based operations and getting-started
-docs.
+Deployment guidance lives in the operations and getting-started guides.
 
 Start here:
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -12,7 +12,8 @@ task check
 ```
 
 `task dev` runs native API and frontend dev servers with the local Compose
-dependency stack. Stop the Kind stack first because both paths use local
+dependency stack. Stop the [Kind](https://kind.sigs.k8s.io/) stack first
+because both paths use local
 PostgreSQL and S3 ports.
 
 ## Kubernetes Confidence Loop
@@ -22,7 +23,7 @@ task kind:up PROFILE=local-kind
 task kind:test PROFILE=local-kind
 ```
 
-Use this when changes affect Kubernetes manifests, operator behavior, ingress,
+Use this when changes affect Kubernetes manifests, operator behaviour, ingress,
 authentication, S3, or deployed UI/API integration.
 
 ## Operator Work
@@ -40,7 +41,8 @@ Run the normal operator gate:
 task operator:test
 ```
 
-Use the detailed Chainsaw tasks only when changing operator reconciliation or
+Use the detailed [Chainsaw](https://kyverno.github.io/chainsaw/) tasks only
+when changing operator reconciliation or
 lifecycle behaviour. Those commands are documented in
 `operator/test/chainsaw/README.md`.
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -1,7 +1,7 @@
 # Testing
 
 Use the smallest test that proves the change, then widen the scope when the
-change touches shared behavior or deployed contracts.
+change touches shared behaviour or deployed contracts.
 
 ## Fast Local Gate
 
@@ -13,7 +13,8 @@ task test:fast
 `task check` runs lint plus the fast focused test subset. `task test:fast`
 runs the pure local Python subset directly: local TAMS in-process checks,
 local storage adapters, application architecture checks, workers, scripts, and
-support helpers. It excludes database, S3/RustFS, media-tooling, deployed e2e,
+support helpers. It excludes database,
+S3/[RustFS](https://github.com/rustfs/rustfs), media-tooling, deployed e2e,
 and operator-cluster tests by marker.
 
 ## Unit and Contract Gates
@@ -31,8 +32,8 @@ checks, and focused real Postgres/S3 checks. `task test:tams:conformance` is an
 alias for the same local gate. Run `task deps` first when local Postgres and
 RustFS are not already running. `task test:tams:deployed` runs the deployed
 TAMS slice against a target env file.
-`task test:media:fixtures` validates the tiny managed-ingest media fixture with
-containerized `ffprobe`, so developers do not need unmanaged local media tools.
+`task test:media:fixtures` validates the small managed-ingest media fixture with
+containerised `ffprobe`, so developers do not need unmanaged local media tools.
 
 Validation tasks print compact suite labels before runner output. Common labels
 include `test py.tams.contract`, `test py.tams.semantics`,
@@ -56,7 +57,7 @@ The report names identify the affected quality area:
 
 ## Deployed Gates
 
-Run against an existing local Kind target:
+Run against an existing local [Kind](https://kind.sigs.k8s.io/) target:
 
 ```bash
 task test:smoke PROFILE=local-kind KUBECONFIG=tams.kubeconfig
@@ -66,7 +67,8 @@ task e2e:deployed PROFILE=local-kind KUBECONFIG=tams.kubeconfig
 
 `task test:smoke` runs the deployed smoke slice for the common API/UI workflows,
 including demo-media retrieval, storage lifecycle, webhook delivery, UI ingress,
-UI ingest, and playback preview, then validates the operator Chainsaw label set
+UI ingest, and playback preview, then validates the operator
+[Chainsaw](https://kyverno.github.io/chainsaw/) label set
 so the explicit operator smoke slice remains selectable. These tasks sync the
 Python dev dependencies and install Playwright Chromium on first run, then reuse
 them on later runs. Use the Chainsaw maintainer workflow when you specifically
@@ -102,8 +104,8 @@ Some operator tests use envtest. Use `task operator:test` rather than direct
 `go test ./...` for the full suite; the task delegates to `operator/Makefile`,
 which downloads the pinned `setup-envtest` helper and sets `KUBEBUILDER_ASSETS`
 for the downloaded Kubernetes control-plane binaries. Direct `go test` runs can
-reuse repo-local envtest binaries after they have been downloaded, but a clean
-checkout still needs `task operator:test` to bootstrap them first.
+reuse repository-local envtest binaries after they have been downloaded, but a
+clean checkout still needs `task operator:test` to bootstrap them first.
 
 The envtest suite installs TAMOSS CRDs plus the provider CRDs it needs for typed
 or unstructured test resources: CNPG CRDs from

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,12 +1,53 @@
 # Getting Started
 
-Start with the deployment shape that matches the environment you want to
-validate.
+Pick a profile and follow its guide. Remote installs use the environment
+workflow: run `task env:init`, edit the generated `platform-values.yaml` and
+`tamoss-patch.yaml`, then run `task env:apply` and `task env:wait`.
+`local-kind` runs the whole flow with `task kind:up`.
 
-- [Local Kind](local-kind.md) - disposable local validation on Kind.
-- [Edge](edge.md) - single-node ARM64, self-contained Kubernetes profile.
-- [Single Server](single-server.md) - small self-managed Kubernetes profile.
-- [Multi Server](multi-server.md) - production-shaped self-managed profile.
+| Profile | Use it for |
+| --- | --- |
+| [`local-kind`](local-kind.md) | Disposable local evaluation on [Kind](https://kind.sigs.k8s.io/). |
+| [`edge`](edge.md) | One ARM64 node, 4 GB memory floor. |
+| [`single-server`](single-server.md) | One durable node or small cluster. |
+| [`multi-server`](multi-server.md) | Production, multi-node. |
 
-For existing clusters, read [Install](../operations/install.md) before applying
-profile manifests.
+## Common Configuration
+
+Make these three decisions before `task env:apply`. Each guide's Key
+Settings section covers the profile-specific parts.
+
+### DNS
+
+`local-kind` needs no DNS: it uses `tamoss.localtest.me` hostnames, which
+resolve to 127.0.0.1 from public DNS. Every other profile derives `api`,
+`app`, `s3`, and `auth` hostnames from `spec.publicEndpoint.baseDomain`.
+Create real DNS records for those names, or use a wildcard resolver such as
+`<ip>.sslip.io` as the base domain when no DNS control exists. Host-file
+entries work for edge installs on private networks.
+
+### TLS
+
+Set `tls.mode` in the environment `platform-values.yaml`:
+
+- `selfSigned` (local-kind and edge default): no external dependencies;
+  browsers and API clients must trust or skip verification.
+- `public`: [cert-manager](https://cert-manager.io/) requests certificates
+  from Let's Encrypt. Requires
+  real DNS for the derived hostnames, an ACME email in the platform values, and
+  port 80 reachable for HTTP-01.
+- `existing`/`disabled`: certificate ownership stays outside the platform
+  layer; name the TLS Secrets in the `Tamoss` CR.
+
+### Auth
+
+Every profile enforces authentication by default. `local-kind`,
+`single-server`, and `multi-server` run the managed
+[Authentik](https://goauthentik.io/) stack and issue
+OAuth logins. `edge` defaults to a bearer-token Secret and can opt into the
+same Authentik stack; both modes are covered in the
+[edge guide](edge.md#key-settings). OAuth requires the `auth` hostname to
+resolve and carry valid TLS, so configure DNS and TLS first.
+
+See [Profiles](../concepts/profiles.md) for the full comparison and
+[Install](../operations/install.md) for the environment workflow.

--- a/docs/getting-started/edge.md
+++ b/docs/getting-started/edge.md
@@ -1,40 +1,91 @@
 # Edge
 
-`edge` is the single-node ARM64 profile for self-contained TAMOSS installs. It
-uses the normal operator install path, disables Authentik, and keeps API access
-token-only through the TAMOSS API token Secret.
+`edge` is the single-node ARM64 profile for self-contained TAMOSS installs.
+The target shape is one ARM64 node with local persistent storage; a
+Raspberry Pi 4 class machine is the minimum reference. API access is bearer-token by default; the profile can
+also run the managed [Authentik](https://goauthentik.io/) OAuth stack on the
+same node within a 4 GB memory budget.
 
-## Cluster Requirements
+## Requirements
 
-- A 64-bit ARM Kubernetes node. Raspberry Pi 4 Model B with 4 GB RAM is the
-  minimum target; larger Raspberry Pi 4/5 boards give more headroom.
-- Raspberry Pi OS Lite 64-bit with K3s is the reference software shape.
-- Persistent storage backed by an SSD. Avoid SD-card-backed database and object
-  storage.
-- Active cooling, a stable power supply, and wired Ethernet.
-- Swap configured on SSD-backed storage for constrained 4 GB nodes.
-- A default StorageClass, or explicit CNPG and RustFS storage classes in the
+- One 64-bit ARM Linux node with at least 4 GB of memory: a Raspberry Pi 4
+  Model B, a comparable single-board computer, or a small ARM cloud
+  instance.
+- Any 64-bit ARM Linux distribution. [K3s](https://k3s.io/) is the reference
+  Kubernetes distribution.
+- Persistent storage backed by an SSD or equivalent. Avoid SD-card-backed
+  database and object storage.
+- On single-board computers: active cooling, a stable power supply, and
+  wired Ethernet.
+- A default StorageClass, or explicit [CNPG](https://cloudnative-pg.io/) and
+  [RustFS](https://github.com/rustfs/rustfs) storage classes in the
   `Tamoss` CR.
-- cert-manager, Traefik, CNPG, and RustFS Operator installed by the TAMOSS
-  platform layer unless the cluster already owns those services.
-- Local DNS or host entries for API, UI, and S3 hostnames.
+- [cert-manager](https://cert-manager.io/), [Traefik](https://traefik.io/),
+  CNPG, and RustFS Operator installed by the TAMOSS platform layer unless the
+  cluster already owns those services.
+- Local DNS or host entries for API, UI, S3, and (with OAuth) auth hostnames.
 
-K3s should be installed without its bundled Traefik when the TAMOSS platform
-installs the pinned Traefik release for this profile.
+Install K3s without its bundled Traefik when the TAMOSS platform installs the
+pinned Traefik release for this profile.
 
 ## Install
 
-For local profile validation on Kind:
+Every `task` command below runs from a clone of this repository with the
+pinned toolchain on the PATH. Install [aqua](https://aquaproj.github.io/docs/install)
+and run `aqua install` first, as shown in the
+[repository quickstart](../../README.md#quickstart).
+
+### Provision K3s on the node
+
+On a blank node running any 64-bit ARM Linux, such as Raspberry Pi OS Lite
+64-bit, install K3s with its bundled Traefik disabled so the TAMOSS platform
+can install the pinned Traefik release. Set `<node-address>` to the IP
+address or DNS name you will manage the node through:
+
+```bash
+curl -sfL https://get.k3s.io | sh -s - --disable traefik --tls-san <node-address>
+```
+
+`--tls-san` adds `<node-address>` to the Kubernetes API certificate so
+`kubectl` works from another machine. Omit it when you only run `kubectl` on
+the node itself.
+
+Copy the cluster credentials to your workstation and point them at the node:
+
+```bash
+mkdir -p ~/.kube
+ssh <user>@<node-address> sudo cat /etc/rancher/k3s/k3s.yaml \
+  | sed 's/127.0.0.1/<node-address>/' > ~/.kube/tamoss-edge.yaml
+export KUBECONFIG=~/.kube/tamoss-edge.yaml
+kubectl get nodes
+```
+
+The node reports `Ready` within about a minute. Run the remaining commands
+from the workstation that holds this kubeconfig and a clone of this
+repository.
+
+### Validate the profile on Kind (optional)
+
+This step is optional. To rehearse the profile locally on
+[Kind](https://kind.sigs.k8s.io/) before touching the node:
 
 ```bash
 task kind:up PROFILE=edge
 ```
 
-For an existing ARM64 cluster:
+### Install TAMOSS
+
+For the K3s node provisioned above, `KUBECONFIG` is already set. For any
+other existing ARM64 cluster, export the path to its kubeconfig first:
 
 ```bash
 export KUBECONFIG=/path/to/kubeconfig
+```
 
+Create the environment composition, edit the two generated files, then
+apply and inspect it:
+
+```bash
 task env:init NAME=my-edge PROFILE=edge DOMAIN=tamoss.edge
 $EDITOR deploy/environments/my-edge/platform-values.yaml
 $EDITOR deploy/environments/my-edge/tamoss-patch.yaml
@@ -43,43 +94,113 @@ task env:wait ENV=my-edge KUBECONFIG="$KUBECONFIG"
 task env:summary ENV=my-edge KUBECONFIG="$KUBECONFIG"
 ```
 
-The generated edge platform values disable Authentik and use self-signed TLS by
-default. Keep `authentik.enabled: false` unless the install intentionally moves
-to an identity-backed profile.
+The generated edge platform values disable Authentik and use self-signed TLS
+by default. Work through the [Key Settings](#key-settings) while
+editing the two generated files, before `task env:apply`.
 
-## Defaults
+## Key Settings
 
-The operator defaults for `edge` are intentionally smaller than `single-server`
-and sized to fit a Raspberry Pi 4 Model B with 4 GB RAM:
+### Auth: bearer token (default)
 
-- API, worker, and UI run as one replica each.
-- Authentik is not selected by default.
-- Runtime auth is token-only with OAuth2 disabled.
-- CNPG runs one PostgreSQL instance with a 10 GiB volume and bounded resources.
-- RustFS Operator runs one server with four 10 GiB volumes.
-- RustFS disk checks are bypassed for single-node local storage.
-- API and worker runtime pools are reduced for small ARM systems.
-- Worker health probes use longer timeouts for ARM startup and import latency.
-- TLS defaults to `ClusterIssuer/tamoss-edge-selfsigned`.
+The operator defaults `edge` to token-only runtime auth. The API token lives
+in the generated `<fullname>-api-token` Secret — `tams-api-token` for the
+default fullname — under the `TAMOSS_API_TOKEN` key; `task env:summary` prints
+the resolved value once the instance is ready. Read it into a variable and
+send it as a bearer header:
 
-The API token is stored in the generated `<fullname>-api-token` Secret. Use
-`task env:summary` to print the resolved Secret value after the instance is
-ready.
+```bash
+export TAMOSS_API_TOKEN=$(kubectl -n tams get secret tams-api-token \
+  -o jsonpath='{.data.TAMOSS_API_TOKEN}' | base64 -d)
+curl -k -H "Authorization: Bearer $TAMOSS_API_TOKEN" https://api.tamoss.edge/
+```
 
-## Configure
+`-k` accepts the profile's default self-signed certificate; for real use,
+trust the issuing CA on the client (for example with `--cacert`) instead of
+disabling verification.
 
-Use `tamoss-patch.yaml` for durable overrides:
+### Auth: managed OAuth
+
+Declaring the Authentik provider runs the full OAuth stack on the node.
+OAuth on edge needs the operator release that ships the spec-driven edge
+Authentik defaults: the next release after 8.1.0-oss4.
+
+On a live instance, apply the change in this order.
+
+First, in `platform-values.yaml`, enable Authentik and set its ingress host
+to `auth.` followed by your instance's `spec.publicEndpoint.baseDomain`
+value. The operator derives the OAuth issuer hostname from the base domain,
+so the two must agree. The generated platform values already contain the
+`authentikChart` sizing block that bounds the Authentik server, worker, and
+PostgreSQL for a 4 GB node; `task env:init PROFILE=edge` copies it from
+[`deploy/platform/values/edge-reference.yaml`](../../deploy/platform/values/edge-reference.yaml).
 
 ```yaml
-apiVersion: tamoss.livewyer.io/v1alpha1
-kind: Tamoss
-metadata:
-  name: tamoss-edge
-  namespace: tams
-spec:
-  profile: edge
-  publicEndpoint:
-    baseDomain: tamoss.edge
+authentik:
+  enabled: true
+  ingress:
+    host: auth.<base-domain>
+```
+
+Re-run `task env:apply` to roll out the Authentik stack.
+
+Then switch the provider on the running instance with a merge patch. The
+API server rejects a spec that carries both auth blocks, and `kubectl apply`
+does not delete the old `external` block it does not own, so on a live
+token-mode instance `task env:apply` alone fails that one-of admission
+rule; the patch must come first. The generated composition keeps the
+instance name `tamoss-edge` and the `tams` namespace from the checked-in
+edge instance manifest:
+
+```bash
+kubectl -n tams patch tamoss tamoss-edge --type=merge \
+  -p '{"spec":{"auth":{"providedBy":"authentik-blueprints","external":null}}}'
+```
+
+Finally, record the same change in `tamoss-patch.yaml` so later applies
+agree with the cluster:
+
+```yaml
+  auth:
+    providedBy: authentik-blueprints
+    external: null
+```
+
+The operator submits the blueprint, waits for the issuer, and redeploys the
+API and UI against it. The UI then redirects to the Authentik login. The
+static API token stays valid in OAuth mode: the API accepts the generated
+token as a bearer credential alongside Authentik-issued OAuth2 tokens.
+
+### Memory budget
+
+Steady-state memory use on a 4 GB ARM64 node:
+
+| Mode | Node memory used |
+| --- | --- |
+| Bearer token | ~1.9 GiB |
+| Managed OAuth | ~3.2 GiB |
+
+Bearer mode fits a 4 GB node as installed. For OAuth mode, configure
+SSD-backed swap before enabling Authentik; on a 4 GB node it is a
+requirement, not a safety margin. The generated platform values bound the
+Authentik components to fit this budget; do not lower the Authentik
+PostgreSQL memory limit, which also carries the Authentik task queue.
+
+### UI on and off
+
+The UI serves static assets from nginx and holds ~3 MiB resident, so leaving
+it enabled costs almost nothing. To disable it, add one line to the spec in
+`tamoss-patch.yaml`:
+
+```yaml
+  ui:
+    enabled: false
+```
+
+Removing the line (or setting `true`) restores the UI on the next reconcile.
+
+### Storage
+
+```yaml
   backends:
     db:
       cnpg:
@@ -97,6 +218,44 @@ spec:
 
 Use larger PVC sizes on 128 GB or larger SSDs, and make backup ownership
 explicit before accepting durable data.
+
+## Validate
+
+```bash
+task e2e:deployed PROFILE=edge KUBECONFIG="$KUBECONFIG"
+```
+
+The checked-in target file behind this command,
+[`tests/targets/edge.env`](../../tests/targets/edge.env), carries the Kind
+validation hostnames. For a remote node whose hostnames differ, copy
+[`tests/targets/remote.env.example`](../../tests/targets/remote.env.example)
+into the environment directory, set the API, UI, and auth URLs plus
+`TEST_TAMOSS_TOKEN_SECRET=tams-api-token` and
+`TEST_TAMOSS_CR_NAME=tamoss-edge`, and point the checks at it:
+
+```bash
+task e2e:deployed PROFILE=edge KUBECONFIG="$KUBECONFIG" \
+  TARGET_ENV=deploy/environments/my-edge/target.env
+```
+
+To validate the OAuth mode, apply the two [Key Settings](#key-settings)
+changes to the environment and run the same deployed checks. The UI check
+expects a redirect to the Authentik login instead of a direct 200.
+
+The deployed checks exercise the API with the bearer token, certificate
+state, and UI availability against the running instance.
+
+## Operate
+
+The profile also sets the following operator defaults:
+
+- One replica each of API, worker, and UI.
+- One CNPG PostgreSQL instance with a 10 GiB volume.
+- One RustFS server with four 10 GiB volumes and disk checks bypassed for
+  single-node local storage.
+- Reduced API and worker runtime pools.
+- Longer worker probe timeouts for ARM startup latency.
+- TLS from `ClusterIssuer/tamoss-edge-selfsigned`.
 
 See also:
 

--- a/docs/getting-started/local-kind.md
+++ b/docs/getting-started/local-kind.md
@@ -1,14 +1,14 @@
 # Local Kind
 
-Use this local Kind path to evaluate TAMOSS with the same operator flow used by
-the other profiles.
+Use this local [Kind](https://kind.sigs.k8s.io/) path to evaluate TAMOSS with
+the same operator flow used by the other profiles.
 
-## Prerequisites
+## Requirements
 
 - Docker or a compatible container runtime.
-- `aqua` for the pinned toolchain, or equivalent versions of Task, Kind,
-  kubectl, Go, uv, node, jq, and yamlfmt.
-- `curl`, `openssl`, and `git`.
+- [`aqua`](https://aquaproj.github.io/) for the pinned toolchain, or
+  equivalent versions of Task, Kind, kubectl, Helm, Helmfile, uv, yq, and jq.
+- `curl` and `git`.
 
 `aqua install` installs the pinned command-line tools used by the tasks. It
 does not preinstall project virtualenvs or browser binaries; validation tasks
@@ -25,15 +25,18 @@ task kind:up PROFILE=local-kind
 
 `task kind:up PROFILE=local-kind` does the following:
 
-1. Create or reuse the Kind cluster from `deploy/kind.yaml`.
-2. Build and load local API, UI, and operator images.
-3. Apply the Helmfile-managed platform from
+1. Creates or reuses the Kind cluster from `deploy/kind.yaml`.
+2. Builds and loads local API, UI, and operator images.
+3. Applies the Helmfile-managed platform from
    `deploy/environments/local-kind/platform-values.yaml`.
-4. Apply the TAMOSS operator from `deploy/operator/local`.
-5. Apply the `local-kind` instance overlay.
-6. Wait for `Tamoss/tamoss-kind` to report `Ready=True`.
-7. Ingest one tiny playable demo segment through the deployed API and storage
+4. Applies the TAMOSS operator from `deploy/operator/local`.
+5. Applies the `local-kind` instance overlay.
+6. Waits for `Tamoss/tamoss-kind` to report `Ready=True`.
+7. Ingests one small playable demo segment through the deployed API and storage
    backend, unless `KIND_DEMO_INGEST=false` is set.
+
+`task kind:up` writes the cluster kubeconfig to `tams.kubeconfig` in the
+repository root. The commands in this guide reference it explicitly.
 
 The summary prints first-start lifecycle status, the app URL, app
 username/password, API docs URL, API token, OAuth client details, and storage
@@ -51,9 +54,21 @@ To print the same access details and current Kubernetes status again:
 task env:summary ENV_DIR=deploy/environments/local-kind KUBECONFIG=tams.kubeconfig
 ```
 
+## Key Settings
+
+Everything in this profile is bundled and disposable: self-signed TLS,
+`tamoss.localtest.me` hostnames, PostgreSQL and
+[RustFS](https://github.com/rustfs/rustfs), and the managed
+[Authentik](https://goauthentik.io/) stack, all inside one Kind cluster that
+`task kind:up` creates and
+`task kind:down` deletes. Nothing in it is intended to survive or be tuned. If
+an override matters enough to keep, it belongs in an environment directory
+targeting one of the other profiles.
+
 ## Access
 
-The local Kind profile uses Traefik on host port 443. It does not require
+The local Kind profile uses [Traefik](https://traefik.io/) on host port 443.
+It does not require
 application NodePorts or port-forwarding.
 
 - API docs: <https://api.tamoss.localtest.me/docs>

--- a/docs/getting-started/multi-server.md
+++ b/docs/getting-started/multi-server.md
@@ -3,16 +3,19 @@
 `multi-server` is the production reference profile. Use it for durable,
 multi-node self-managed Kubernetes installs.
 
-## Preflight
+## Requirements
 
 Before applying the profile, confirm:
 
 - The cluster has enough schedulable CPU, memory, and storage for replicated
   API, worker, UI, PostgreSQL, and S3 workloads.
 - A default StorageClass exists, or the `Tamoss` CR names storage classes for
-  CNPG and RustFS Operator volumes.
-- Public DNS exists for API, UI, S3, and Authentik hostnames.
-- TLS issuance is planned through cert-manager or existing TLS Secrets.
+  [CNPG](https://cloudnative-pg.io/) and
+  [RustFS](https://github.com/rustfs/rustfs) Operator volumes.
+- Public DNS exists for API, UI, S3, and
+  [Authentik](https://goauthentik.io/) hostnames.
+- TLS issuance is planned through [cert-manager](https://cert-manager.io/) or
+  existing TLS Secrets.
 - Secret management is in place for database, S3, OAuth, Authentik, and API
   token material.
 - The CNI enforces Kubernetes NetworkPolicy if you rely on the profile's
@@ -22,7 +25,7 @@ Before applying the profile, confirm:
 
 ## Install
 
-For local validation on Kind:
+For local validation on [Kind](https://kind.sigs.k8s.io/):
 
 ```bash
 task kind:up PROFILE=multi-server
@@ -47,10 +50,43 @@ task env:wait ENV=my-prod KUBECONFIG="$KUBECONFIG"
 task env:summary ENV=my-prod KUBECONFIG="$KUBECONFIG"
 ```
 
+Work through the [Key Settings](#key-settings) while editing the two
+generated files, before `task env:apply`.
+
 The platform layer installs the components enabled in
 `deploy/environments/my-prod/platform-values.yaml`. The TAMOSS operator
 reconciles the instance resources selected by the `Tamoss` CR; it does not
 install platform operators from inside a `Tamoss` reconcile.
+
+## Key Settings
+
+### High availability
+
+The profile defaults to two replicas each of API, worker, and UI with
+PodDisruptionBudgets, pod anti-affinity, and NetworkPolicies enabled, and
+three CNPG PostgreSQL instances with a 100 GiB volume each. Review these
+defaults before overriding them. Lowering replicas or removing
+PodDisruptionBudgets gives up the profile's zero-downtime upgrade behaviour.
+
+### Backups
+
+Decide backup ownership before accepting durable data. Scheduled CNPG
+backups and restore procedures are covered in
+[Backup and Restore](../operations/backup-restore.md); object storage
+replication stays with the S3 provider. For planned shutdowns of whole
+instances, see [Hibernate and Resume](../operations/hibernate-resume.md).
+
+### Identity
+
+The profile selects the managed Authentik stack by default. Set the ACME
+email and public hostnames before applying, and keep the OAuth issuer URL on
+its public hostname so browser logins and API token validation agree.
+
+## Validate
+
+```bash
+task e2e:deployed PROFILE=multi-server KUBECONFIG="$KUBECONFIG"
+```
 
 ## Operate
 

--- a/docs/getting-started/single-server.md
+++ b/docs/getting-started/single-server.md
@@ -4,17 +4,39 @@ Use `single-server` when TAMOSS runs on one Kubernetes node or a small
 self-managed cluster and should still use the same operator-managed backend
 shape as the larger profile.
 
-## Cluster Requirements
+## Requirements
 
 - A conformant Kubernetes cluster.
 - A working kubeconfig with permissions to apply platform, operator, and
   instance resources.
 - A default StorageClass or explicit storage classes in the `Tamoss` CR.
-- DNS and TLS planning for API, UI, S3, and Authentik hostnames.
+- DNS and TLS planning for API, UI, S3, and
+  [Authentik](https://goauthentik.io/) hostnames.
 
 ## Install
 
-For local validation on Kind:
+### Provision a single-node cluster
+
+Any conformant Kubernetes distribution works. On a blank Linux server,
+[K3s](https://k3s.io/) provisions a suitable single-node cluster; disable its
+bundled [Traefik](https://traefik.io/) so
+the TAMOSS platform can install the pinned Traefik release, and set
+`<node-address>` to the address you will manage the server through:
+
+```bash
+curl -sfL https://get.k3s.io | sh -s - --disable traefik --tls-san <node-address>
+ssh <user>@<node-address> sudo cat /etc/rancher/k3s/k3s.yaml \
+  | sed 's/127.0.0.1/<node-address>/' > ~/.kube/tamoss-single.yaml
+export KUBECONFIG=~/.kube/tamoss-single.yaml
+kubectl get nodes
+```
+
+Run the install commands from the workstation that holds this kubeconfig and
+a clone of this repository.
+
+### Validate the profile on Kind
+
+For local validation on [Kind](https://kind.sigs.k8s.io/):
 
 ```bash
 task kind:up PROFILE=single-server
@@ -36,19 +58,65 @@ task env:wait ENV=my-single-server KUBECONFIG="$KUBECONFIG"
 task env:summary ENV=my-single-server KUBECONFIG="$KUBECONFIG"
 ```
 
-## Configure
+Work through the [Key Settings](#key-settings) while editing the two
+generated files, before `task env:apply`.
 
-Start from a generated environment composition under `deploy/environments/<name>`.
-Use `platform-values.yaml` to select platform components, and set a public base
-domain unless you configure every public endpoint directly.
+## Key Settings
 
-The operator derives `api`, `app`, `s3`, and `auth` hostnames from that base
-domain and applies profile defaults. The remote profile defaults to
-`ClusterIssuer/tamoss-public`; set the ACME email in `platform-values.yaml`, or
-switch `tls.mode` to `existing`/`disabled` when certificate ownership is outside
-the TAMOSS platform layer. Override normal `Tamoss` YAML fields directly in
-`tamoss-patch.yaml` when you need different provider ownership, resources,
-storage, or routing.
+Start from the generated environment composition under
+`deploy/environments/<name>`. Use `platform-values.yaml` to select platform
+components, and set a public base domain unless you configure every public
+endpoint directly. The operator derives `api`, `app`, `s3`, and `auth`
+hostnames from that base domain and applies profile defaults.
+
+The profile defaults TLS to `ClusterIssuer/tamoss-public`; set the ACME email
+in `platform-values.yaml`, or switch `tls.mode` to `existing`/`disabled` when
+certificate ownership is outside the TAMOSS platform layer. Override normal
+`Tamoss` YAML fields directly in `tamoss-patch.yaml` when you need different
+provider ownership, resources, storage, or routing.
+
+### One replica of everything
+
+The profile runs one replica each of API, worker, and UI, one
+[CNPG](https://cloudnative-pg.io/) PostgreSQL
+instance, and one [RustFS](https://github.com/rustfs/rustfs) server. There
+are no PodDisruptionBudgets or
+anti-affinity rules; a node drain takes the service down until pods
+reschedule. The profile accepts that trade-off by design.
+
+### Scaling up without scaling out
+
+Raise the resources of the single pods in `tamoss-patch.yaml` when the
+defaults (API 384Mi request/768Mi limit, worker 128Mi/384Mi) run short:
+
+```yaml
+  api:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 768Mi
+      limits:
+        cpu: "2"
+        memory: 1536Mi
+  backends:
+    db:
+      cnpg:
+        resources:
+          requests:
+            memory: 1Gi
+          limits:
+            memory: 2Gi
+```
+
+When one node is no longer enough, move to `multi-server` rather than adding
+replicas here. PodDisruptionBudgets, anti-affinity, and replicated CNPG
+PostgreSQL are profile defaults there.
+
+## Validate
+
+```bash
+task e2e:deployed PROFILE=single-server KUBECONFIG="$KUBECONFIG"
+```
 
 See also:
 

--- a/docs/operations/backup-restore.md
+++ b/docs/operations/backup-restore.md
@@ -6,7 +6,8 @@ depends on the selected providers.
 ## Scope
 
 TAMOSS owns backup and restore configuration only for PostgreSQL databases
-managed through CNPG. External PostgreSQL services, RustFS, and external
+managed through [CNPG](https://cloudnative-pg.io/). External PostgreSQL
+services, [RustFS](https://github.com/rustfs/rustfs), and external
 S3-compatible object stores remain provider-owned. Configure and test those
 backups with the provider's documented tooling.
 
@@ -54,7 +55,7 @@ kubectl -n tams get tamoss tamoss-multi-server -o jsonpath='{.status.backupPolic
 Use this status as a readiness signal, not as proof that restore works. Restore
 testing remains a separate operational control.
 
-## Restore Into A New Instance
+## Restore Into a New Instance
 
 Prefer restoring into a new namespace or a new `Tamoss` instance first. This is
 the supported low-risk path because it lets operators verify recovery before
@@ -125,5 +126,6 @@ For managed RustFS Operator storage, follow RustFS backup, replication, and
 erasure-coding guidance for the selected pool layout. TAMOSS does not manage S3
 backup automation in the current operator.
 
-For managed Authentik Blueprints, back up the shared platform Authentik
+For managed [Authentik](https://goauthentik.io/) Blueprints, back up the
+shared platform Authentik
 database and the API token Secret needed to reapply managed Blueprints.

--- a/docs/operations/day-2.md
+++ b/docs/operations/day-2.md
@@ -22,8 +22,8 @@ kubectl --kubeconfig "$KUBECONFIG" -n tamoss-system logs deploy/operator-control
 | --- | --- |
 | `Ready` | Enabled workloads and required integrations are available. |
 | `Progressing` | The operator is applying resources or waiting for rollout. |
-| `BackendsReady` | Database, S3, Authentik, and dependency references are configured. |
-| `BackupPolicyReady` | Managed CNPG backup policy and continuous archiving are ready, disabled, external, or report the reason they are not usable. |
+| `BackendsReady` | Database, S3, [Authentik](https://goauthentik.io/), and dependency references are configured. |
+| `BackupPolicyReady` | Managed [CNPG](https://cloudnative-pg.io/) backup policy and continuous archiving are ready, disabled, external, or report the reason they are not usable. |
 | `SchemaMigrated` | The embedded database schema has been applied. |
 | `IdentityBlueprintSubmitted` | Managed Authentik blueprint submission has completed or is not required. |
 | `IdentityReady` | Managed or external OAuth/OIDC readiness checks pass. |
@@ -59,8 +59,8 @@ kubectl --kubeconfig "$KUBECONFIG" -n "$TAMOSS_NAMESPACE" annotate tamoss "$TAMO
 ```
 
 The operator records the consumed value, clears the schema failure counter, and
-deletes the failed migration Job before launching a new attempt. Reusing the
-same annotation value is ignored.
+deletes the failed migration Job before launching a new attempt. The operator
+ignores a reused annotation value.
 
 ## Observability
 
@@ -121,7 +121,7 @@ kubectl --kubeconfig "$KUBECONFIG" -n "$TAMOSS_NAMESPACE" patch tamoss "$TAMOSS_
   --type=merge -p '{"spec":{"api":{"replicaCount":3},"worker":{"replicaCount":3},"ui":{"replicaCount":2}}}'
 ```
 
-Manual `kubectl scale deployment ...` is temporary. The operator will reconcile
+Manual `kubectl scale deployment ...` is temporary. The operator reconciles
 managed Deployments back to the CR.
 
 ## Pausing Reconciliation
@@ -167,6 +167,6 @@ clients that use the API token.
 
 ## Drift
 
-The operator renders canonical resources from the CR on every reconcile. Manual
-edits to managed Deployments, Services, Ingresses, Jobs, ConfigMaps, and Secrets
-will be corrected unless the instance is paused.
+The operator renders canonical resources from the CR on every reconcile. It
+corrects manual edits to managed Deployments, Services, Ingresses, Jobs,
+ConfigMaps, and Secrets unless the instance is paused.

--- a/docs/operations/deletion-protection.md
+++ b/docs/operations/deletion-protection.md
@@ -1,8 +1,8 @@
 # Deletion Protection
 
 `Tamoss`, `StorageBackend`, and `TamossHibernate` resources are protected by
-admission webhooks. Kubernetes delete requests are rejected
-until the confirmation annotation is present.
+admission webhooks. The webhooks reject Kubernetes delete requests until the
+confirmation annotation is present.
 
 ## Tamoss
 
@@ -25,8 +25,9 @@ kubectl --kubeconfig "$KUBECONFIG" -n tams annotate storagebackend archive \
 kubectl --kubeconfig "$KUBECONFIG" -n tams delete storagebackend archive
 ```
 
-For managed RustFS, the operator can remove the managed bucket and database
-registration during finalization.
+For managed [RustFS](https://github.com/rustfs/rustfs), the operator can
+remove the managed bucket and database
+registration when its finalizer runs.
 
 For `external-s3`, deletion removes only TAMOSS database registration and
 operator state. The external bucket, credentials, lifecycle rules, CORS rules,
@@ -40,14 +41,14 @@ kubectl --kubeconfig "$KUBECONFIG" -n tams annotate tamosshibernate snapshot \
 kubectl --kubeconfig "$KUBECONFIG" -n tams delete tamosshibernate snapshot
 ```
 
-Operator-materialised operations (from `spec.hibernation.enabled`) carry
-the confirmation annotation already so the operator can abort its own
+Operator-materialised operations (from `spec.hibernation.enabled`) already
+carry the confirmation annotation, so the operator can abort its own
 cycles. Deleting an operation that has not reached `Completed` marks the parent
 `Tamoss` lifecycle `Failed` and lets normal reconciliation take over again;
 see [Hibernate and Resume](hibernate-resume.md) for the recovery flow.
 
-## Break Glass
+## Webhook Removal
 
 If the validating webhook is unavailable and blocks recovery, fix or reapply the
-operator first. Removing the webhook bypasses destructive-action protection and
-should be treated as break-glass only.
+operator first. Removing the webhook bypasses destructive-action protection;
+treat it as a last resort.

--- a/docs/operations/hibernate-resume.md
+++ b/docs/operations/hibernate-resume.md
@@ -3,30 +3,30 @@
 Hibernation captures the managed TAMOSS database into an external
 S3-compatible bucket as a portable, checksummed artifact, quiesces the
 workloads, and removes the database compute. Resuming bootstraps a managed
-database from such an artifact — waking the same instance, or seeding a new
-instance in another namespace or cluster.
+database from such an artifact, either waking the same instance or seeding a
+new instance in another namespace or cluster.
 
 The lifecycle is declared on the `Tamoss` spec. The operator materialises a
 `TamossHibernate` operation for each hibernation cycle; the operation records
 progress, the artifact identity, and its trusted checksum.
 
 This workflow is database-only. It does not copy TAMS media objects or
-Authentik state.
+[Authentik](https://goauthentik.io/) state.
 
-## Supported backend combinations
+## Supported Backend Combinations
 
 | Database | Media S3 | Hibernate and resume |
 | --- | --- | --- |
-| Managed (`providedBy: cnpg`) | External | **Supported** — the workflow on this page. |
-| Managed (`cnpg` or `bundled`) | Managed (RustFS) | Not supported — media would not survive. |
-| Managed (`providedBy: bundled`) | External | Not supported — capture needs the CNPG `Backup` machinery. |
-| External | External | Not needed — redeploy against the same database and bucket. |
+| Managed (`providedBy: cnpg`) | External | Supported. The workflow on this page. |
+| Managed (`cnpg` or `bundled`) | Managed ([RustFS](https://github.com/rustfs/rustfs)) | Not supported. Managed media would be lost. |
+| Managed (`providedBy: bundled`) | External | Not supported. Capture requires the [CNPG](https://cloudnative-pg.io/) `Backup` resource. |
+| External | External | Not needed. Redeploy against the same database and bucket. |
 
 The artifact captures only the database, so hibernation refuses managed
-RustFS media (the operation fails with `UnsupportedProvider`): the media
+RustFS media and the operation fails with `UnsupportedProvider`. The media
 objects would be removed with the source instance, leaving a resumed database
 referencing deleted segments. With an external database there is nothing
-managed to capture or deprovision — the database and media both outlive the
+managed to capture or deprovision. The database and media both outlive the
 instance, so deleting the `Tamoss` and redeploying with the same external
 connection details already achieves what hibernate and resume provide.
 
@@ -69,25 +69,24 @@ kubectl -n tams get tamoss tamoss-cnpg \
 ```
 
 The operation moves through `Quiescing`, `CapturingDatabase`,
-`WritingManifest`, and `DeprovisioningSource` before `Completed`; the parent
-lifecycle then reports `Hibernated` and reconciliation stays gated while
-`spec.hibernation.enabled` is true. Hibernation is destructive by design: the
-artifact in the bucket is the authoritative copy of the database once the
-source cluster is removed, so keep the default `Retain` retention until a
-resume has been verified.
+`WritingManifest`, and `DeprovisioningSource` before `Completed`. The parent
+lifecycle then reports `Hibernated`, and reconciliation stays gated while
+`spec.hibernation.enabled` is true. Hibernation is destructive by design.
+Once the source cluster is removed, the artifact in the bucket is the
+authoritative copy of the database, so keep the default `Retain` retention
+until a resume has been verified.
 
-Setting `enabled: false` again wakes the instance: the operator resolves the
+Setting `enabled: false` again wakes the instance. The operator resolves the
 most recent hibernation artifact, verifies its checksum, and bootstraps a new
 CNPG cluster from it before normal reconciliation restores the workloads.
 
-Creating a `TamossHibernate` directly (see
-`config/samples/tamoss_v1alpha1_tamosshibernate.yaml`) still works and
-behaves identically; the spec toggle is the recommended, GitOps-friendly
-path.
+Creating a `TamossHibernate` directly still works and behaves identically;
+the spec toggle is the recommended, GitOps-friendly path. See
+`operator/config/samples/tamoss_v1alpha1_tamosshibernate.yaml` for a sample.
 
-## Resume into a new instance
+## Resume Into a New Instance
 
-Declare the source on the new instance; it is honoured only while the
+Declare the source on the new instance. It is honoured only while the
 database cluster does not exist, exactly like CNPG bootstrap:
 
 ```yaml
@@ -98,7 +97,7 @@ spec:
         name: tamoss-cnpg-hibernation-1   # same-namespace TamossHibernate
 ```
 
-or, across namespaces or clusters, by artifact identity:
+Across namespaces or clusters, refer to the artifact identity instead:
 
 ```yaml
 spec:
@@ -111,8 +110,8 @@ spec:
         checksum: sha256:…   # from the TamossHibernate status.artifact.checksum
 ```
 
-The checksum is required for artifact restores: it is the trust anchor that
-the manifest in the bucket is the one the hibernation wrote. The operator
+The checksum is required for artifact restores. It proves that the manifest
+in the bucket is the one the hibernation wrote. The operator
 reads and validates the manifest (checksum, schema version, TAMS API
 compatibility, completed CNPG backup), persists the resolved source in
 `.status.lifecycle.resolvedRestore`, and renders the CNPG recovery bootstrap
@@ -120,11 +119,11 @@ from it on every reconcile. The lifecycle reports `Resuming` until the
 restored database is ready, then `Running` while the workloads finish
 starting up.
 
-If the database cluster already exists, `resumeFrom` is ignored and a
-`ResumeSourceIgnored` warning event is emitted — it can never rewire an
+If the database cluster already exists, the operator ignores `resumeFrom` and
+emits a `ResumeSourceIgnored` warning event. `resumeFrom` never replaces an
 existing database.
 
-## Artifact retention
+## Artifact Retention
 
 The hibernate `StorageBackend` controls what happens to the artifact after a
 successful resume, through `.spec.hibernate.retention.mode`:
@@ -135,67 +134,68 @@ successful resume, through `.spec.hibernate.retention.mode`:
 | `DeleteAfterResume` | Delete the artifact prefix once the restored database is ready. |
 | `TTL` | Delete the artifact prefix `.spec.hibernate.retention.ttlSecondsAfterResume` seconds after the restored database became ready. |
 
-Retention is applied by the **resumed** instance, anchored on database
-readiness: the artifact has served its purpose once the database it carried
-runs again, so cleanup is not held up by unrelated workload start-up. The
-restore completion time is recorded first and progress is reported in
+The resumed instance applies retention, anchored on database readiness.
+Cleanup does not wait for unrelated workload start-up; it proceeds once the
+database the artifact carried runs again. The restore completion time is
+recorded first and progress is reported in
 `.status.lifecycle.resolvedRestore.cleanup`. Transient deletion failures
-retry every minute with a warning event; structural problems (an invalid
-manifest key, a missing or wrong-typed StorageBackend) set the terminal
-`Blocked` phase, after which the objects must be removed manually. Cleanup
+retry every minute with a warning event. Structural problems, such as an
+invalid manifest key or a missing or wrong-typed `StorageBackend`, set the
+terminal `Blocked` phase. After that, remove the objects manually. Cleanup
 uses plain S3 list and delete calls, so it works identically on AWS S3, B2,
 RustFS, and similar stores.
 
-## Failure handling
+## Failure Handling
 
 - Waiting states (`Pending`, `ResolvingSource`, `PreparingTarget`,
   `Quiescing`, `CapturingDatabase`, `WritingManifest`,
-  `DeprovisioningSource`) poll until their dependencies settle; transient S3
-  errors during manifest upload or read stay non-terminal with the error in
+  `DeprovisioningSource`) poll until their dependencies settle. Transient S3
+  errors during manifest upload or read stay non-terminal, with the error in
   the status message.
-- A `Failed` operation is retried by annotating it with a fresh value:
+- Retry a `Failed` operation by annotating it with a fresh value:
 
   ```bash
   kubectl -n tams annotate tamosshibernate tamoss-cnpg-hibernation-1 \
     tamoss.livewyer.io/operation-retry="$(date +%s)" --overwrite
   ```
 
-  Each distinct value re-arms the operation exactly once
-  (`.status.acceptedRetry` records the last honoured value). Alternatively,
+  Each distinct value re-arms the operation exactly once;
+  `.status.acceptedRetry` records the last honoured value. Alternatively,
   toggling `spec.hibernation.enabled` off and on starts a fresh cycle with a
   new artifact.
-- While `spec.hibernation.enabled` is true the instance stays gated even if a
-  cycle fails — a failure can never implicitly restore a supposedly
-  hibernated instance. Disabling hibernation mid-capture aborts the
-  materialised operation and returns the instance to normal reconciliation.
-- A failed `resumeFrom` bootstrap (checksum mismatch, unsupported schema,
-  corrupt manifest) marks the lifecycle `Failed` with the reason; because
-  `resumeFrom` is immutable, recovery is recreating the instance with a
-  corrected source.
+- While `spec.hibernation.enabled` is true, the instance stays gated even if
+  a cycle fails. A failure never implicitly restores a hibernated instance.
+  Disabling hibernation mid-capture aborts the materialised operation and
+  returns the instance to normal reconciliation.
+- A failed `resumeFrom` bootstrap, such as a checksum mismatch, unsupported
+  schema, or corrupt manifest, marks the lifecycle `Failed` with the reason.
+  Because `resumeFrom` is immutable, recover by recreating the instance with
+  a corrected source.
 
-## Field notes
+## Field Notes
 
-- `spec.hibernation.resumeFrom` (and its nested fields) are immutable;
-  `destination` is required while `enabled` is true; `resumeFrom` must set
-  exactly one of `hibernationRef` or `artifact` — all enforced by the API
-  server.
+- The API server enforces these rules: `spec.hibernation.resumeFrom` and its
+  nested fields are immutable, `destination` is required while `enabled` is
+  true, and `resumeFrom` must set exactly one of `hibernationRef` or
+  `artifact`.
 - `TamossHibernate.spec` is immutable after creation. Operator-materialised
   operations carry the deletion confirmation annotation so the operator can
-  abort its own cycles; delete protection still applies to user-created
-  operations (see [Deletion Protection](deletion-protection.md)).
-- The parent `Tamoss` reports `.status.lifecycle` — phase, reason, message,
-  `lastTransitionTime`, `hibernationCycle`, the active/last operation
-  references, and `resolvedRestore` — plus a `LifecycleReady` condition.
+  abort its own cycles. Delete protection still applies to user-created
+  operations; see [Deletion Protection](deletion-protection.md).
+- The parent `Tamoss` reports a `LifecycleReady` condition and
+  `.status.lifecycle` with the phase, reason, message, `lastTransitionTime`,
+  `hibernationCycle`, the active and last operation references, and
+  `resolvedRestore`.
 - Keep completed `TamossHibernate` resources while any instance may still
-  `resumeFrom` them by reference; artifact-based restores only need the
+  `resumeFrom` them by reference. Artifact-based restores need only the
   bucket contents and the recorded checksum.
 
-## Current limits
+## Current Limits
 
-- `cnpgPhysical` is the implemented hibernation driver; `logicalDump` is
+- `cnpgPhysical` is the implemented hibernation driver. `logicalDump` is
   reserved for a later PostgreSQL logical dump path.
 - Provider support is limited to the combinations in
-  [Supported backend combinations](#supported-backend-combinations).
+  [Supported Backend Combinations](#supported-backend-combinations).
 - `resumeFrom` cannot restore into an existing database cluster; CNPG
   bootstrap semantics apply.
 

--- a/docs/operations/install.md
+++ b/docs/operations/install.md
@@ -16,7 +16,8 @@ task env:wait ENV=my-prod KUBECONFIG="$KUBECONFIG"
 
 The task workflow applies ordered layers. The platform layer uses
 `deploy/platform/helmfile.yaml.gotmpl` to install shared prerequisites as
-separate Helm releases, waits for the dependency operators, then applies
+separate [Helm](https://helm.sh/) releases, waits for the dependency
+operators, then applies
 TAMOSS-owned platform configuration through `deploy/platform/charts/config`.
 The platform state is built from `deploy/platform/values/defaults.yaml` plus the
 environment's `platform-values.yaml`. The operator layer installs the TAMOSS
@@ -37,9 +38,11 @@ they do not create storage backend rows during Kubernetes startup.
 
 The checked-in operator install includes leader election, voluntary leader
 release on shutdown, readiness/liveness probes, a startup probe for slower
-initial cache and webhook setup, and bounded Authentik HTTP clients. The
+initial cache and webhook setup, and bounded
+[Authentik](https://goauthentik.io/) HTTP clients. The
 manager defaults reserve `500m` CPU and `256Mi` memory with a `1` CPU and
-`512Mi` limit; tune these through a Kustomize patch only after checking
+`512Mi` limit; tune these through a [Kustomize](https://kustomize.io/) patch
+only after checking
 operator memory and CPU under your expected number of `Tamoss` resources.
 
 ## Local Convenience Path
@@ -72,7 +75,22 @@ from `deploy/instances/<profile>` and patches the `Tamoss` CR directly. Treat
 both files as the durable source of configuration for provider ownership,
 endpoints, resources, replicas, and routing.
 
-Generated remote environments default to trusted public TLS. The platform Helmfile
+`task env:init` generates this composition:
+
+```text
+deploy/environments/<name>/
+├── kustomization.yaml     # overlay: deploy/instances/<profile> plus the patch
+├── platform-values.yaml   # platform component selection for the Helmfile layer
+└── tamoss-patch.yaml      # instance overrides: profile and public base domain
+```
+
+The patch keeps the instance name `tamoss-<profile>` and the `tams`
+namespace from the checked-in instance manifest. A `multi-server`
+environment therefore contains the instance `tamoss-multi-server` in the
+`tams` namespace.
+
+Generated remote environments default to trusted public TLS. The platform
+[Helmfile](https://helmfile.readthedocs.io/)
 creates `ClusterIssuer/tamoss-public` when `tls.mode: public` is selected:
 
 ```yaml
@@ -83,7 +101,8 @@ tls:
     email: ops@example.com
 ```
 
-Use `tls.mode: existing` when cert-manager and the ClusterIssuer are managed
+Use `tls.mode: existing` when [cert-manager](https://cert-manager.io/) and
+the ClusterIssuer are managed
 outside the TAMOSS platform layer. Use `tls.mode: disabled` when TLS Secrets are
 pre-created and cert-manager annotations should be omitted from explicit
 `Tamoss` ingress overrides.
@@ -117,6 +136,48 @@ same layers in order:
 kubectl --kubeconfig "$KUBECONFIG" apply --server-side -k deploy/operator
 kubectl --kubeconfig "$KUBECONFIG" apply -k deploy/environments/<name>
 ```
+
+## Several Instances in One Environment
+
+An environment directory may hold several `Tamoss` instances on one cluster:
+one file per instance plus a shared `kustomization.yaml`, with each instance
+in its own namespace. Platform components (Authentik,
+[Traefik](https://traefik.io/), cert-manager,
+[CNPG](https://cloudnative-pg.io/),
+[RustFS](https://github.com/rustfs/rustfs) Operator) are installed once per
+cluster and shared; instance
+resources, buckets, and databases stay isolated per namespace.
+
+An environment with two instances looks like this:
+
+```text
+deploy/environments/<env>/
+├── kustomization.yaml         # lists every instance manifest below
+├── platform-values.yaml       # shared platform components, applied once
+├── prod-a.yaml                # Tamoss CR in namespace prod-a
+├── prod-a-storage.yaml        # default StorageBackend for prod-a
+├── prod-b.yaml                # Tamoss CR in namespace prod-b
+└── monitoring/
+    └── prod-a/                # optional per-instance dashboards and alerts
+```
+
+`task env:instance:apply` applies the whole kustomization; adding an
+instance is adding its manifest and listing it in `kustomization.yaml`.
+Instances using `s3.providedBy: external` need their default
+`StorageBackend` manifest alongside the CR, as `prod-a-storage.yaml` shows.
+
+## Environment Secrets
+
+The platform Authentik flow needs no secrets in the environment files: when
+`platform-values.yaml` leaves the Authentik secret key, bootstrap
+credentials, and database passwords unset, the platform chart generates that
+material in-cluster on first apply and preserves it across later applies.
+`task env:summary` prints the resolved admin credentials. Environment files
+carry secret material only when operators choose to set those values
+explicitly; in that case keep the environment directory out of version
+control, restrict file permissions, and take care with broad staging
+commands such as `git add -A` in a worktree that contains live environment
+directories.
 
 ## Expected Signals
 

--- a/docs/operations/secret-rotation.md
+++ b/docs/operations/secret-rotation.md
@@ -5,7 +5,7 @@ database and default S3 credentials. File-backed runtime secrets are kept only
 where the application intentionally reloads them during request or worker
 processing.
 
-| Secret class | Runtime path | Rotation behavior |
+| Secret class | Runtime path | Rotation behaviour |
 | --- | --- | --- |
 | API token | `TAMOSS_API_TOKEN_FILE` | Read on each authenticated request. |
 | Basic auth password | `TAMOSS_BASIC_AUTH_PASSWORD_FILE` | Read on each Basic auth request. |
@@ -13,10 +13,11 @@ processing.
 | Default S3 credentials | `TAMOSS_S3_ACCESS_KEY`, `TAMOSS_S3_SECRET_KEY` | Startup-only; rotate through the operator and roll pods. |
 | Additional StorageBackend credentials | `TAMOSS_STORAGE_BACKEND_CREDENTIALS_FILE` | Reloaded when the credential file changes. |
 | OAuth bearer validation keys | JWKS URL | Provider-owned; TAMOSS uses JWKS caching settings. |
-| TLS certificates | cert-manager or external TLS provider | Provider-owned. |
+| TLS certificates | [cert-manager](https://cert-manager.io/) or external TLS provider | Provider-owned. |
 
-Kubernetes installations should rotate referenced Secrets through the `Tamoss`
-CR or provider-owned Secret, then let the operator roll the affected workloads.
+For Kubernetes installs, rotate referenced Secrets through the `Tamoss`
+CR or the provider-owned Secret, then let the operator roll the affected
+workloads.
 
 The UI must only receive public runtime configuration. Sensitive OAuth client
 credentials, API tokens, database credentials, and S3 credentials stay in API or
@@ -25,7 +26,8 @@ worker server-side runtime files.
 ## Secret Sources
 
 Create Secrets in the namespace that contains the `Tamoss` CR unless a field
-explicitly points at a platform namespace, such as an Authentik API token
+explicitly points at a platform namespace, such as an
+[Authentik](https://goauthentik.io/) API token
 reference.
 
 Do not commit real Secret values. Use your cluster's normal secret-management

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -9,7 +9,8 @@ editing Secrets, or patching the `Tamoss` CR until the failing layer is clear.
 Before sharing diagnostics publicly, remove:
 
 - Secret values, bearer tokens, OAuth client secrets, private keys, database
-  passwords, S3 access keys, and Authentik API tokens.
+  passwords, S3 access keys, and [Authentik](https://goauthentik.io/) API
+  tokens.
 - Complete presigned S3 URLs.
 - Private hostnames or IP addresses that should not be disclosed.
 
@@ -34,14 +35,15 @@ kubectl --kubeconfig "$KUBECONFIG" -n tamoss-system logs deploy/operator-control
 
 If Gateway API CRDs are not installed, the `httproute` query can fail. In that
 case, inspect `RoutingReady` and `HostnamesReady` on the `Tamoss` resource and
-use the Gateway API section below only when `spec.httpRoute.enabled=true`.
+use [Gateway API and HTTPRoute](#gateway-api-and-httproute) only when
+`spec.httpRoute.enabled=true`.
 
 Read `Tamoss` conditions first:
 
 | Condition | Typical area |
 | --- | --- |
 | `BackendsReady=False` | Database, S3, Authentik, or prerequisite CRDs. |
-| `BackupPolicyReady=False` | Managed CNPG backup policy or archiving health. |
+| `BackupPolicyReady=False` | Managed [CNPG](https://cloudnative-pg.io/) backup policy or archiving health. |
 | `SchemaMigrated=False` | PostgreSQL or schema migration Job. |
 | `IdentityBlueprintSubmitted=False` | Managed Authentik blueprint submission. |
 | `IdentityReady=False` | Authentik or external OAuth/OIDC. |
@@ -92,7 +94,7 @@ to the same status surface:
 - `tamoss_reconcile_errors_total` and `tamoss_reconcile_duration_seconds`
   identify controller-level failures or latency.
 
-## API Startup And Readiness
+## API Startup and Readiness
 
 The API separates process health from dependency readiness:
 
@@ -105,6 +107,16 @@ The API separates process health from dependency readiness:
 Readiness checks are read-only. They query database and storage metadata state
 and perform a lightweight object-store bucket check. They do not create schema,
 create buckets, register storage backends, write media, or mutate queue state.
+
+## API Returns 503 StorageBackendMetadataMissing
+
+An instance with `spec.backends.s3.providedBy: external` has no default
+storage backend registered. The operator does not create one for external
+providers. Create a `StorageBackend` for the bucket with
+`defaultStorage: true` and wait for it to report `Ready`; the API recovers
+without a restart. See the
+[StorageBackend CR Reference](../reference/storagebackend-cr.md) for the
+required fields.
 
 ## Platform
 
@@ -185,7 +197,7 @@ The bundle includes `Tamoss`, `StorageBackend`, CNPG backup resources, workload
 objects, routes, events, CRDs, webhook configuration, current logs, and previous
 container logs when Kubernetes has them. Operator namespace objects and events
 are collected separately from instance namespace objects. `bundle.json`
-summarizes the collected `Tamoss` schema, resolved runtime version fields, and
+summarises the collected `Tamoss` schema, resolved runtime version fields, and
 first-start lifecycle phases so version and startup state are visible without
 opening the full resource dump first.
 
@@ -218,7 +230,7 @@ For external PostgreSQL:
 
 ## S3 and StorageBackend
 
-For managed RustFS Operator:
+For managed [RustFS](https://github.com/rustfs/rustfs) Operator:
 
 ```bash
 DEFAULT_STORAGEBACKEND="$(kubectl --kubeconfig "$KUBECONFIG" -n "$TAMOSS_NAMESPACE" \
@@ -240,8 +252,9 @@ reports `ObjectStoreUnreachable`, inspect the `StorageBackend` `BucketReady`,
 `DatabaseReady`, and external diagnostic conditions plus the mounted runtime
 credentials Secret.
 
-For local Kind, browser ingest uploads directly to
-`https://s3.tamoss.localtest.me`. If the browser has accepted the app origin
+For local [Kind](https://kind.sigs.k8s.io/), browser ingest uploads directly
+to `https://s3.tamoss.localtest.me`. If the browser has accepted the app
+origin
 but not the S3 origin, uploads can fail as a CORS or generic network error even
 though the backend is healthy.
 
@@ -260,7 +273,7 @@ The operator records a best-effort `ExternalS3DiagnosticReady` condition on
 external `StorageBackend` resources. `CORSMisconfigured`,
 `EndpointUnreachable`, and `TLSValidationFailed` are diagnostic warnings; they
 do not mutate external buckets and can be false positives or false negatives
-because browser behavior, presigned URL shape, and provider CORS evaluation are
+because browser behaviour, presigned URL shape, and provider CORS evaluation are
 owned by the external service. The diagnostic sends its preflight to
 `<endpoint>/<bucketName>` because S3 providers evaluate CORS rules per bucket,
 and the probed URL is included in the condition message.
@@ -361,7 +374,8 @@ already has native CORS configuration.
 
 ## TLS and Ingress
 
-The local and reference profiles expose TAMOSS through Traefik on port 443.
+The local and reference profiles expose TAMOSS through
+[Traefik](https://traefik.io/) on port 443.
 They do not require application NodePorts or application port-forwarding.
 
 ```bash

--- a/docs/operations/upgrades.md
+++ b/docs/operations/upgrades.md
@@ -12,9 +12,10 @@ overlay changes in order.
 5. Confirm the current `Tamoss` resource reports `Ready=True` and
    `Upgradeable=True`.
 
-For local validation, `task kind:e2e PROFILE=local-kind` creates a fresh Kind
-cluster with the current operator image and proves the deployed TAMS API/UI
-workflows.
+For local validation, `task kind:e2e PROFILE=local-kind` creates a fresh
+[Kind](https://kind.sigs.k8s.io/)
+cluster with the current operator image and runs the deployed TAMS API and UI
+checks.
 
 ## Sequence
 
@@ -61,6 +62,20 @@ kubectl --kubeconfig "$KUBECONFIG" apply --server-side -k deploy/operator
 kubectl --kubeconfig "$KUBECONFIG" apply -k "deploy/environments/$TAMOSS_ENV"
 ```
 
+## Upgrading a Pinned Environment Instance
+
+Environment instances pin `spec.api.image.tag` and `spec.ui.image.tag` to a
+release. To move an instance to a new release without touching the platform
+or operator layers, update the tags in the instance file, then apply the
+instance layer and wait for `Ready=True`:
+
+```bash
+task env:instance:apply ENV="$TAMOSS_ENV" KUBECONFIG="$KUBECONFIG"
+task env:wait ENV="$TAMOSS_ENV" KUBECONFIG="$KUBECONFIG"
+```
+
+Upgrade one instance at a time on shared clusters.
+
 ## Status Checks
 
 ```bash
@@ -99,15 +114,15 @@ POSTGRES_HOST=postgres POSTGRES_USER=tamoss POSTGRES_PASSWORD=secret POSTGRES_DB
 
 Fresh installs run from an empty database to the current head.
 
-## Operator Artifacts
+## Operator Manifests
 
-Maintainer commands:
+`task operator:template` renders the checked-in
+[Kustomize](https://kustomize.io/) operator install
+for review:
 
 ```bash
 task operator:template
 ```
-
-`task operator:template` renders the Kustomize operator install.
 
 ## Rollback
 
@@ -119,4 +134,4 @@ schema. Restore provider data from your backup plan when a failed migration
 requires a data rollback.
 
 For short investigations, pause reconciliation before manual edits and resume
-afterward. See [Day 2 Operations](day-2.md).
+afterwards. See [Day 2 Operations](day-2.md).

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -1,7 +1,7 @@
 # Operator
 
 The TAMOSS operator reconciles `Tamoss` and `StorageBackend` custom resources.
-Operator guidance is split across:
+Operator guidance is split across the following pages:
 
 - [Architecture](concepts/architecture.md)
 - [Install](operations/install.md)

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -20,7 +20,7 @@ These endpoints are TAMOSS operational endpoints, not BBC TAMS resources:
 
 ## Authentication
 
-The operator-generated API token is accepted as:
+The API accepts the operator-generated token as a bearer token:
 
 ```bash
 curl -k -H "Authorization: Bearer $TAMOSS_TOKEN" \

--- a/docs/reference/crd-versioning.md
+++ b/docs/reference/crd-versioning.md
@@ -29,13 +29,13 @@ resources through conversion.
 - secret material in spec needs to move to Secret references
 - StorageBackend identity, endpoint, or credential fields need a different
   shape
-- conversion behavior cannot preserve existing resources without lossy mapping
+- conversion behaviour cannot preserve existing resources without lossy mapping
 
 Direct `v1beta1` promotion is appropriate only when all of these are true:
 
 - each spec field is classified and either stable or intentionally experimental
 - immutable identity fields have API-server validation
-- defaulting behavior is documented and tested
+- defaulting behaviour is documented and tested
 - status fields are documented as observational and do not carry secret values
 - upgrade tests cover existing `v1alpha1` fixtures
 - release notes include migration guidance for deprecated or removed alpha
@@ -43,7 +43,7 @@ Direct `v1beta1` promotion is appropriate only when all of these are true:
 
 `Tamoss` and `StorageBackend` may promote on different timelines. For example,
 `StorageBackend` can become beta first if its identity and provider model is
-stable while the larger `Tamoss` profile and routing API still needs cleanup.
+stable while the larger `Tamoss` profile and routing API still need cleanup.
 
 ## Spec Field Classification
 
@@ -61,13 +61,13 @@ complete schema:
 | `.spec.profile` | Stable candidate | Profile names are core user-facing install shapes: `local-kind`, `edge`, `single-server`, `multi-server`. Any rename is breaking. |
 | `.spec.publicEndpoint` | Stable candidate | Base-domain driven endpoint derivation is the preferred low-boilerplate path. |
 | `.spec.backends.db.providedBy` | Stable candidate | `cnpg` and `external` are the supported product modes. |
-| `.spec.backends.db.cnpg` | Stable candidate | CNPG is the managed PostgreSQL provider. Backup, monitoring, storage, resources, and instance count are provider-native settings. |
+| `.spec.backends.db.cnpg` | Stable candidate | [CNPG](https://cloudnative-pg.io/) is the managed PostgreSQL provider. Backup, monitoring, storage, resources, and instance count are provider-native settings. |
 | `.spec.backends.db.external` | Stable candidate | External SQL configuration is required for RDS and similar providers. Secret references should remain the only credential path. |
 | `.spec.backends.s3.providedBy` | Stable candidate | `rustfs-operator` and `external` are the supported product modes. |
-| `.spec.backends.s3.rustfsOperator` | Stable candidate | RustFS Operator is the managed S3-compatible provider. Pool, bucket, endpoint, and credential settings map to managed resources. |
+| `.spec.backends.s3.rustfsOperator` | Stable candidate | [RustFS](https://github.com/rustfs/rustfs) Operator is the managed S3-compatible provider. Pool, bucket, endpoint, and credential settings map to managed resources. |
 | `.spec.backends.s3.external` | Stable candidate | External S3-compatible storage uses provider-owned bucket lifecycle and TAMOSS-owned runtime registration. |
 | `.spec.auth.providedBy` | Stable candidate | `authentik-blueprints`, `external`, and `none` match managed, external, and disabled authentication modes. |
-| `.spec.auth.authentikBlueprints` | Experimental | The managed Authentik shape should settle after more operational use with shared platform Authentik. |
+| `.spec.auth.authentikBlueprints` | Experimental | The managed [Authentik](https://goauthentik.io/) shape should settle after more operational use with shared platform Authentik. |
 | `.spec.auth.external.oauth2` | Stable candidate | External OAuth/OIDC is a required provider mode. |
 | `.spec.auth.trustForwardAuthHeaders` | Experimental | Header trust is security-sensitive and may need tighter naming or validation. |
 | `.spec.httpRoute` | Stable candidate | Gateway API routing is the preferred future routing surface. |
@@ -78,8 +78,8 @@ complete schema:
 | `.spec.serviceAccount` | Stable candidate | Standard Kubernetes service-account settings. |
 | `.spec.imagePullSecrets` | Stable candidate | Standard Kubernetes image-pull secret references. |
 | `.spec.secrets.apiToken.generate` | Stable candidate | Secret generation is useful for day-zero installs. |
-| `.spec.secrets.apiToken.token` | Likely to change before beta | Inline secret values in spec should be reconsidered in favor of Secret references. |
-| `.spec.advanced` | Advanced | Operator-facing escape hatches for resource patches and additional resources. Compatibility with provider CRD changes is owned by the user of the advanced field. |
+| `.spec.secrets.apiToken.token` | Likely to change before beta | Inline secret values in spec should be reconsidered in favour of Secret references. |
+| `.spec.advanced` | Advanced | Operator-facing overrides for resource patches and additional resources. Compatibility with provider CRD changes is owned by the user of the advanced field. |
 | `.spec.nameOverride` | Likely to change before beta | Naming overrides should be reviewed with `fullnameOverride` before beta. |
 | `.spec.fullnameOverride` | Stable candidate, immutable | Controls generated resource names. Already protected as immutable after creation. |
 | `.spec.paused` | Stable candidate | Pausing reconciliation is a clear operational control. |
@@ -198,9 +198,9 @@ After a public beta API exists:
 Before promoting a CRD version, review the API against these rules:
 
 - spec is desired state; status is observed state
-- destructive behavior is protected by explicit confirmation where applicable
+- destructive behaviour is protected by explicit confirmation where applicable
 - immutable identity fields are enforced by API-server validation
-- provider-specific configuration is modeled as clear discriminated shapes
+- provider-specific configuration is modelled as clear discriminated shapes
 - references point to Kubernetes resources by name and namespace where needed
 - status uses conditions with actionable reasons and messages
 - no one-shot action fields are added to spec

--- a/docs/reference/runtime-configuration.md
+++ b/docs/reference/runtime-configuration.md
@@ -27,7 +27,8 @@ Use `.spec.api`, `.spec.worker`, and `.spec.ui` for resources, scheduling,
 labels, annotations, probes, environment variables, volumes, and security
 context.
 
-`single-server` and `multi-server` default API, worker, and UI pods to run as
+`edge`, `single-server`, and `multi-server` default API, worker, and UI pods
+to run as
 non-root with runtime default seccomp, no privilege escalation, and dropped
 Linux capabilities. Override `podSecurityContext` or `securityContext` only
 when a workload image requires a different setting.
@@ -60,15 +61,19 @@ spec:
 The API image also carries the TAMOSS database migration CLI used by the
 operator schema Job. `schemaMigrationPostgresClient` remains the helper image
 for storage-backend database registration Jobs. Managed provider images are
-configured where the provider is selected. For example, CNPG PostgreSQL uses
-`.spec.backends.db.cnpg.postgresVersion` and RustFS uses
+configured where the provider is selected. For example,
+[CNPG](https://cloudnative-pg.io/) PostgreSQL uses
+`.spec.backends.db.cnpg.postgresVersion` and
+[RustFS](https://github.com/rustfs/rustfs) uses
 `.spec.backends.s3.rustfsOperator.image`.
 
 Set API and UI image tags explicitly in non-local overlays. If a tag is omitted,
-the operator resolves the image to the repo development tag (`dev`) rather than
-letting Kubernetes implicitly pull `latest`.
+the operator resolves the image to the repository development tag (`dev`) rather
+than letting Kubernetes implicitly pull `latest`.
 
-Platform controllers such as cert-manager, Traefik, Authentik, CNPG Operator,
+Platform controllers such as [cert-manager](https://cert-manager.io/),
+[Traefik](https://traefik.io/), [Authentik](https://goauthentik.io/), CNPG
+Operator,
 and RustFS Operator are installed before TAMOSS and are versioned in the
 platform dependency source, not in the `Tamoss` CR.
 

--- a/docs/reference/storagebackend-cr.md
+++ b/docs/reference/storagebackend-cr.md
@@ -60,7 +60,7 @@ spec:
 | `.spec.credentials.secretKeys.accessKey` | Secret key name for the access key. |
 | `.spec.credentials.secretKeys.secretKey` | Secret key name for the secret key. |
 | `.spec.hibernate.retention.mode` | Hibernate artifact retention mode: `Retain`, `DeleteAfterResume`, or `TTL`. Defaults to `Retain`. |
-| `.spec.hibernate.retention.ttlSecondsAfterResume` | Required when retention mode is `TTL`; seconds to wait after successful Resume before deleting the artifact prefix. |
+| `.spec.hibernate.retention.ttlSecondsAfterResume` | Required when retention mode is `TTL`; seconds to wait after a successful resume before deleting the artifact prefix. |
 
 ## Immutable and Required Fields
 
@@ -89,9 +89,10 @@ the object store is consumed.
 | `.status.resolved.credentialsSecret` | Secret name containing backend credentials. Secret values and key names are not exposed. |
 | `.status.conditions` | `Ready`, `BucketReady`, and `DatabaseReady` condition details. |
 
-## Provider Behavior
+## Provider Behaviour
 
-- `rustfs`: the operator can create and delete managed RustFS bucket resources.
+- `rustfs`: the operator can create and delete managed
+  [RustFS](https://github.com/rustfs/rustfs) bucket resources.
 - `external-s3`: the operator registers metadata and runtime credentials only.
   Bucket lifecycle, CORS, IAM, replication, backups, and bucket deletion remain
   provider-owned.
@@ -102,12 +103,20 @@ readiness, but they are not registered in the TAMS database and are not exposed
 to API or worker runtime credentials.
 
 For hibernate destinations, `.spec.hibernate.retention.mode` controls
-operator-managed cleanup of completed hibernation artifacts after Resume.
+operator-managed cleanup of completed hibernation artifacts after resume.
 Cleanup deletes the artifact prefix with S3-compatible list/delete calls, which
 keeps the operator contract portable across supported S3-compatible backends.
 Use `Retain` when provider-native lifecycle, object lock, audit retention, or
 manual review should own deletion. Use `DeleteAfterResume` or `TTL` only when
 the referenced credentials can list and delete the hibernation prefix.
+
+## Default Backend for External S3
+
+The operator materialises a default storage backend automatically only for
+managed RustFS providers. With `spec.backends.s3.providedBy: external`, create
+a `StorageBackend` with `defaultStorage: true` alongside the instance; until
+one exists the API cannot allocate storage and returns
+`StorageBackendMetadataMissing`.
 
 See [Storage Backends](../concepts/storage-backends.md).
 See [Hibernate and Resume](../operations/hibernate-resume.md) for hibernation

--- a/docs/reference/tamoss-cr.md
+++ b/docs/reference/tamoss-cr.md
@@ -40,9 +40,9 @@ spec:
 | Field | Purpose |
 | --- | --- |
 | `.spec.profile` | Selects `local-kind`, `edge`, `single-server`, or `multi-server` defaults. |
-| `.spec.publicEndpoint` | Derives public API, UI, S3, and Authentik endpoint defaults when the selected auth mode uses Authentik. |
-| `.spec.backends.db` | Selects managed CNPG or external PostgreSQL and configures database backup/restore when CNPG is used. |
-| `.spec.backends.s3` | Selects managed RustFS Operator or external S3-compatible storage for the default backend. |
+| `.spec.publicEndpoint` | Derives public API, UI, S3, and [Authentik](https://goauthentik.io/) endpoint defaults when the selected auth mode uses Authentik. |
+| `.spec.backends.db` | Selects managed [CNPG](https://cloudnative-pg.io/) or external PostgreSQL and configures database backup/restore when CNPG is used. |
+| `.spec.backends.s3` | Selects managed [RustFS](https://github.com/rustfs/rustfs) Operator or external S3-compatible storage for the default backend. |
 | `.spec.auth` | Selects Authentik Blueprints, external OAuth/OIDC, or no authentication. |
 | `.spec.api`, `.spec.ui`, `.spec.worker` | Component enablement, replicas, images, resources, scheduling, probes, env, volumes, and security context. |
 | `.spec.service`, `.spec.ingress`, `.spec.httpRoute` | Service and public routing configuration. |
@@ -90,13 +90,14 @@ origins. Exact origin values must be absolute `http` or `https` origins without
 a path, query string, or fragment.
 
 For managed RustFS backends, the operator also applies exact allowed origins to
-bucket CORS and to Traefik S3 ingress middleware. `allowedOriginRegexes` is
+bucket CORS and to [Traefik](https://traefik.io/) S3 ingress middleware.
+`allowedOriginRegexes` is
 also applied to Traefik S3 ingress middleware, but not to S3 bucket CORS. For
 `external-s3` backends, update the bucket CORS policy separately for every
 browser origin that dereferences presigned `put_url` or `get_urls`; see
 [Storage Backends](../concepts/storage-backends.md).
 
-## Immutability And Required Fields
+## Immutability and Required Fields
 
 The API server rejects updates that change `.spec.fullnameOverride` after
 creation because it controls generated Kubernetes resource names. Updates that

--- a/docs/reference/task-commands.md
+++ b/docs/reference/task-commands.md
@@ -1,7 +1,7 @@
 # Task Commands
 
 This is the supported command surface. Operator-facing workflows are listed
-first. Maintainer and helper commands are separated so internal plumbing is not
+first. Maintainer and helper commands are separated so internal tooling is not
 confused with the product install path.
 
 This page is manually maintained. Refresh it against `task -l` when task
@@ -13,7 +13,7 @@ names or descriptions change.
 
 | Command | Purpose |
 | --- | --- |
-| `task kind:up PROFILE=local-kind` | Local Kind evaluation path: build local images, create or reuse Kind, apply the operator, apply the selected `Tamoss` instance, and ingest one playable demo segment unless `KIND_DEMO_INGEST=false` is set. `PROFILE=multi-server` uses a multi-node Kind cluster. |
+| `task kind:up PROFILE=local-kind` | Local [Kind](https://kind.sigs.k8s.io/) evaluation path: build local images, create or reuse Kind, apply the operator, apply the selected `Tamoss` instance, and ingest one playable demo segment unless `KIND_DEMO_INGEST=false` is set. `PROFILE=multi-server` uses a multi-node Kind cluster. |
 | `task env:summary ENV_DIR=deploy/environments/local-kind KUBECONFIG=tams.kubeconfig` | Print lifecycle status, access URLs, app credentials, API token, OAuth client details, and storage credentials for a Kind or remote environment. |
 | `task kind:operator:reload` | Rebuild the operator image, load it into the existing Kind cluster, and restart the operator deployment without rerunning the full `task kind:up` flow. |
 | `task kind:down` | Delete the disposable Kind cluster and local runtime state. |
@@ -26,7 +26,7 @@ names or descriptions change.
 | Command | Purpose |
 | --- | --- |
 | `task env:init NAME=my-prod PROFILE=single-server DOMAIN=tamoss.example.com` | Create a remote environment composition from checked-in templates. Use `PROFILE=edge` for the ARM64 single-node profile. |
-| `task env:apply ENV=my-prod KUBECONFIG=/path/to/kubeconfig` | Apply the Helmfile platform releases, TAMOSS operator, and selected environment overlay. |
+| `task env:apply ENV=my-prod KUBECONFIG=/path/to/kubeconfig` | Apply the [Helmfile](https://helmfile.readthedocs.io/) platform releases, TAMOSS operator, and selected environment overlay. |
 | `task env:diff ENV=my-prod KUBECONFIG=/path/to/kubeconfig` | Diff the Helmfile platform releases, TAMOSS operator, and selected environment overlay. |
 | `task env:wait ENV=my-prod KUBECONFIG=/path/to/kubeconfig` | Wait for the selected environment's `Tamoss` resource to report `Ready=True`. |
 | `task env:status ENV=my-prod KUBECONFIG=/path/to/kubeconfig` | Show the selected environment's `Tamoss` status, namespace resources, routes, and recent events. |
@@ -38,10 +38,10 @@ names or descriptions change.
 | --- | --- |
 | `task e2e:deployed PROFILE=local-kind KUBECONFIG=tams.kubeconfig` | Run deployed checks against an existing target without creating a cluster; first run syncs Python test dependencies and installs Playwright Chromium. |
 | `task test:tams:deployed PROFILE=local-kind KUBECONFIG=tams.kubeconfig` | Run deployed TAMS conformance checks against an existing target without creating a cluster. |
-| `task test:media:fixtures` | Validate managed-ingest fixture timing with containerized `ffprobe`. |
+| `task test:media:fixtures` | Validate managed-ingest fixture timing with containerised `ffprobe`. |
 
 Validation commands print compact suite labels such as `test frontend.unit` and
-deployed checks such as `tams deployed.storage-object-lifecycle`. JUnit artifacts
+deployed checks such as `tams deployed.storage-object-lifecycle`. JUnit reports
 use stable `reports/junit-*.xml` names.
 
 ## Maintainer Workflows
@@ -55,7 +55,7 @@ use stable `reports/junit-*.xml` names.
 | `task deps` | Start local Compose dependencies only. |
 | `task check` | Fast confidence gate: lint plus focused tests. |
 | `task test` | Fast local test subset. |
-| `task test:smoke` | Run deployed API/UI smoke and verify the operator Chainsaw smoke labels. |
+| `task test:smoke` | Run deployed API/UI smoke and verify the operator [Chainsaw](https://kyverno.github.io/chainsaw/) smoke labels. |
 | `task lint` | Lint Python and frontend code. |
 | `task security:audit` | Run local security audits. |
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting
 
-Troubleshooting guidance now lives at
+Troubleshooting guidance lives at
 [operations/troubleshooting.md](operations/troubleshooting.md).
 
 Start with:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,13 +5,13 @@ BBC TAMS API as the authoritative protocol contract.
 
 ## Web UI
 
-After local Kind install, open:
+After local [Kind](https://kind.sigs.k8s.io/) install, open:
 
 ```text
 https://app.tamoss.localtest.me
 ```
 
-The UI can:
+The UI supports the following actions:
 
 - Browse flows, segments, objects, and service state.
 - Allocate storage and register uploaded media.
@@ -50,11 +50,11 @@ curl -k -H "Authorization: Bearer $TAMOSS_TOKEN" \
 
 ## Ingest Helper
 
-`task kind:up` creates one tiny playable demo ingest without requiring local media
+`task kind:up` creates one small playable demo ingest without requiring local media
 conversion tools. Set `KIND_DEMO_INGEST=false` when you need a clean validation
 target with no seeded flow/source. The demo segment is registered with probe-derived
 `object_timerange`, `ts_offset`, `last_duration`, and `key_frame_count`
-metadata. Browser-managed ingest also probes finalized MPEG-TS segments before
+metadata. Browser-managed ingest also probes finalised MPEG-TS segments before
 registering them, so registered segment timeranges come from measured media
 duration rather than desired segment length.
 
@@ -68,7 +68,7 @@ task ingest VIDEO=/path/to/video.mp4 LABEL="Example"
 The arbitrary ingest helper may require local media tooling such as `ffmpeg`
 because it segments user-supplied files before uploading them.
 
-Validate the checked-in managed-ingest fixture through containerized media
+Validate the checked-in managed-ingest fixture through containerised media
 tooling:
 
 ```bash


### PR DESCRIPTION
Unifies the profile guides, golden path, and deployment lessons into one reviewed set, then closes every gap found by a clean-room install test of the edge guide on a blank ARM64 server. Merge after the edge feature branch, which the guides reference.