### PR TITLE
chore: add 8.1.0-oss5 release metadata

### DIFF
--- a/operator/compatibility.yaml
+++ b/operator/compatibility.yaml
@@ -74,6 +74,17 @@
           "8.1.0-oss3"
         ]
       }
+    },
+    {
+      "version": "8.1.0-oss5",
+      "tamsAPI": "8.1",
+      "schemaRevision": "8.1.0-oss2",
+      "upgrade": {
+        "class": "APIOnly",
+        "from": [
+          "8.1.0-oss4"
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
Release metadata for 8.1.0-oss5: TAMS API 8.1, schema revision 8.1.0-oss2, APIOnly upgrade from 8.1.0-oss4.