### PR TITLE
feat: target individual instances within an environment

### DIFF
--- a/.tasks/env.yaml
+++ b/.tasks/env.yaml
@@ -13,6 +13,7 @@ vars:
       else
         printf '\n'
       fi
+  INSTANCE: '{{default "" (default (env "INSTANCE") .INSTANCE)}}'
   PLATFORM_HELMFILE: '{{default "deploy/platform/helmfile.yaml.gotmpl" .PLATFORM_HELMFILE}}'
   PLATFORM_TIMEOUT: '{{default "15m" .PLATFORM_TIMEOUT}}'
   OPERATOR_KUSTOMIZE_DIR: '{{default "deploy/operator" .OPERATOR_KUSTOMIZE_DIR}}'
@@ -136,8 +137,33 @@ tasks:
           "{{.OPERATOR_KUSTOMIZE_DIR}}" \
           "{{.PLATFORM_TIMEOUT}}"
 
+  instance:init:
+    desc: "Instance: add a Tamoss instance to an existing environment"
+    silent: true
+    requires:
+      vars: [INSTANCE, PROFILE, DOMAIN]
+    vars:
+      NAMESPACE: '{{default "" (default (env "NAMESPACE") .NAMESPACE)}}'
+    preconditions:
+      - sh: command -v yq
+        msg: "yq required"
+      - sh: test -n "{{.ENV_DIR}}"
+        msg: "ENV or ENV_DIR is required"
+      - sh: test -d "{{.ENV_DIR}}"
+        msg: "environment dir {{.ENV_DIR}} not found"
+    cmds:
+      - |
+        set -euo pipefail
+        . .tasks/lib/env.sh
+        task_init_env_instance \
+          "{{.ENV_DIR}}" \
+          "{{.INSTANCE}}" \
+          "{{.PROFILE}}" \
+          "{{.DOMAIN}}" \
+          "{{.NAMESPACE}}"
+
   wait:
-    desc: "Environment: wait for the Tamoss instance to become ready"
+    desc: "Environment: wait for Tamoss instances to become ready"
     silent: true
     requires:
       vars: [KUBECONFIG]
@@ -156,7 +182,7 @@ tasks:
       - |
         set -euo pipefail
         . .tasks/lib/env.sh
-        task_wait_env "{{.ENV_DIR}}" "{{.KUBECONFIG}}" "{{.TIMEOUT}}"
+        task_wait_env "{{.ENV_DIR}}" "{{.KUBECONFIG}}" "{{.TIMEOUT}}" "{{.INSTANCE}}"
 
   status:
     desc: "Environment: show Tamoss status and namespace resources"
@@ -166,6 +192,8 @@ tasks:
     preconditions:
       - sh: command -v kubectl
         msg: "kubectl required"
+      - sh: command -v yq
+        msg: "yq required"
       - sh: test -n "{{.ENV_DIR}}"
         msg: "ENV or ENV_DIR is required"
       - sh: test -d "{{.ENV_DIR}}"
@@ -174,7 +202,7 @@ tasks:
       - |
         set -euo pipefail
         . .tasks/lib/env.sh
-        task_show_env_status "{{.ENV_DIR}}" "{{.KUBECONFIG}}"
+        task_show_env_status "{{.ENV_DIR}}" "{{.KUBECONFIG}}" "{{.INSTANCE}}"
 
   summary:
     desc: "Environment: print access URLs, credentials, OAuth details, and lifecycle status"
@@ -196,7 +224,7 @@ tasks:
       - |
         set -euo pipefail
         . .tasks/lib/env.sh
-        task_print_env_summary "{{.ENV_DIR}}" "{{.KUBECONFIG}}" "{{.TARGET_ENV}}"
+        task_print_env_summary "{{.ENV_DIR}}" "{{.KUBECONFIG}}" "{{.TARGET_ENV}}" "{{.INSTANCE}}"
 
   diff:
     desc: "Environment: diff Helmfile platform releases, operator, and Tamoss resources"

--- a/.tasks/lib/env.sh
+++ b/.tasks/lib/env.sh
@@ -16,7 +16,8 @@ fi
 task_tamoss_field_from_rendered() {
   local rendered="$1"
   local field="$2"
-  local query
+  local instance="${3:-}"
+  local query selection
 
   case "$field" in
     baseDomain) query='.spec.publicEndpoint.baseDomain // ""' ;;
@@ -29,9 +30,51 @@ task_tamoss_field_from_rendered() {
       ;;
   esac
 
-  yq -r "select(.kind == \"Tamoss\") | ${query}" "$rendered" \
+  selection='select(.kind == "Tamoss")'
+  if [ -n "$instance" ]; then
+    selection="${selection} | select(.metadata.name == \"${instance}\")"
+  fi
+
+  yq -r "${selection} | ${query}" "$rendered" \
     | sed '/^---$/d; /^$/d' \
     | sed -n '1p'
+}
+
+# task_tamoss_names_from_rendered lists every Tamoss instance in a rendered
+# environment, in the order the environment composes them.
+task_tamoss_names_from_rendered() {
+  local rendered="$1"
+
+  yq -r 'select(.kind == "Tamoss") | .metadata.name // ""' "$rendered" \
+    | sed '/^---$/d; /^$/d'
+}
+
+# task_tamoss_instances_for resolves which instances a command acts on. With no
+# requested instance every instance in the environment is returned, so
+# single-instance environments behave as before and multi-instance environments
+# report on all of them. A requested instance must exist in the environment.
+task_tamoss_instances_for() {
+  local rendered="$1"
+  local requested="${2:-}"
+  local names
+
+  names="$(task_tamoss_names_from_rendered "$rendered")"
+  if [ -z "$names" ]; then
+    echo "No Tamoss instance was found in the rendered environment." >&2
+    return 1
+  fi
+  if [ -z "$requested" ]; then
+    printf '%s\n' "$names"
+    return 0
+  fi
+  if ! printf '%s\n' "$names" | grep -Fxq "$requested"; then
+    {
+      printf 'Instance %s was not found in this environment. Available instances:\n' "$requested"
+      printf '%s\n' "$names" | sed 's/^/  /'
+    } >&2
+    return 1
+  fi
+  printf '%s\n' "$requested"
 }
 
 task_render_environment() {
@@ -162,6 +205,71 @@ task_init_env() {
   printf 'Created %s\n' "$environment_dir"
   printf 'Edit the YAML files there, then run:\n'
   printf '  task env:apply ENV=%s KUBECONFIG=/path/to/kubeconfig\n' "$name"
+}
+
+# task_init_env_instance adds an instance manifest to an existing environment
+# and registers it in the environment kustomization, so the environment always
+# composes every instance it holds.
+task_init_env_instance() {
+  local environment_dir="$1"
+  local instance="$2"
+  local profile="$3"
+  local domain="$4"
+  local namespace="${5:-}"
+  local manifest kustomization
+
+  namespace="${namespace:-$instance}"
+  manifest="$environment_dir/$instance.yaml"
+  kustomization="$environment_dir/kustomization.yaml"
+
+  case "$instance" in
+    *[!a-z0-9-]*|""|-*)
+      echo "INSTANCE must be a non-empty DNS-style name using lowercase letters, numbers, and hyphens." >&2
+      return 2
+      ;;
+  esac
+  case "$profile" in
+    single-server|multi-server|edge) ;;
+    *)
+      echo "PROFILE must be single-server, multi-server, or edge for remote Kubernetes environments." >&2
+      return 2
+      ;;
+  esac
+  if [ ! -d "$environment_dir" ]; then
+    echo "Environment $environment_dir was not found. Create it with task env:init." >&2
+    return 1
+  fi
+  if [ ! -f "$kustomization" ]; then
+    echo "Environment $environment_dir has no kustomization.yaml." >&2
+    return 1
+  fi
+  if [ -e "$manifest" ]; then
+    echo "Instance manifest $manifest already exists; refusing to overwrite it." >&2
+    return 1
+  fi
+
+  cat > "$manifest" <<YAML
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: $namespace
+---
+apiVersion: tamoss.livewyer.io/v1alpha1
+kind: Tamoss
+metadata:
+  name: $instance
+  namespace: $namespace
+spec:
+  profile: $profile
+  publicEndpoint:
+    baseDomain: $domain
+YAML
+
+  yq -i ".resources += [\"$instance.yaml\"]" "$kustomization"
+
+  printf 'Created %s and registered it in %s\n' "$manifest" "$kustomization"
+  printf 'Edit the instance manifest, then run:\n'
+  printf '  task env:apply ENV=%s KUBECONFIG=/path/to/kubeconfig\n' "$(basename "$environment_dir")"
 }
 
 task_env_values_enabled() {
@@ -378,7 +486,7 @@ task_apply_env() {
   local helmfile_path="$3"
   local operator_kustomize_dir="$4"
   local platform_timeout="$5"
-  local rendered profile namespace name env_name
+  local rendered profile namespace name env_name instances
 
   env_name="$(basename "$environment_dir")"
   rendered="$(mktemp)"
@@ -389,22 +497,21 @@ task_apply_env() {
     "$rendered" \
     "Environment $environment_dir was not found. Create it with task env:init."
 
-  profile="$(task_tamoss_field_from_rendered "$rendered" profile)"
-  namespace="$(task_tamoss_field_from_rendered "$rendered" namespace)"
-  name="$(task_tamoss_field_from_rendered "$rendered" name)"
-  namespace="${namespace:-tams}"
+  instances="$(task_tamoss_instances_for "$rendered")" || return 1
 
-  case "$profile" in
-    local-kind|single-server|multi-server|edge) ;;
-    *)
-      echo "Unable to infer a supported Tamoss spec.profile from $environment_dir." >&2
-      return 1
-      ;;
-  esac
-  if [ -z "$name" ]; then
-    echo "Unable to infer Tamoss metadata.name from $environment_dir." >&2
-    return 1
-  fi
+  while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    profile="$(task_tamoss_field_from_rendered "$rendered" profile "$name")"
+    case "$profile" in
+      local-kind|single-server|multi-server|edge) ;;
+      *)
+        echo "Unable to infer a supported Tamoss spec.profile for $name in $environment_dir." >&2
+        return 1
+        ;;
+    esac
+  done <<EOF
+$instances
+EOF
 
   task_apply_env_platform \
     "$kubeconfig" \
@@ -415,7 +522,14 @@ task_apply_env() {
   task_wait_operator "$kubeconfig" tamoss-system operator-controller-manager
   task_apply_env_instance "$environment_dir" "$kubeconfig"
 
-  printf 'Applied %s/%s from %s\n' "$namespace" "$name" "$environment_dir"
+  while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    namespace="$(task_tamoss_field_from_rendered "$rendered" namespace "$name")"
+    namespace="${namespace:-tams}"
+    printf 'Applied %s/%s from %s\n' "$namespace" "$name" "$environment_dir"
+  done <<EOF
+$instances
+EOF
 }
 
 task_apply_env_instance() {
@@ -432,7 +546,8 @@ task_wait_env() {
   local environment_dir="$1"
   local kubeconfig="$2"
   local timeout="$3"
-  local rendered namespace name
+  local instance="${4:-}"
+  local rendered namespace name instances
 
   rendered="$(mktemp)"
   trap "rm -f '$rendered'" EXIT
@@ -441,23 +556,25 @@ task_wait_env() {
     "$environment_dir" \
     "$rendered" \
     "Environment $environment_dir was not found. Create it with task env:init."
-  namespace="$(task_tamoss_field_from_rendered "$rendered" namespace)"
-  name="$(task_tamoss_field_from_rendered "$rendered" name)"
-  namespace="${namespace:-tams}"
-  if [ -z "$name" ]; then
-    echo "Unable to infer Tamoss metadata.name from $environment_dir." >&2
-    return 1
-  fi
+  instances="$(task_tamoss_instances_for "$rendered" "$instance")" || return 1
 
-  task_step "wait for Tamoss instance" \
-    kubectl --kubeconfig "$kubeconfig" -n "$namespace" \
-      wait --for=condition=Ready "tamoss/$name" --timeout="$timeout"
+  while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    namespace="$(task_tamoss_field_from_rendered "$rendered" namespace "$name")"
+    namespace="${namespace:-tams}"
+    task_step "wait for Tamoss instance $name" \
+      kubectl --kubeconfig "$kubeconfig" -n "$namespace" \
+        wait --for=condition=Ready "tamoss/$name" --timeout="$timeout"
+  done <<EOF
+$instances
+EOF
 }
 
 task_show_env_status() {
   local environment_dir="$1"
   local kubeconfig="$2"
-  local rendered namespace name
+  local instance="${3:-}"
+  local rendered namespace name instances multiple
 
   rendered="$(mktemp)"
   trap "rm -f '$rendered'" EXIT
@@ -466,20 +583,26 @@ task_show_env_status() {
     "$environment_dir" \
     "$rendered" \
     "Environment $environment_dir was not found. Create it with task env:init."
-  namespace="$(task_tamoss_field_from_rendered "$rendered" namespace)"
-  name="$(task_tamoss_field_from_rendered "$rendered" name)"
-  namespace="${namespace:-tams}"
-  if [ -z "$name" ]; then
-    echo "Unable to infer Tamoss metadata.name from $environment_dir." >&2
-    return 1
-  fi
+  instances="$(task_tamoss_instances_for "$rendered" "$instance")" || return 1
+  multiple=0
+  [ "$(printf '%s\n' "$instances" | wc -l)" -gt 1 ] && multiple=1
 
-  kubectl --kubeconfig "$kubeconfig" -n "$namespace" get "tamoss/$name" -o wide
-  kubectl --kubeconfig "$kubeconfig" -n "$namespace" get pods,svc,ingress
-  if kubectl --kubeconfig "$kubeconfig" api-resources --api-group=gateway.networking.k8s.io | grep -q '^httproutes'; then
-    kubectl --kubeconfig "$kubeconfig" -n "$namespace" get httproute
-  fi
-  kubectl --kubeconfig "$kubeconfig" -n "$namespace" get events --sort-by=.lastTimestamp | tail -40
+  while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    namespace="$(task_tamoss_field_from_rendered "$rendered" namespace "$name")"
+    namespace="${namespace:-tams}"
+    if [ "$multiple" -eq 1 ]; then
+      printf '\n=== %s (%s) ===\n' "$name" "$namespace"
+    fi
+    kubectl --kubeconfig "$kubeconfig" -n "$namespace" get "tamoss/$name" -o wide
+    kubectl --kubeconfig "$kubeconfig" -n "$namespace" get pods,svc,ingress
+    if kubectl --kubeconfig "$kubeconfig" api-resources --api-group=gateway.networking.k8s.io | grep -q '^httproutes'; then
+      kubectl --kubeconfig "$kubeconfig" -n "$namespace" get httproute
+    fi
+    kubectl --kubeconfig "$kubeconfig" -n "$namespace" get events --sort-by=.lastTimestamp | tail -40
+  done <<EOF
+$instances
+EOF
 }
 
 task_diff_env() {
@@ -643,10 +766,44 @@ task_print_rustfs_access() {
   printf '  RustFS Password:  %s\n\n' "${rustfs_password:-<not available>}"
 }
 
+# task_print_env_summary reports on every instance in the environment, or on
+# one when an instance is named.
 task_print_env_summary() {
   local environment_dir="$1"
   local kubeconfig="$2"
   local target_file="${3:-}"
+  local instance="${4:-}"
+  local rendered instances name multiple
+
+  rendered="$(mktemp)"
+  task_render_environment \
+    "$environment_dir" \
+    "$rendered" \
+    "Environment $environment_dir was not found. Create it with task env:init."
+  instances="$(task_tamoss_instances_for "$rendered" "$instance")" || {
+    rm -f "$rendered"
+    return 1
+  }
+  rm -f "$rendered"
+  multiple=0
+  [ "$(printf '%s\n' "$instances" | wc -l)" -gt 1 ] && multiple=1
+
+  while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    if [ "$multiple" -eq 1 ]; then
+      printf '\n=== %s ===\n' "$name"
+    fi
+    task_print_instance_summary "$environment_dir" "$kubeconfig" "$target_file" "$name"
+  done <<EOF
+$instances
+EOF
+}
+
+task_print_instance_summary() {
+  local environment_dir="$1"
+  local kubeconfig="$2"
+  local target_file="${3:-}"
+  local instance="${4:-}"
   local rendered profile api_namespace tamoss_name base_domain
   local app_url api_url auth_url token_key
   local token_resource_name token_secret bearer_token default_storagebackend ready_status phase
@@ -661,10 +818,10 @@ task_print_env_summary() {
     "$environment_dir" \
     "$rendered" \
     "Environment $environment_dir was not found. Create it with task env:init."
-  profile="$(task_tamoss_field_from_rendered "$rendered" profile)"
-  api_namespace="$(task_tamoss_field_from_rendered "$rendered" namespace)"
-  tamoss_name="$(task_tamoss_field_from_rendered "$rendered" name)"
-  base_domain="$(task_tamoss_field_from_rendered "$rendered" baseDomain)"
+  profile="$(task_tamoss_field_from_rendered "$rendered" profile "$instance")"
+  api_namespace="$(task_tamoss_field_from_rendered "$rendered" namespace "$instance")"
+  tamoss_name="$(task_tamoss_field_from_rendered "$rendered" name "$instance")"
+  base_domain="$(task_tamoss_field_from_rendered "$rendered" baseDomain "$instance")"
   rm -f "$rendered"
 
   api_namespace="${api_namespace:-tams}"

--- a/docs/operations/install.md
+++ b/docs/operations/install.md
@@ -161,10 +161,24 @@ deploy/environments/<env>/
     └── prod-a/                # optional per-instance dashboards and alerts
 ```
 
-`task env:instance:apply` applies the whole kustomization; adding an
-instance is adding its manifest and listing it in `kustomization.yaml`.
-Instances using `s3.providedBy: external` need their default
-`StorageBackend` manifest alongside the CR, as `prod-a-storage.yaml` shows.
+Add an instance with `task env:instance:init`, which writes the manifest and
+registers it in `kustomization.yaml`:
+
+```bash
+task env:instance:init ENV=<env> INSTANCE=prod-b PROFILE=multi-server \
+  DOMAIN=prod-b.example.com NAMESPACE=prod-b
+```
+
+`task env:instance:apply` then applies the whole kustomization. Instances
+using `s3.providedBy: external` need their default `StorageBackend` manifest
+alongside the CR, as `prod-a-storage.yaml` shows.
+
+`env:wait`, `env:status`, and `env:summary` report on every instance in the
+environment. Pass `INSTANCE=<name>` to work with one:
+
+```bash
+task env:summary ENV=<env> INSTANCE=prod-a KUBECONFIG="$KUBECONFIG"
+```
 
 ## Environment Secrets
 

--- a/docs/reference/task-commands.md
+++ b/docs/reference/task-commands.md
@@ -26,11 +26,18 @@ names or descriptions change.
 | Command | Purpose |
 | --- | --- |
 | `task env:init NAME=my-prod PROFILE=single-server DOMAIN=tamoss.example.com` | Create a remote environment composition from checked-in templates. Use `PROFILE=edge` for the ARM64 single-node profile. |
+| `task env:instance:init ENV=my-prod INSTANCE=second PROFILE=single-server DOMAIN=second.example.com` | Add a `Tamoss` instance to an existing environment and register it in the environment kustomization. `NAMESPACE` defaults to the instance name. |
 | `task env:apply ENV=my-prod KUBECONFIG=/path/to/kubeconfig` | Apply the [Helmfile](https://helmfile.readthedocs.io/) platform releases, TAMOSS operator, and selected environment overlay. |
 | `task env:diff ENV=my-prod KUBECONFIG=/path/to/kubeconfig` | Diff the Helmfile platform releases, TAMOSS operator, and selected environment overlay. |
 | `task env:wait ENV=my-prod KUBECONFIG=/path/to/kubeconfig` | Wait for the selected environment's `Tamoss` resource to report `Ready=True`. |
 | `task env:status ENV=my-prod KUBECONFIG=/path/to/kubeconfig` | Show the selected environment's `Tamoss` status, namespace resources, routes, and recent events. |
 | `task env:summary ENV=my-prod KUBECONFIG=/path/to/kubeconfig` | Print lifecycle status, access URLs, app credentials, API token, OAuth client details, and storage credentials for the selected environment. |
+
+`env:wait`, `env:status`, and `env:summary` act on every instance in the
+environment. Add `INSTANCE=<name>` to act on one, for example
+`task env:summary ENV=my-prod INSTANCE=second KUBECONFIG=/path/to/kubeconfig`.
+Naming an instance the environment does not compose fails with the list of
+instances it does.
 
 ### Additional Validation Commands
 

--- a/tests/test_env_instance_selection.py
+++ b/tests/test_env_instance_selection.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+INSTANCE_MANIFEST = """\
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {namespace}
+---
+apiVersion: tamoss.livewyer.io/v1alpha1
+kind: Tamoss
+metadata:
+  name: {name}
+  namespace: {namespace}
+spec:
+  profile: multi-server
+  publicEndpoint:
+    baseDomain: {name}.example.com
+"""
+
+
+@pytest.fixture(name="rendered")
+def rendered_fixture(tmp_path: Path) -> Path:
+    """Render a two-instance environment the same way the tasks do."""
+    if shutil.which("kubectl") is None or shutil.which("yq") is None:
+        pytest.skip("kubectl and yq are required for environment selection checks")
+
+    environment = tmp_path / "env"
+    environment.mkdir()
+    for name, namespace in (("prod-a", "prod-a"), ("prod-b", "prod-b")):
+        (environment / f"{name}.yaml").write_text(
+            INSTANCE_MANIFEST.format(name=name, namespace=namespace),
+            encoding="utf-8",
+        )
+    (environment / "kustomization.yaml").write_text(
+        textwrap.dedent(
+            """\
+            apiVersion: kustomize.config.k8s.io/v1beta1
+            kind: Kustomization
+
+            resources:
+              - prod-a.yaml
+              - prod-b.yaml
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    target = tmp_path / "rendered.yaml"
+    target.write_text(
+        subprocess.run(
+            ["kubectl", "kustomize", str(environment)],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout,
+        encoding="utf-8",
+    )
+    return target
+
+
+def run_env_helper(script: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "-c", f". .tasks/lib/env.sh\n{script}"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_every_instance_is_listed_in_composition_order(rendered: Path) -> None:
+    result = run_env_helper(f'task_tamoss_names_from_rendered "{rendered}"')
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.split() == ["prod-a", "prod-b"]
+
+
+def test_unset_instance_selects_all_instances(rendered: Path) -> None:
+    result = run_env_helper(f'task_tamoss_instances_for "{rendered}"')
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.split() == ["prod-a", "prod-b"]
+
+
+def test_named_instance_narrows_the_selection(rendered: Path) -> None:
+    result = run_env_helper(f'task_tamoss_instances_for "{rendered}" prod-b')
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.split() == ["prod-b"]
+
+
+def test_unknown_instance_fails_and_lists_the_available_instances(
+    rendered: Path,
+) -> None:
+    result = run_env_helper(f'task_tamoss_instances_for "{rendered}" prod-c')
+
+    assert result.returncode != 0
+    assert "prod-c was not found" in result.stderr
+    assert "prod-a" in result.stderr
+    assert "prod-b" in result.stderr
+
+
+def test_fields_resolve_per_instance(rendered: Path) -> None:
+    """Without this the tasks report the first instance for every instance."""
+    first = run_env_helper(
+        f'task_tamoss_field_from_rendered "{rendered}" namespace prod-a'
+    )
+    second = run_env_helper(
+        f'task_tamoss_field_from_rendered "{rendered}" namespace prod-b'
+    )
+
+    assert first.stdout.strip() == "prod-a", first.stderr
+    assert second.stdout.strip() == "prod-b", second.stderr
+
+
+def test_instance_init_registers_the_manifest(tmp_path: Path) -> None:
+    if shutil.which("yq") is None:
+        pytest.skip("yq is required for environment instance creation")
+
+    environment = tmp_path / "env"
+    environment.mkdir()
+    (environment / "kustomization.yaml").write_text(
+        textwrap.dedent(
+            """\
+            apiVersion: kustomize.config.k8s.io/v1beta1
+            kind: Kustomization
+
+            resources: []
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    created = run_env_helper(
+        f'task_init_env_instance "{environment}" prod-a multi-server '
+        "prod-a.example.com prod-a"
+    )
+    assert created.returncode == 0, created.stderr
+
+    manifest = environment / "prod-a.yaml"
+    assert manifest.exists()
+    assert "name: prod-a" in manifest.read_text(encoding="utf-8")
+    assert "prod-a.yaml" in (environment / "kustomization.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    repeated = run_env_helper(
+        f'task_init_env_instance "{environment}" prod-a multi-server '
+        "prod-a.example.com prod-a"
+    )
+    assert repeated.returncode != 0
+    assert "already exists" in repeated.stderr


### PR DESCRIPTION
Environment commands now treat instances as a level below the environment: env:wait, env:status, and env:summary report on every Tamoss in the environment and accept INSTANCE=<name> to narrow to one, instead of silently acting on whichever instance rendered first. A new env:instance:init adds an instance manifest to an existing environment and registers it in the kustomization.