### PR TITLE
fix: make the mainline golden path self-consistent

### DIFF
--- a/.github/workflows/docker-hub.yaml
+++ b/.github/workflows/docker-hub.yaml
@@ -45,14 +45,27 @@ jobs:
       - name: Resolve operator build metadata
         id: build-version
         shell: bash
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
             version="${GITHUB_REF_NAME#v}"
             python3 .github/scripts/release-metadata.py "${version}" >> "$GITHUB_OUTPUT"
           else
-            echo "version=dev" >> "$GITHUB_OUTPUT"
+            # Non-tag builds publish images tagged after the ref (:main for
+            # mainline pushes, :pr-N for internal PRs), so bake that same tag
+            # as the version instead of "dev". The TAMS API version comes from
+            # the newest compatibility release rather than a hard-coded value,
+            # which is how branch builds previously went stale at 8.0.
+            if [ -n "${PR_NUMBER}" ]; then
+              version="pr-${PR_NUMBER}"
+            else
+              version="$(printf '%s' "${GITHUB_REF_NAME}" | sed 's![^a-zA-Z0-9._-]!-!g')"
+            fi
+            tams_api="$(python3 -c 'import json; print(json.load(open("operator/compatibility.yaml"))["releases"][-1]["tamsAPI"])')"
+            echo "version=${version}" >> "$GITHUB_OUTPUT"
             echo "schema_revision=dev" >> "$GITHUB_OUTPUT"
-            echo "tams_api=8.0" >> "$GITHUB_OUTPUT"
+            echo "tams_api=${tams_api}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Extract Git metadata
@@ -219,15 +232,32 @@ jobs:
       - name: Resolve build version
         id: build-version
         shell: bash
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
             version="${GITHUB_REF_NAME#v}"
             python3 .github/scripts/release-metadata.py "${version}" >> "$GITHUB_OUTPUT"
           else
-            echo "version=dev" >> "$GITHUB_OUTPUT"
+            # Non-tag builds publish images tagged after the ref (:main for
+            # mainline pushes, :pr-N for internal PRs), so bake that same tag
+            # as the version instead of "dev": OPERAND_VERSION then defaults
+            # operands to images this workflow actually publishes. The TAMS
+            # API version comes from the newest compatibility release rather
+            # than a hard-coded value, which is how branch builds previously
+            # went stale at 8.0. The schema revision stays on the "dev"
+            # development marker because branch builds are not a released
+            # schema.
+            if [ -n "${PR_NUMBER}" ]; then
+              version="pr-${PR_NUMBER}"
+            else
+              version="$(printf '%s' "${GITHUB_REF_NAME}" | sed 's![^a-zA-Z0-9._-]!-!g')"
+            fi
+            tams_api="$(python3 -c 'import json; print(json.load(open("operator/compatibility.yaml"))["releases"][-1]["tamsAPI"])')"
+            echo "version=${version}" >> "$GITHUB_OUTPUT"
             echo "schema_revision=dev" >> "$GITHUB_OUTPUT"
             echo "previous_schema_revision=" >> "$GITHUB_OUTPUT"
-            echo "tams_api=8.0" >> "$GITHUB_OUTPUT"
+            echo "tams_api=${tams_api}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Extract Git metadata

--- a/docs/getting-started/edge.md
+++ b/docs/getting-started/edge.md
@@ -244,9 +244,15 @@ expects a redirect to the Authentik login instead of a direct 200.
 
 The deployed checks exercise the API with the bearer token, certificate
 state, and UI availability against the running instance. Set
-`TEST_TAMOSS_MEMORY_BUDGET_MIB` in the target file (the remote example uses
-3500) to also assert that `kubectl top node` memory usage stays below that
-budget.
+`TEST_TAMOSS_MEMORY_BUDGET_MIB` in the target file (the remote example shows
+an edge-sized 3500) to also assert that `kubectl top node` memory usage
+stays below that budget.
+
+A fresh install has no demo media, so seed it first with the demo ingest
+helper that `task kind:up` runs —
+[`.tasks/lib/demo_ingest.sh`](../../.tasks/lib/demo_ingest.sh)
+`<target.env> <media-file> <kubeconfig>` — or expect the deployed media
+checks to fail on the first run.
 
 ## Operate
 

--- a/docs/getting-started/single-server.md
+++ b/docs/getting-started/single-server.md
@@ -131,6 +131,12 @@ into the environment directory, set the API, UI, and auth URLs plus
 `TARGET_ENV=deploy/environments/my-single-server/target.env` to the same
 command.
 
+A fresh install has no demo media, so seed it first with the demo ingest
+helper that `task kind:up` runs —
+[`.tasks/lib/demo_ingest.sh`](../../.tasks/lib/demo_ingest.sh)
+`<target.env> <media-file> <kubeconfig>` — or expect the deployed media
+checks to fail on the first run.
+
 See also:
 
 - [Profiles](../concepts/profiles.md)

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -8,8 +8,8 @@ ARG SCHEMA_VERSION
 ARG PREVIOUS_SCHEMA_VERSION
 ARG TAMS_API_VERSION=8.1
 # Operand image tag the operator defaults to when a Tamoss spec omits one.
-# Release builds pass the release version; otherwise operands default to the
-# published "dev" tag.
+# CI passes the image tag it publishes for the build (release version, :main,
+# or :pr-N); plain local builds fall back to "dev".
 ARG OPERAND_VERSION=""
 
 WORKDIR /workspace/operator

--- a/operator/internal/controller/defaults/profile.go
+++ b/operator/internal/controller/defaults/profile.go
@@ -112,6 +112,10 @@ func applySingleServer(tamoss *tamossv1alpha1.Tamoss) {
 	})
 	setBool(&tamoss.Spec.Worker.Enabled, true)
 	setEnvDefault(&tamoss.Spec.UI.Env, "TAMOSS_API_URL", "/api")
+	// Single-server hosts can be as small as edge boxes (the base 5s exec
+	// probe timeout crashlooped the worker on a 2-vCPU ARM host), so apply
+	// the same relaxed worker probe timings as edge.
+	defaultRelaxedWorkerProbes(&tamoss.Spec.Worker.WorkloadCommonSpec)
 	defaultWorkloadResources(&tamoss.Spec.API.WorkloadCommonSpec, "250m", "384Mi", "1", "768Mi")
 	defaultWorkloadResources(&tamoss.Spec.Worker.WorkloadCommonSpec, "100m", "128Mi", "500m", "384Mi")
 	defaultWorkloadResources(&tamoss.Spec.UI.WorkloadCommonSpec, "25m", "32Mi", "200m", "128Mi")
@@ -151,7 +155,7 @@ func applyEdge(tamoss *tamossv1alpha1.Tamoss) {
 	setEnvDefault(&tamoss.Spec.Worker.Env, "TAMOSS_DATABASE_POOL_MAX_SIZE", "3")
 	setEnvDefault(&tamoss.Spec.Worker.Env, "TAMOSS_WEBHOOK_ALLOWED_HOSTS", ".svc.cluster.local")
 	setEnvDefault(&tamoss.Spec.UI.Env, "TAMOSS_API_URL", "/api")
-	defaultEdgeWorkerProbes(&tamoss.Spec.Worker.WorkloadCommonSpec)
+	defaultRelaxedWorkerProbes(&tamoss.Spec.Worker.WorkloadCommonSpec)
 	defaultWorkloadResources(&tamoss.Spec.API.WorkloadCommonSpec, "100m", "192Mi", "600m", "384Mi")
 	defaultWorkloadResources(&tamoss.Spec.Worker.WorkloadCommonSpec, "100m", "128Mi", "500m", "384Mi")
 	defaultWorkloadResources(&tamoss.Spec.UI.WorkloadCommonSpec, "25m", "32Mi", "150m", "96Mi")
@@ -483,7 +487,11 @@ func defaultWorkerProbes(spec *tamossv1alpha1.WorkloadCommonSpec) {
 	}
 }
 
-func defaultEdgeWorkerProbes(spec *tamossv1alpha1.WorkloadCommonSpec) {
+// defaultRelaxedWorkerProbes stretches the worker exec probe periods and
+// timeouts for profiles that run on small hosts (edge, single-server), where
+// forking the probe interpreter can exceed the base 5s timeout and crashloop
+// an otherwise healthy worker.
+func defaultRelaxedWorkerProbes(spec *tamossv1alpha1.WorkloadCommonSpec) {
 	command := []string{"/bin/uv", "run", "python", "-m", "tamoss.worker", "health"}
 	if spec.ReadinessProbe == nil {
 		spec.ReadinessProbe = execProbe(command, 30, 30, 3)

--- a/operator/internal/controller/defaults/profile_test.go
+++ b/operator/internal/controller/defaults/profile_test.go
@@ -222,6 +222,21 @@ func TestApplySingleServerManagedBackendDefaults(t *testing.T) {
 	if got := rustFSEnvValue(rustfs, "RUSTFS_UNSAFE_BYPASS_DISK_CHECK"); got != "true" {
 		t.Fatalf("expected single-server RustFS disk check bypass, got %q", got)
 	}
+	if got := tamoss.Spec.Worker.ReadinessProbe.TimeoutSeconds; got != 30 {
+		t.Fatalf("expected single-server worker readiness timeout 30, got %d", got)
+	}
+	if got := tamoss.Spec.Worker.ReadinessProbe.PeriodSeconds; got != 30 {
+		t.Fatalf("expected single-server worker readiness period 30, got %d", got)
+	}
+	if got := tamoss.Spec.Worker.LivenessProbe.PeriodSeconds; got != 60 {
+		t.Fatalf("expected single-server worker liveness period 60, got %d", got)
+	}
+	if got := tamoss.Spec.Worker.LivenessProbe.TimeoutSeconds; got != 30 {
+		t.Fatalf("expected single-server worker liveness timeout 30, got %d", got)
+	}
+	if got := tamoss.Spec.Worker.StartupProbe.TimeoutSeconds; got != 30 {
+		t.Fatalf("expected single-server worker startup timeout 30, got %d", got)
+	}
 	assertRestrictedWorkloadSecurity(t, tamoss.Spec.API.WorkloadCommonSpec)
 	assertRestrictedWorkloadSecurity(t, tamoss.Spec.Worker.WorkloadCommonSpec)
 	assertRestrictedWorkloadSecurity(t, tamoss.Spec.UI.WorkloadCommonSpec)

--- a/tests/targets/remote.env.example
+++ b/tests/targets/remote.env.example
@@ -25,7 +25,8 @@ TEST_TAMOSS_TOKEN=
 
 # Optional node memory ceiling for constrained targets: when set, the
 # deployed checks assert `kubectl top node` usage stays below this many MiB.
-TEST_TAMOSS_MEMORY_BUDGET_MIB=3500
+# The 3500 figure is sized for a 4 GB edge box; opt in per target.
+# TEST_TAMOSS_MEMORY_BUDGET_MIB=3500
 
 # Browser UI E2E authenticates through the public UI/Auth ingress.
 TEST_TAMOSS_AUTH_USER=akadmin


### PR DESCRIPTION
Branch builds of main now bake the ref-consistent version (a :main operator defaults to :main operands and /service reports TAMS 8.1 resolved from the compatibility manifest), while tag builds keep resolving release metadata exactly as before. Also relaxes the single-server worker probe defaults to the edge timings for small hosts, makes the edge-sized memory budget example opt-in per target, and documents demo media seeding before the deployed media checks.