### PR TITLE
feat: add optional node memory budget assertion to deployed checks

### DIFF
--- a/docs/getting-started/edge.md
+++ b/docs/getting-started/edge.md
@@ -243,7 +243,10 @@ changes to the environment and run the same deployed checks. The UI check
 expects a redirect to the Authentik login instead of a direct 200.
 
 The deployed checks exercise the API with the bearer token, certificate
-state, and UI availability against the running instance.
+state, and UI availability against the running instance. Set
+`TEST_TAMOSS_MEMORY_BUDGET_MIB` in the target file (the remote example uses
+3500) to also assert that `kubectl top node` memory usage stays below that
+budget.
 
 ## Operate
 

--- a/tests/e2e/reporting.py
+++ b/tests/e2e/reporting.py
@@ -19,6 +19,9 @@ _E2E_CHECK_IDS = {
         "e2e ui.ingress-auth-proxy"
     ),
     "test_deployed_cert_manager_certificates_are_ready": "e2e platform.certificates",
+    "test_deployed_node_memory_usage_stays_within_budget": (
+        "e2e platform.memory-budget"
+    ),
     "test_deployed_oauth2_client_credentials_token_grants_api_access": (
         "e2e auth.oauth2-client-scoped"
     ),

--- a/tests/e2e/target.py
+++ b/tests/e2e/target.py
@@ -66,6 +66,7 @@ class E2ETarget:
     readiness_mode: str
     upload_checksum_header: bool
     timeout_seconds: float = 10.0
+    memory_budget_mib: int | None = None
 
     @classmethod
     def from_file(cls, path: Path) -> E2ETarget:
@@ -144,6 +145,9 @@ class E2ETarget:
                 values.get("TEST_TAMOSS_UPLOAD_CHECKSUM_HEADER", "true")
             ),
             timeout_seconds=float(values.get("TEST_TIMEOUT_SECONDS", "10")),
+            memory_budget_mib=_memory_budget_mib(
+                values.get("TEST_TAMOSS_MEMORY_BUDGET_MIB")
+            ),
         )
 
 
@@ -250,6 +254,20 @@ def _readiness_mode(value: str) -> str:
             "TEST_TAMOSS_READINESS_MODE must be 'tamoss' or 'service'."
         )
     return mode
+
+
+def _memory_budget_mib(raw: str | None) -> int | None:
+    if raw is None or not raw.strip():
+        return None
+    try:
+        value = int(raw.strip())
+    except ValueError:
+        value = 0
+    if value <= 0:
+        raise pytest.UsageError(
+            "TEST_TAMOSS_MEMORY_BUDGET_MIB must be a positive integer number of MiB."
+        )
+    return value
 
 
 def _load_auth_password(

--- a/tests/e2e/test_deployed_webhooks_and_ui.py
+++ b/tests/e2e/test_deployed_webhooks_and_ui.py
@@ -6,7 +6,7 @@ import time
 from contextlib import suppress
 from pathlib import Path
 from string import Template
-from subprocess import CompletedProcess
+from subprocess import CalledProcessError, CompletedProcess
 from typing import Any
 from uuid import uuid4
 
@@ -181,6 +181,38 @@ def test_deployed_cert_manager_certificates_are_ready(e2e_target: E2ETarget) -> 
         assert ready.get("status") == "True", (
             f"Certificate {namespace}/{name} is not Ready: {ready}"
         )
+
+
+_MEMORY_UNIT_MIB = {"Ki": 1 / 1024, "Mi": 1.0, "Gi": 1024.0, "Ti": 1024.0 * 1024.0}
+
+
+def test_deployed_node_memory_usage_stays_within_budget(
+    e2e_target: E2ETarget,
+) -> None:
+    if e2e_target.memory_budget_mib is None:
+        pytest.skip("no TEST_TAMOSS_MEMORY_BUDGET_MIB configured for this target")
+    if not e2e_target.kubeconfig:
+        pytest.skip("node memory checks require Kubernetes access")
+
+    try:
+        result = _kubectl_for_target(e2e_target, "top", "node", "--no-headers")
+    except CalledProcessError as exc:
+        pytest.fail(f"kubectl top node failed: {exc.stderr or exc}")
+    rows = [line.split() for line in result.stdout.splitlines() if line.strip()]
+    assert rows, "kubectl top node returned no nodes"
+    for row in rows:
+        node_name, memory_raw = row[0], row[3]
+        memory_mib = _memory_quantity_to_mib(memory_raw)
+        assert memory_mib < e2e_target.memory_budget_mib, (
+            f"Node {node_name} memory usage {memory_raw} is not below the "
+            f"{e2e_target.memory_budget_mib}Mi budget"
+        )
+
+
+def _memory_quantity_to_mib(raw: str) -> float:
+    match = re.fullmatch(r"(\d+)(Ki|Mi|Gi|Ti)", raw)
+    assert match, f"Unrecognised kubectl top memory quantity: {raw!r}"
+    return int(match.group(1)) * _MEMORY_UNIT_MIB[match.group(2)]
 
 
 def test_deployed_oauth2_client_credentials_token_grants_api_access(

--- a/tests/e2e/test_target_env.py
+++ b/tests/e2e/test_target_env.py
@@ -65,6 +65,7 @@ def test_target_env_loads_token_command_and_service_readiness(
                 f"TEST_TAMOSS_TOKEN_COMMAND={token_command}",
                 "TEST_TAMOSS_READINESS_MODE=service",
                 "TEST_TAMOSS_UPLOAD_CHECKSUM_HEADER=false",
+                "TEST_TAMOSS_MEMORY_BUDGET_MIB=3500",
             ]
         ),
         encoding="utf-8",
@@ -75,6 +76,26 @@ def test_target_env_loads_token_command_and_service_readiness(
     assert loaded.auth_headers == {"Authorization": "Bearer command-token"}
     assert loaded.readiness_mode == "service"
     assert loaded.upload_checksum_header is False
+    assert loaded.memory_budget_mib == 3500
+
+
+def test_target_env_rejects_non_positive_memory_budget(tmp_path: Path) -> None:
+    target = tmp_path / "target.env"
+    target.write_text(
+        "\n".join(
+            [
+                "TEST_TAMOSS_API=https://api.example.test",
+                "TEST_TAMOSS_UI=https://ui.example.test",
+                "TEST_TAMOSS_AUTH_PASSWORD=unused",
+                "TEST_TAMOSS_TOKEN=token",
+                "TEST_TAMOSS_MEMORY_BUDGET_MIB=0",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(pytest.UsageError, match="MEMORY_BUDGET_MIB"):
+        E2ETarget.from_file(target)
 
 
 def test_target_env_rejects_unknown_readiness_mode(tmp_path: Path) -> None:

--- a/tests/targets/remote.env.example
+++ b/tests/targets/remote.env.example
@@ -23,6 +23,10 @@ TEST_TAMOSS_TOKEN=
 # Set to false for targets whose storage rejects the upload checksum header.
 # TEST_TAMOSS_UPLOAD_CHECKSUM_HEADER=true
 
+# Optional node memory ceiling for constrained targets: when set, the
+# deployed checks assert `kubectl top node` usage stays below this many MiB.
+TEST_TAMOSS_MEMORY_BUDGET_MIB=3500
+
 # Browser UI E2E authenticates through the public UI/Auth ingress.
 TEST_TAMOSS_AUTH_USER=akadmin
 TEST_TAMOSS_AUTH_PASSWORD=


### PR DESCRIPTION
When TEST_TAMOSS_MEMORY_BUDGET_MIB is set in a target env, the deployed suite asserts kubectl top node memory usage stays below that budget; the remote example target sets 3500 for edge-class nodes. Validated live against the standing edge box.