### PR TITLE
fix: tolerate slow Authentik startup

### DIFF
--- a/deploy/operator/install.yaml
+++ b/deploy/operator/install.yaml
@@ -16681,6 +16681,8 @@ spec:
           value: info
         - name: TAMOSS_OPERATOR_LOG_LEVEL_OVERRIDES
           value: ""
+        - name: TAMOSS_AUTHENTIK_PROBE_TIMEOUT
+          value: 30s
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/deploy/platform/values/defaults.yaml
+++ b/deploy/platform/values/defaults.yaml
@@ -80,6 +80,13 @@ authentikChart:
   server:
     ingress:
       enabled: false
+  worker:
+    startupProbe:
+      timeoutSeconds: 30
+    livenessProbe:
+      timeoutSeconds: 30
+    readinessProbe:
+      timeoutSeconds: 30
   serviceAccount:
     namespaceOverride: auth
 

--- a/operator/cmd/manager_runtime_manifest_test.go
+++ b/operator/cmd/manager_runtime_manifest_test.go
@@ -76,6 +76,9 @@ func assertManagerRuntimeSettings(t *testing.T, manager map[string]any) {
 	if env["POD_SERVICE_ACCOUNT_NAME"] != "spec.serviceAccountName" {
 		t.Fatalf("expected POD_SERVICE_ACCOUNT_NAME downward API env, got %#v", env["POD_SERVICE_ACCOUNT_NAME"])
 	}
+	if env["TAMOSS_AUTHENTIK_PROBE_TIMEOUT"] != "30s" {
+		t.Fatalf("expected Authentik probe timeout 30s, got %#v", env["TAMOSS_AUTHENTIK_PROBE_TIMEOUT"])
+	}
 	startupProbe := asMap(t, manager["startupProbe"], "manager startupProbe")
 	failureThreshold := intValue(t, startupProbe["failureThreshold"], "startupProbe.failureThreshold")
 	periodSeconds := intValue(t, startupProbe["periodSeconds"], "startupProbe.periodSeconds")

--- a/operator/cmd/manager_setup.go
+++ b/operator/cmd/manager_setup.go
@@ -122,6 +122,7 @@ func setupControllers(
 		Discovery:                   dependencyDiscovery,
 		DependencyProbeInterval:     dependencyProbeInterval,
 		AuthentikPlatformNamespaces: authentik.NewPlatformNamespacePolicy(os.Getenv("TAMOSS_AUTHENTIK_PLATFORM_NAMESPACES")),
+		AuthentikProbeTimeout:       authentikProbeTimeout(),
 		AuthentikHTTPClient:         authentik.NewHTTPClient(),
 	}
 	if err := tamossReconciler.SetupWithManager(mgr); err != nil {
@@ -206,4 +207,17 @@ func dependencyDiscoveryInterval() time.Duration {
 		return 5 * time.Minute
 	}
 	return interval
+}
+
+func authentikProbeTimeout() time.Duration {
+	value := os.Getenv("TAMOSS_AUTHENTIK_PROBE_TIMEOUT")
+	if value == "" {
+		return authentik.DefaultProbeTimeout
+	}
+	timeout, err := time.ParseDuration(value)
+	if err != nil || timeout <= 0 {
+		setupLog.Info("invalid TAMOSS_AUTHENTIK_PROBE_TIMEOUT; using default", "value", value)
+		return authentik.DefaultProbeTimeout
+	}
+	return timeout
 }

--- a/operator/cmd/manager_setup_test.go
+++ b/operator/cmd/manager_setup_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/livewyer-ops/tamoss/operator/internal/controller/auth/authentik"
+)
+
+func TestAuthentikProbeTimeoutFromEnvironment(t *testing.T) {
+	t.Setenv("TAMOSS_AUTHENTIK_PROBE_TIMEOUT", "45s")
+	if got := authentikProbeTimeout(); got != 45*time.Second {
+		t.Fatalf("expected 45s timeout, got %s", got)
+	}
+}
+
+func TestAuthentikProbeTimeoutUsesDefaultForInvalidValues(t *testing.T) {
+	for _, value := range []string{"", "invalid", "0s", "-1s"} {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv("TAMOSS_AUTHENTIK_PROBE_TIMEOUT", value)
+			if got := authentikProbeTimeout(); got != authentik.DefaultProbeTimeout {
+				t.Fatalf("expected default timeout %s, got %s", authentik.DefaultProbeTimeout, got)
+			}
+		})
+	}
+}

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -50,6 +50,8 @@ spec:
           value: info
         - name: TAMOSS_OPERATOR_LOG_LEVEL_OVERRIDES
           value: ""
+        - name: TAMOSS_AUTHENTIK_PROBE_TIMEOUT
+          value: 30s
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/operator/internal/controller/auth/authentik/probe.go
+++ b/operator/internal/controller/auth/authentik/probe.go
@@ -11,7 +11,8 @@ import (
 )
 
 const (
-	defaultProbeTimeout        = 5 * time.Second
+	// DefaultProbeTimeout bounds OIDC discovery when callers do not provide a deadline.
+	DefaultProbeTimeout        = 30 * time.Second
 	defaultAPIOperationTimeout = 30 * time.Second
 )
 
@@ -23,6 +24,10 @@ type discoveryDocument struct {
 }
 
 func ProbeWithClient(ctx context.Context, client *http.Client, issuerURL, applicationSlug string) error {
+	return ProbeWithClientTimeout(ctx, client, issuerURL, applicationSlug, DefaultProbeTimeout)
+}
+
+func ProbeWithClientTimeout(ctx context.Context, client *http.Client, issuerURL, applicationSlug string, timeout time.Duration) error {
 	if client == nil {
 		client = http.DefaultClient
 	}
@@ -31,8 +36,11 @@ func ProbeWithClient(ctx context.Context, client *http.Client, issuerURL, applic
 		return err
 	}
 	if _, ok := ctx.Deadline(); !ok {
+		if timeout <= 0 {
+			timeout = DefaultProbeTimeout
+		}
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, defaultProbeTimeout)
+		ctx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()
 	}
 

--- a/operator/internal/controller/auth/authentik/probe_test.go
+++ b/operator/internal/controller/auth/authentik/probe_test.go
@@ -72,3 +72,15 @@ func TestProbeHonoursContextTimeout(t *testing.T) {
 		t.Fatalf("expected timeout error")
 	}
 }
+
+func TestProbeUsesConfiguredTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+	}))
+	defer server.Close()
+
+	err := ProbeWithClientTimeout(context.Background(), server.Client(), server.URL, "slow", 10*time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Fatalf("expected configured timeout error, got %v", err)
+	}
+}

--- a/operator/internal/controller/tamoss_controller.go
+++ b/operator/internal/controller/tamoss_controller.go
@@ -54,6 +54,7 @@ type TamossReconciler struct {
 	Discovery                   *operatordiscovery.Manager
 	AuthentikPlatformNamespaces *authentik.PlatformNamespacePolicy
 	AuthentikProbeInterval      time.Duration
+	AuthentikProbeTimeout       time.Duration
 	DependencyProbeInterval     time.Duration
 	AuthentikHTTPClient         *http.Client
 	ManifestReader              HibernationManifestReader

--- a/operator/internal/controller/tamoss_identity.go
+++ b/operator/internal/controller/tamoss_identity.go
@@ -121,7 +121,13 @@ func (r *TamossReconciler) identityResult(ctx context.Context, tamoss *tamossv1a
 		}
 		slug := tamoss.Spec.Auth.ApplicationSlug(tamoss.Namespace, tamoss.Name)
 		issuerURL := authentik.APIBaseURL(tamoss)
-		err := authentik.ProbeWithClient(ctx, authentik.HTTPClientOrDefault(r.AuthentikHTTPClient), issuerURL, slug)
+		err := authentik.ProbeWithClientTimeout(
+			ctx,
+			authentik.HTTPClientOrDefault(r.AuthentikHTTPClient),
+			issuerURL,
+			slug,
+			r.authentikProbeTimeout(),
+		)
 		if err != nil {
 			result.Message = fmt.Sprintf("Authentik issuer is unreachable for application %s: %v", slug, err)
 			return result
@@ -159,4 +165,11 @@ func (r *TamossReconciler) authentikProbeInterval() time.Duration {
 		return r.AuthentikProbeInterval
 	}
 	return defaultAuthentikProbeInterval
+}
+
+func (r *TamossReconciler) authentikProbeTimeout() time.Duration {
+	if r.AuthentikProbeTimeout > 0 {
+		return r.AuthentikProbeTimeout
+	}
+	return authentik.DefaultProbeTimeout
 }

--- a/tests/test_profile_kind_config.py
+++ b/tests/test_profile_kind_config.py
@@ -183,6 +183,15 @@ def test_kind_multi_server_platform_values_render_nodeport() -> None:
         == "authentik"
     )
 
+    worker = _resource(rendered, "Deployment", "authentik-worker", "auth")
+    container = next(
+        item
+        for item in worker["spec"]["template"]["spec"]["containers"]
+        if item["name"] == "worker"
+    )
+    for probe_name in ["startupProbe", "livenessProbe", "readinessProbe"]:
+        assert container[probe_name]["timeoutSeconds"] == 30
+
 
 def test_profile_platform_values_enable_authentik_by_default() -> None:
     registry = _load_yaml(ROOT / "deploy/profiles.yaml")
@@ -205,6 +214,14 @@ def test_profile_platform_values_enable_authentik_by_default() -> None:
 
     values = _load_yaml(ROOT / "deploy/platform/values/edge-reference.yaml")
     assert values["authentik"]["enabled"] is False
+
+
+def test_default_authentik_worker_probe_timeouts_allow_slow_startup() -> None:
+    values = _load_yaml(ROOT / "deploy/platform/values/defaults.yaml")
+    worker = values["authentikChart"]["worker"]
+
+    for probe_name in ["startupProbe", "livenessProbe", "readinessProbe"]:
+        assert worker[probe_name]["timeoutSeconds"] == 30
 
 
 def test_reference_platform_values_render_profile_authentik_host() -> None:


### PR DESCRIPTION
## Summary

- raise Authentik worker probe timeouts to 30 seconds
- add a configurable Authentik issuer probe timeout, defaulting to 30 seconds

## Testing

- `make -C operator test`
- targeted platform values test and Authentik 2026.2.3 chart render