### PR TITLE
fix: default the single-server profile RustFS disk check for single-disk hosts

### DIFF
--- a/docs/getting-started/single-server.md
+++ b/docs/getting-started/single-server.md
@@ -71,7 +71,9 @@ hostnames from that base domain and applies profile defaults.
 
 The profile defaults TLS to `ClusterIssuer/tamoss-public`; set the ACME email
 in `platform-values.yaml`, or switch `tls.mode` to `existing`/`disabled` when
-certificate ownership is outside the TAMOSS platform layer. Override normal
+certificate ownership is outside the TAMOSS platform layer. Switch `tls.mode`
+to `selfSigned` when port 80 is not reachable from the public internet, as
+ACME HTTP-01 issuance needs it. Override normal
 `Tamoss` YAML fields directly in `tamoss-patch.yaml` when you need different
 provider ownership, resources, storage, or routing.
 
@@ -117,6 +119,17 @@ PostgreSQL are profile defaults there.
 ```bash
 task e2e:deployed PROFILE=single-server KUBECONFIG="$KUBECONFIG"
 ```
+
+The checked-in target file behind this command,
+[`tests/targets/single-server.env`](../../tests/targets/single-server.env),
+carries the Kind validation hostnames; for a remote server whose hostnames
+differ, copy
+[`tests/targets/remote.env.example`](../../tests/targets/remote.env.example)
+into the environment directory, set the API, UI, and auth URLs plus
+`TEST_TAMOSS_TOKEN_SECRET=tams-api-token` and
+`TEST_TAMOSS_CR_NAME=tamoss-single-server`, and pass
+`TARGET_ENV=deploy/environments/my-single-server/target.env` to the same
+command.
 
 See also:
 

--- a/operator/internal/controller/defaults/profile.go
+++ b/operator/internal/controller/defaults/profile.go
@@ -121,6 +121,9 @@ func applySingleServer(tamoss *tamossv1alpha1.Tamoss) {
 
 	defaultCNPG(tamoss, 1, "50Gi", false, false)
 	defaultRustFSOperator(tamoss, 1, 4, "100Gi")
+	// A single server places all four erasure volumes on one physical disk,
+	// which RustFS rejects unless the disk-distinctness check is bypassed.
+	setRustFSEnvDefault(tamoss, "RUSTFS_UNSAFE_BYPASS_DISK_CHECK", "true")
 }
 
 func applyEdge(tamoss *tamossv1alpha1.Tamoss) {

--- a/operator/internal/controller/defaults/profile_test.go
+++ b/operator/internal/controller/defaults/profile_test.go
@@ -219,6 +219,9 @@ func TestApplySingleServerManagedBackendDefaults(t *testing.T) {
 		rustfs.Pools[0].Storage.Size != "100Gi" {
 		t.Fatalf("unexpected single-server RustFS Operator defaults: %#v", rustfs)
 	}
+	if got := rustFSEnvValue(rustfs, "RUSTFS_UNSAFE_BYPASS_DISK_CHECK"); got != "true" {
+		t.Fatalf("expected single-server RustFS disk check bypass, got %q", got)
+	}
 	assertRestrictedWorkloadSecurity(t, tamoss.Spec.API.WorkloadCommonSpec)
 	assertRestrictedWorkloadSecurity(t, tamoss.Spec.Worker.WorkloadCommonSpec)
 	assertRestrictedWorkloadSecurity(t, tamoss.Spec.UI.WorkloadCommonSpec)


### PR DESCRIPTION
The single-server profile omitted the RUSTFS_UNSAFE_BYPASS_DISK_CHECK default that local-kind and edge already set, so the default install crashlooped RustFS on hosts where all four erasure volumes share one physical disk. Adds the default with a unit test, and documents the selfSigned TLS option and the remote validation target flow in the single-server guide.