### PR TITLE
fix: replace worker exec probes with HTTP health checks

### DIFF
--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -153,8 +153,10 @@ kubectl --kubeconfig "$KUBECONFIG" -n "$TAMOSS_NAMESPACE" describe pod <pod-name
 kubectl --kubeconfig "$KUBECONFIG" -n "$TAMOSS_NAMESPACE" logs <pod-name> --previous
 ```
 
-Worker pods use an exec probe that runs the same dependency check available
-from the container:
+Worker pods expose `/healthz` and `/readyz` on their metrics port. These
+constant-time probes report process progress and the result of the latest worker
+poll without opening new backend connections. For a deeper dependency check,
+run the diagnostic command in the container:
 
 ```bash
 WORKER_DEPLOYMENT="$(kubectl --kubeconfig "$KUBECONFIG" -n "$TAMOSS_NAMESPACE" \

--- a/operator/internal/controller/defaults/profile.go
+++ b/operator/internal/controller/defaults/profile.go
@@ -112,10 +112,6 @@ func applySingleServer(tamoss *tamossv1alpha1.Tamoss) {
 	})
 	setBool(&tamoss.Spec.Worker.Enabled, true)
 	setEnvDefault(&tamoss.Spec.UI.Env, "TAMOSS_API_URL", "/api")
-	// Single-server hosts can be as small as edge boxes (the base 5s exec
-	// probe timeout crashlooped the worker on a 2-vCPU ARM host), so apply
-	// the same relaxed worker probe timings as edge.
-	defaultRelaxedWorkerProbes(&tamoss.Spec.Worker.WorkloadCommonSpec)
 	defaultWorkloadResources(&tamoss.Spec.API.WorkloadCommonSpec, "250m", "384Mi", "1", "768Mi")
 	defaultWorkloadResources(&tamoss.Spec.Worker.WorkloadCommonSpec, "100m", "128Mi", "500m", "384Mi")
 	defaultWorkloadResources(&tamoss.Spec.UI.WorkloadCommonSpec, "25m", "32Mi", "200m", "128Mi")
@@ -155,7 +151,6 @@ func applyEdge(tamoss *tamossv1alpha1.Tamoss) {
 	setEnvDefault(&tamoss.Spec.Worker.Env, "TAMOSS_DATABASE_POOL_MAX_SIZE", "3")
 	setEnvDefault(&tamoss.Spec.Worker.Env, "TAMOSS_WEBHOOK_ALLOWED_HOSTS", ".svc.cluster.local")
 	setEnvDefault(&tamoss.Spec.UI.Env, "TAMOSS_API_URL", "/api")
-	defaultRelaxedWorkerProbes(&tamoss.Spec.Worker.WorkloadCommonSpec)
 	defaultWorkloadResources(&tamoss.Spec.API.WorkloadCommonSpec, "100m", "192Mi", "600m", "384Mi")
 	defaultWorkloadResources(&tamoss.Spec.Worker.WorkloadCommonSpec, "100m", "128Mi", "500m", "384Mi")
 	defaultWorkloadResources(&tamoss.Spec.UI.WorkloadCommonSpec, "25m", "32Mi", "150m", "96Mi")
@@ -463,7 +458,7 @@ func defaultRustFSOperator(tamoss *tamossv1alpha1.Tamoss, servers, volumesPerSer
 		}}
 	}
 	if rustfs.Bucket.Name == "" {
-		rustfs.Bucket.Name = "tamoss"
+		rustfs.Bucket.Name = defaultAppName
 	}
 }
 
@@ -475,32 +470,14 @@ func defaultWorkloadResources(spec *tamossv1alpha1.WorkloadCommonSpec, requestCP
 }
 
 func defaultWorkerProbes(spec *tamossv1alpha1.WorkloadCommonSpec) {
-	command := []string{"/bin/uv", "run", "python", "-m", "tamoss.worker", "health"}
 	if spec.ReadinessProbe == nil {
-		spec.ReadinessProbe = execProbe(command, 10, 5, 3)
+		spec.ReadinessProbe = httpProbeOnPort("/readyz", "metrics", 10, 5, 3)
 	}
 	if spec.LivenessProbe == nil {
-		spec.LivenessProbe = execProbe(command, 30, 10, 3)
+		spec.LivenessProbe = httpProbeOnPort("/healthz", "metrics", 30, 5, 3)
 	}
 	if spec.StartupProbe == nil {
-		spec.StartupProbe = execProbe(command, 10, 5, 12)
-	}
-}
-
-// defaultRelaxedWorkerProbes stretches the worker exec probe periods and
-// timeouts for profiles that run on small hosts (edge, single-server), where
-// forking the probe interpreter can exceed the base 5s timeout and crashloop
-// an otherwise healthy worker.
-func defaultRelaxedWorkerProbes(spec *tamossv1alpha1.WorkloadCommonSpec) {
-	command := []string{"/bin/uv", "run", "python", "-m", "tamoss.worker", "health"}
-	if spec.ReadinessProbe == nil {
-		spec.ReadinessProbe = execProbe(command, 30, 30, 3)
-	}
-	if spec.LivenessProbe == nil {
-		spec.LivenessProbe = execProbe(command, 60, 30, 3)
-	}
-	if spec.StartupProbe == nil {
-		spec.StartupProbe = execProbe(command, 30, 30, 12)
+		spec.StartupProbe = httpProbeOnPort("/healthz", "metrics", 10, 5, 12)
 	}
 }
 
@@ -517,23 +494,16 @@ func defaultAPIProbes(spec *tamossv1alpha1.WorkloadCommonSpec) {
 }
 
 func httpProbe(path string, periodSeconds, timeoutSeconds, failureThreshold int32) *corev1.Probe {
+	return httpProbeOnPort(path, "http", periodSeconds, timeoutSeconds, failureThreshold)
+}
+
+func httpProbeOnPort(path, port string, periodSeconds, timeoutSeconds, failureThreshold int32) *corev1.Probe {
 	return &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Path: path,
-				Port: intstr.FromString("http"),
+				Port: intstr.FromString(port),
 			},
-		},
-		PeriodSeconds:    periodSeconds,
-		TimeoutSeconds:   timeoutSeconds,
-		FailureThreshold: failureThreshold,
-	}
-}
-
-func execProbe(command []string, periodSeconds, timeoutSeconds, failureThreshold int32) *corev1.Probe {
-	return &corev1.Probe{
-		ProbeHandler: corev1.ProbeHandler{
-			Exec: &corev1.ExecAction{Command: append([]string{}, command...)},
 		},
 		PeriodSeconds:    periodSeconds,
 		TimeoutSeconds:   timeoutSeconds,

--- a/operator/internal/controller/defaults/profile_test.go
+++ b/operator/internal/controller/defaults/profile_test.go
@@ -222,21 +222,6 @@ func TestApplySingleServerManagedBackendDefaults(t *testing.T) {
 	if got := rustFSEnvValue(rustfs, "RUSTFS_UNSAFE_BYPASS_DISK_CHECK"); got != "true" {
 		t.Fatalf("expected single-server RustFS disk check bypass, got %q", got)
 	}
-	if got := tamoss.Spec.Worker.ReadinessProbe.TimeoutSeconds; got != 30 {
-		t.Fatalf("expected single-server worker readiness timeout 30, got %d", got)
-	}
-	if got := tamoss.Spec.Worker.ReadinessProbe.PeriodSeconds; got != 30 {
-		t.Fatalf("expected single-server worker readiness period 30, got %d", got)
-	}
-	if got := tamoss.Spec.Worker.LivenessProbe.PeriodSeconds; got != 60 {
-		t.Fatalf("expected single-server worker liveness period 60, got %d", got)
-	}
-	if got := tamoss.Spec.Worker.LivenessProbe.TimeoutSeconds; got != 30 {
-		t.Fatalf("expected single-server worker liveness timeout 30, got %d", got)
-	}
-	if got := tamoss.Spec.Worker.StartupProbe.TimeoutSeconds; got != 30 {
-		t.Fatalf("expected single-server worker startup timeout 30, got %d", got)
-	}
 	assertRestrictedWorkloadSecurity(t, tamoss.Spec.API.WorkloadCommonSpec)
 	assertRestrictedWorkloadSecurity(t, tamoss.Spec.Worker.WorkloadCommonSpec)
 	assertRestrictedWorkloadSecurity(t, tamoss.Spec.UI.WorkloadCommonSpec)
@@ -287,18 +272,6 @@ func TestApplyEdgeDefaults(t *testing.T) {
 	}
 	if got := tamoss.Spec.Worker.Resources.Limits[corev1.ResourceMemory]; got.String() != "384Mi" {
 		t.Fatalf("expected edge worker memory limit, got %s", got.String())
-	}
-	if got := tamoss.Spec.Worker.ReadinessProbe.TimeoutSeconds; got != 30 {
-		t.Fatalf("expected edge worker readiness timeout 30, got %d", got)
-	}
-	if got := tamoss.Spec.Worker.ReadinessProbe.PeriodSeconds; got != 30 {
-		t.Fatalf("expected edge worker readiness period 30, got %d", got)
-	}
-	if got := tamoss.Spec.Worker.LivenessProbe.PeriodSeconds; got != 60 {
-		t.Fatalf("expected edge worker liveness period 60, got %d", got)
-	}
-	if got := tamoss.Spec.Worker.StartupProbe.TimeoutSeconds; got != 30 {
-		t.Fatalf("expected edge worker startup timeout 30, got %d", got)
 	}
 	cnpg := tamoss.Spec.Backends.DB.CNPG
 	if cnpg == nil || cnpg.Instances != 1 || cnpg.Storage.Size != "10Gi" {
@@ -638,6 +611,60 @@ func TestSupportedProfilesUseOperatorManagedBackends(t *testing.T) {
 	}
 }
 
+func TestSupportedProfilesUseWorkerHTTPProbes(t *testing.T) {
+	profiles := []tamossv1alpha1.TamossProfile{
+		tamossv1alpha1.TamossProfileLocalKind,
+		tamossv1alpha1.TamossProfileSingleServer,
+		tamossv1alpha1.TamossProfileMultiServer,
+		tamossv1alpha1.TamossProfileEdge,
+	}
+
+	for _, profile := range profiles {
+		t.Run(string(profile), func(t *testing.T) {
+			tamoss := &tamossv1alpha1.Tamoss{
+				ObjectMeta: metav1.ObjectMeta{Name: "tamoss", Namespace: "tams"},
+				Spec: tamossv1alpha1.TamossSpec{
+					Profile: profile,
+				},
+			}
+
+			Apply(tamoss)
+
+			assertWorkerHTTPProbe(t, "readiness", tamoss.Spec.Worker.ReadinessProbe, "/readyz", 10, 3)
+			assertWorkerHTTPProbe(t, "liveness", tamoss.Spec.Worker.LivenessProbe, "/healthz", 30, 3)
+			assertWorkerHTTPProbe(t, "startup", tamoss.Spec.Worker.StartupProbe, "/healthz", 10, 12)
+		})
+	}
+}
+
+func TestApplyPreservesExplicitWorkerProbes(t *testing.T) {
+	readiness := &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			Exec: &corev1.ExecAction{Command: []string{"/custom-ready"}},
+		},
+		PeriodSeconds:    7,
+		TimeoutSeconds:   3,
+		FailureThreshold: 4,
+	}
+	tamoss := &tamossv1alpha1.Tamoss{
+		ObjectMeta: metav1.ObjectMeta{Name: "tamoss", Namespace: "tams"},
+		Spec: tamossv1alpha1.TamossSpec{
+			Profile: tamossv1alpha1.TamossProfileLocalKind,
+			Worker: tamossv1alpha1.WorkerComponentSpec{
+				WorkloadCommonSpec: tamossv1alpha1.WorkloadCommonSpec{
+					ReadinessProbe: readiness,
+				},
+			},
+		},
+	}
+
+	Apply(tamoss)
+
+	if tamoss.Spec.Worker.ReadinessProbe != readiness {
+		t.Fatalf("expected explicit worker readiness probe to be preserved")
+	}
+}
+
 func TestApplyPublicEndpointDefaultsPreserveExternalProviders(t *testing.T) {
 	tamoss := &tamossv1alpha1.Tamoss{
 		ObjectMeta: metav1.ObjectMeta{Name: "tamoss-external", Namespace: "tams"},
@@ -834,6 +861,19 @@ func assertAPIHTTPProbes(t *testing.T, spec tamossv1alpha1.WorkloadCommonSpec) {
 	}
 	if spec.StartupProbe.HTTPGet.Path != "/healthz" {
 		t.Fatalf("expected API startup path /healthz, got %q", spec.StartupProbe.HTTPGet.Path)
+	}
+}
+
+func assertWorkerHTTPProbe(t *testing.T, name string, probe *corev1.Probe, path string, periodSeconds, failureThreshold int32) {
+	t.Helper()
+	if probe == nil || probe.HTTPGet == nil {
+		t.Fatalf("expected worker %s HTTP probe, got %#v", name, probe)
+	}
+	if probe.HTTPGet.Path != path || probe.HTTPGet.Port.StrVal != "metrics" {
+		t.Fatalf("unexpected worker %s probe target: %#v", name, probe.HTTPGet)
+	}
+	if probe.PeriodSeconds != periodSeconds || probe.TimeoutSeconds != 5 || probe.FailureThreshold != failureThreshold {
+		t.Fatalf("unexpected worker %s probe timings: %#v", name, probe)
 	}
 }
 

--- a/operator/internal/controller/workload_renderer/worker_probe_test.go
+++ b/operator/internal/controller/workload_renderer/worker_probe_test.go
@@ -1,7 +1,6 @@
 package workload_renderer
 
 import (
-	"reflect"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -10,36 +9,30 @@ import (
 	"github.com/livewyer-ops/tamoss/operator/internal/controller/defaults"
 )
 
-func TestWorkerDeploymentRendersHealthCommandProbes(t *testing.T) {
+func TestWorkerDeploymentRendersHTTPProbes(t *testing.T) {
 	tamoss := rendererFixture()
 	tamoss.Spec.Worker.Enabled = ptr.To(true)
 	defaults.Apply(tamoss)
 
 	deployment := deploymentByName(t, Render(tamoss), "example-worker")
 	container := deployment.Spec.Template.Spec.Containers[0]
-	want := []string{"/bin/uv", "run", "python", "-m", "tamoss.worker", "health"}
-
-	assertProbeCommand(t, "readiness", container.ReadinessProbe, want)
-	assertProbeCommand(t, "liveness", container.LivenessProbe, want)
-	assertProbeCommand(t, "startup", container.StartupProbe, want)
-	assertProbeTimeout(t, "readiness", container.ReadinessProbe, 5)
-	assertProbeTimeout(t, "liveness", container.LivenessProbe, 10)
-	assertProbeTimeout(t, "startup", container.StartupProbe, 5)
+	assertHTTPProbe(t, "readiness", container.ReadinessProbe, "/readyz")
+	assertHTTPProbe(t, "liveness", container.LivenessProbe, "/healthz")
+	assertHTTPProbe(t, "startup", container.StartupProbe, "/healthz")
 }
 
-func assertProbeCommand(t *testing.T, name string, probe *corev1.Probe, want []string) {
+func assertHTTPProbe(t *testing.T, name string, probe *corev1.Probe, wantPath string) {
 	t.Helper()
-	if probe == nil || probe.Exec == nil {
-		t.Fatalf("expected %s probe exec command", name)
+	if probe == nil || probe.HTTPGet == nil {
+		t.Fatalf("expected %s HTTP probe", name)
 	}
-	if !reflect.DeepEqual(probe.Exec.Command, want) {
-		t.Fatalf("expected %s probe command %#v, got %#v", name, want, probe.Exec.Command)
+	if probe.HTTPGet.Path != wantPath {
+		t.Fatalf("expected %s probe path %q, got %q", name, wantPath, probe.HTTPGet.Path)
 	}
-}
-
-func assertProbeTimeout(t *testing.T, name string, probe *corev1.Probe, want int32) {
-	t.Helper()
-	if probe == nil || probe.TimeoutSeconds != want {
-		t.Fatalf("expected %s probe timeout %d, got %#v", name, want, probe)
+	if probe.HTTPGet.Port.StrVal != "metrics" {
+		t.Fatalf("expected %s probe port metrics, got %#v", name, probe.HTTPGet.Port)
+	}
+	if probe.TimeoutSeconds != 5 {
+		t.Fatalf("expected %s probe timeout 5, got %d", name, probe.TimeoutSeconds)
 	}
 }

--- a/src/app/tamoss/metrics.py
+++ b/src/app/tamoss/metrics.py
@@ -88,7 +88,7 @@ def record_presigned_url(operation: str) -> None:
 
 # Worker media-load metrics: the background worker is a separate process that
 # drains the delete and webhook queues, so it exports its own throughput signals
-# on the shared side port via start_metrics_server.
+# on the worker HTTP side port.
 WORKER_TASKS_PROCESSED_TOTAL = Counter(
     "tamoss_worker_tasks_processed_total",
     "Worker queue tasks drained per poll.",

--- a/src/app/tamoss/settings.py
+++ b/src/app/tamoss/settings.py
@@ -308,6 +308,11 @@ class Settings(BaseSettings):
         default=DEFAULT_WORKER_LEASE_SECONDS,
         validation_alias="TAMOSS_WORKER_LEASE_SECONDS",
     )
+    worker_health_stale_after_seconds: float = Field(
+        default=600.0,
+        ge=30.0,
+        validation_alias="TAMOSS_WORKER_HEALTH_STALE_AFTER_SECONDS",
+    )
     worker_id: str = Field(
         default_factory=_worker_id_from_env,
         validation_alias="TAMOSS_WORKER_ID",

--- a/src/app/tamoss/worker.py
+++ b/src/app/tamoss/worker.py
@@ -10,9 +10,10 @@ from datetime import timedelta
 from tamoss.application.use_cases import TamossUseCases
 from tamoss.bootstrap import create_use_cases
 from tamoss.domain.model import utc_now
-from tamoss.metrics import record_worker_tasks_processed, start_metrics_server
+from tamoss.metrics import record_worker_tasks_processed
 from tamoss.settings import DEFAULT_WORKER_LEASE_SECONDS, Settings, get_settings
 from tamoss.storage_credentials import validate_credentials_file
+from tamoss.worker_health import WorkerHealthState, start_worker_http_server
 
 logger = logging.getLogger("tamoss.worker")
 _shutdown = False
@@ -204,11 +205,14 @@ def main(argv: list[str] | None = None) -> None:
         enable_delete,
         enable_webhook,
     )
-    metrics_server = start_metrics_server(settings)
-    use_cases = create_use_cases(settings)
+    health = WorkerHealthState(settings.worker_health_stale_after_seconds)
+    worker_http_server = start_worker_http_server(settings, health)
+    use_cases: TamossUseCases | None = None
     try:
+        use_cases = create_use_cases(settings)
         while not _shutdown:
             processed = 0
+            health.mark_poll_started()
             try:
                 delete_processed, webhook_processed = drain_once(
                     use_cases,
@@ -234,13 +238,18 @@ def main(argv: list[str] | None = None) -> None:
                 if purged:
                     logger.info("purged %s finished queue record(s)", purged)
             except Exception:
+                health.mark_poll_failed()
                 logger.exception("worker poll failed; retrying")
+            else:
+                health.mark_poll_succeeded()
             if not processed:
                 time.sleep(poll_interval)
     finally:
-        if metrics_server is not None:
-            metrics_server.close()
-        _close_use_cases(use_cases)
+        health.mark_stopping()
+        if worker_http_server is not None:
+            worker_http_server.close()
+        if use_cases is not None:
+            _close_use_cases(use_cases)
 
 
 if __name__ == "__main__":

--- a/src/app/tamoss/worker_health.py
+++ b/src/app/tamoss/worker_health.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Lock, Thread
+from urllib.parse import urlsplit
+
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+
+from tamoss.settings import Settings
+
+logger = logging.getLogger(__name__)
+
+
+class WorkerHealthState:
+    def __init__(
+        self,
+        stale_after_seconds: float,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if stale_after_seconds <= 0:
+            raise ValueError("stale_after_seconds must be positive")
+        self._stale_after_seconds = stale_after_seconds
+        self._clock = clock
+        self._lock = Lock()
+        self._last_progress = clock()
+        self._ready = False
+        self._running = True
+
+    def mark_poll_started(self) -> None:
+        self._mark_progress()
+
+    def mark_poll_succeeded(self) -> None:
+        with self._lock:
+            self._last_progress = self._clock()
+            self._ready = True
+
+    def mark_poll_failed(self) -> None:
+        with self._lock:
+            self._last_progress = self._clock()
+            self._ready = False
+
+    def mark_stopping(self) -> None:
+        with self._lock:
+            self._running = False
+            self._ready = False
+
+    def is_live(self) -> bool:
+        running, _, age = self._snapshot()
+        return running and age <= self._stale_after_seconds
+
+    def is_ready(self) -> bool:
+        running, ready, age = self._snapshot()
+        return running and ready and age <= self._stale_after_seconds
+
+    def _mark_progress(self) -> None:
+        with self._lock:
+            self._last_progress = self._clock()
+
+    def _snapshot(self) -> tuple[bool, bool, float]:
+        with self._lock:
+            return (
+                self._running,
+                self._ready,
+                max(0.0, self._clock() - self._last_progress),
+            )
+
+
+@dataclass
+class WorkerHTTPServer:
+    server: ThreadingHTTPServer
+    thread: Thread
+
+    @property
+    def port(self) -> int:
+        return self.server.server_port
+
+    def close(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+
+
+def start_worker_http_server(
+    settings: Settings,
+    health: WorkerHealthState,
+) -> WorkerHTTPServer | None:
+    if settings.metrics_port is None:
+        return None
+    try:
+        server = ThreadingHTTPServer(
+            (settings.metrics_bind_address, settings.metrics_port),
+            _worker_handler(health),
+        )
+    except OSError:
+        logger.warning(
+            "worker HTTP endpoint disabled: cannot bind %s:%s",
+            settings.metrics_bind_address,
+            settings.metrics_port,
+            exc_info=True,
+        )
+        return None
+    server.daemon_threads = True
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return WorkerHTTPServer(server=server, thread=thread)
+
+
+def _worker_handler(
+    health: WorkerHealthState,
+) -> type[BaseHTTPRequestHandler]:
+    class WorkerRequestHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            self._serve(include_body=True)
+
+        def do_HEAD(self) -> None:
+            self._serve(include_body=False)
+
+        def log_message(self, _format: str, *_args: object) -> None:
+            return
+
+        def _serve(self, *, include_body: bool) -> None:
+            path = urlsplit(self.path).path
+            if path == "/metrics":
+                self._respond(
+                    HTTPStatus.OK,
+                    generate_latest(),
+                    CONTENT_TYPE_LATEST,
+                    include_body=include_body,
+                )
+                return
+            if path == "/healthz":
+                live = health.is_live()
+                status = HTTPStatus.OK if live else HTTPStatus.SERVICE_UNAVAILABLE
+                body = b"ok\n" if live else b"stale\n"
+                self._respond(status, body, include_body=include_body)
+                return
+            if path == "/readyz":
+                ready = health.is_ready()
+                status = HTTPStatus.OK if ready else HTTPStatus.SERVICE_UNAVAILABLE
+                body = b"ok\n" if ready else b"not ready\n"
+                self._respond(status, body, include_body=include_body)
+                return
+            self._respond(
+                HTTPStatus.NOT_FOUND, b"not found\n", include_body=include_body
+            )
+
+        def _respond(
+            self,
+            status: HTTPStatus,
+            body: bytes,
+            content_type: str = "text/plain; charset=utf-8",
+            *,
+            include_body: bool,
+        ) -> None:
+            self.send_response(status)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            if include_body:
+                self.wfile.write(body)
+
+    return WorkerRequestHandler

--- a/tests/application/test_settings.py
+++ b/tests/application/test_settings.py
@@ -9,6 +9,11 @@ from tamoss.settings import Settings, read_secret_file
     [
         ("TAMOSS_WORKER_MAX_REQUESTS", "many", "positive integer"),
         ("TAMOSS_WORKER_LEASE_SECONDS", "0", "positive integer"),
+        (
+            "TAMOSS_WORKER_HEALTH_STALE_AFTER_SECONDS",
+            "29",
+            "TAMOSS_WORKER_HEALTH_STALE_AFTER_SECONDS",
+        ),
         ("TAMOSS_WEBHOOK_TIMEOUT_SECONDS", "-1", "positive number"),
         ("TAMOSS_WORKER_ENABLE_DELETE", "sometimes", "boolean"),
         ("TAMOSS_STORAGE_BACKEND_REGISTRATION_ENABLED", "sometimes", "boolean"),
@@ -46,6 +51,7 @@ def test_operator_rendered_runtime_env_values_parse(
         "TAMOSS_WEBHOOK_ALLOWED_HOSTS": ".svc.cluster.local",
         "TAMOSS_WORKER_POLL_INTERVAL_SECONDS": "1",
         "TAMOSS_WORKER_MAX_REQUESTS": "25",
+        "TAMOSS_WORKER_HEALTH_STALE_AFTER_SECONDS": "900",
         "TAMOSS_STORAGE_BACKEND_REGISTRATION_ENABLED": "false",
         "TAMOSS_OAUTH2_ENABLED": "true",
         "TAMOSS_OAUTH2_ISSUER": "https://auth.example.test/application/o/tamoss/",
@@ -63,6 +69,7 @@ def test_operator_rendered_runtime_env_values_parse(
     assert settings.webhook_allowed_hosts == [".svc.cluster.local"]
     assert settings.worker_poll_interval_seconds == 1
     assert settings.worker_max_requests == 25
+    assert settings.worker_health_stale_after_seconds == 900
     assert settings.storage_backend_registration_enabled is False
     assert settings.oauth2_enabled is True
     assert settings.oauth2_algorithms == ["RS256", "PS256"]

--- a/tests/workers/test_worker_http_health.py
+++ b/tests/workers/test_worker_http_health.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import urllib.error
+import urllib.request
+
+import pytest
+from tamoss.settings import Settings
+from tamoss.worker_health import WorkerHealthState, start_worker_http_server
+
+pytestmark = pytest.mark.worker
+
+
+def test_worker_http_server_tracks_readiness_without_backend_calls() -> None:
+    state = WorkerHealthState(600)
+    server = start_worker_http_server(_settings(), state)
+    assert server is not None
+    try:
+        assert _status(server.port, "/healthz") == 200
+        assert _status(server.port, "/readyz") == 503
+
+        state.mark_poll_succeeded()
+        assert _status(server.port, "/readyz") == 200
+
+        state.mark_poll_failed()
+        assert _status(server.port, "/healthz") == 200
+        assert _status(server.port, "/readyz") == 503
+
+        status, body = _response(server.port, "/metrics")
+        assert status == 200
+        assert b"python_info" in body
+    finally:
+        server.close()
+
+
+def test_worker_health_becomes_unhealthy_when_progress_is_stale() -> None:
+    now = [100.0]
+    state = WorkerHealthState(30, clock=lambda: now[0])
+    state.mark_poll_succeeded()
+
+    assert state.is_live() is True
+    assert state.is_ready() is True
+
+    now[0] += 31
+
+    assert state.is_live() is False
+    assert state.is_ready() is False
+
+
+def test_worker_health_stops_readiness_during_shutdown() -> None:
+    state = WorkerHealthState(600)
+    state.mark_poll_succeeded()
+
+    state.mark_stopping()
+
+    assert state.is_live() is False
+    assert state.is_ready() is False
+
+
+def _settings() -> Settings:
+    return Settings(
+        auth_required=False,
+        storage_backend=None,
+        metrics_bind_address="127.0.0.1",
+        metrics_port=0,
+    )
+
+
+def _status(port: int, path: str) -> int:
+    return _response(port, path)[0]
+
+
+def _response(port: int, path: str) -> tuple[int, bytes]:
+    try:
+        with urllib.request.urlopen(
+            f"http://127.0.0.1:{port}{path}",
+            timeout=5,
+        ) as response:
+            return response.status, response.read()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read()


### PR DESCRIPTION
## Summary

- expose constant-time worker health and readiness endpoints
- replace Python subprocess probes across all deployment profiles
- preserve the worker health command for manual diagnostics

## Testing

- `task test:workers`
- `task test:fast`
- `make -C operator test`
- `task lint:mypy`