### PR TITLE
fix: retry transient Authentik blueprint failures

### DIFF
--- a/operator/internal/controller/auth/authentik/retry.go
+++ b/operator/internal/controller/auth/authentik/retry.go
@@ -1,0 +1,33 @@
+package authentik
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+)
+
+// IsRetryableAPIError reports whether an Authentik operation should receive a startup grace period.
+func IsRetryableAPIError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var apiError APIError
+	if errors.As(err, &apiError) {
+		switch apiError.StatusCode {
+		case http.StatusMethodNotAllowed,
+			http.StatusRequestTimeout,
+			http.StatusConflict,
+			http.StatusTooEarly,
+			http.StatusTooManyRequests:
+			return true
+		default:
+			return apiError.StatusCode >= http.StatusInternalServerError
+		}
+	}
+	var networkError net.Error
+	return errors.As(err, &networkError)
+}

--- a/operator/internal/controller/auth/authentik/retry_test.go
+++ b/operator/internal/controller/auth/authentik/retry_test.go
@@ -1,0 +1,39 @@
+package authentik
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"testing"
+)
+
+func TestIsRetryableAPIError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "method not allowed", err: APIError{StatusCode: http.StatusMethodNotAllowed}, want: true},
+		{name: "request timeout", err: APIError{StatusCode: http.StatusRequestTimeout}, want: true},
+		{name: "conflict", err: APIError{StatusCode: http.StatusConflict}, want: true},
+		{name: "rate limited", err: APIError{StatusCode: http.StatusTooManyRequests}, want: true},
+		{name: "server error", err: APIError{StatusCode: http.StatusServiceUnavailable}, want: true},
+		{name: "deadline", err: context.DeadlineExceeded, want: true},
+		{name: "network", err: &net.DNSError{Err: "temporary lookup failure", IsTemporary: true}, want: true},
+		{name: "bad request", err: APIError{StatusCode: http.StatusBadRequest}, want: false},
+		{name: "unauthorized", err: APIError{StatusCode: http.StatusUnauthorized}, want: false},
+		{name: "forbidden", err: APIError{StatusCode: http.StatusForbidden}, want: false},
+		{name: "not found", err: APIError{StatusCode: http.StatusNotFound}, want: false},
+		{name: "cancelled", err: context.Canceled, want: false},
+		{name: "validation", err: errors.New("invalid response"), want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := IsRetryableAPIError(test.err); got != test.want {
+				t.Fatalf("IsRetryableAPIError(%v) = %t, want %t", test.err, got, test.want)
+			}
+		})
+	}
+}

--- a/operator/internal/controller/tamoss_controller.go
+++ b/operator/internal/controller/tamoss_controller.go
@@ -40,6 +40,7 @@ const (
 	tamossAppName = "tamoss"
 
 	defaultAuthentikProbeInterval         = 30 * time.Second
+	defaultAuthentikRetryGracePeriod      = 10 * time.Minute
 	defaultDependencyProbeInterval        = 5 * time.Minute
 	defaultFinalizerPollInterval          = 2 * time.Second
 	defaultProviderReadinessProbeInterval = 10 * time.Second
@@ -54,6 +55,7 @@ type TamossReconciler struct {
 	Discovery                   *operatordiscovery.Manager
 	AuthentikPlatformNamespaces *authentik.PlatformNamespacePolicy
 	AuthentikProbeInterval      time.Duration
+	AuthentikRetryGracePeriod   time.Duration
 	DependencyProbeInterval     time.Duration
 	AuthentikHTTPClient         *http.Client
 	ManifestReader              HibernationManifestReader
@@ -364,8 +366,8 @@ func (r *TamossReconciler) reconcileTamossManagedAuthentikStage(ctx context.Cont
 	managedBlueprint, err := authentik.NewManagedBlueprintClient(tamoss, token.Token, r.AuthentikHTTPClient).Reconcile(ctx, authentik.ManagedBlueprintName(tamoss), authentik.ManagedBlueprintPath(tamoss), blueprint)
 	if err != nil {
 		message := fmt.Sprintf("Authentik managed Blueprint apply failed for %s: %v", authentik.ManagedBlueprintName(tamoss), err)
-		if err := r.updateIdentityBlockedStatus(ctx, tamoss, operatorstatus.ReasonAuthentikManagedBlueprintApplyFailed, message); err != nil {
-			return stopReconcile(ctrl.Result{}), err
+		if statusErr := r.updateAuthentikApplyFailureStatus(ctx, tamoss, err, message); statusErr != nil {
+			return stopReconcile(ctrl.Result{}), statusErr
 		}
 		recordPhase(tamoss.Status.Phase)
 		return stopReconcile(ctrl.Result{RequeueAfter: r.authentikProbeInterval()}), nil
@@ -373,8 +375,8 @@ func (r *TamossReconciler) reconcileTamossManagedAuthentikStage(ctx context.Cont
 	log.FromContext(ctx).V(1).Info("applied Authentik managed Blueprint", "name", managedBlueprint.Name, "status", managedBlueprint.Status)
 	if err := authentik.NewProxyOutpostClient(tamoss, token.Token, r.AuthentikHTTPClient).Reconcile(ctx, tamoss, managedBlueprint); err != nil {
 		message := fmt.Sprintf("Authentik proxy outpost apply failed for %s: %v", authentik.ProxyProviderName(tamoss), err)
-		if err := r.updateIdentityBlockedStatus(ctx, tamoss, operatorstatus.ReasonAuthentikManagedBlueprintApplyFailed, message); err != nil {
-			return stopReconcile(ctrl.Result{}), err
+		if statusErr := r.updateAuthentikApplyFailureStatus(ctx, tamoss, err, message); statusErr != nil {
+			return stopReconcile(ctrl.Result{}), statusErr
 		}
 		recordPhase(tamoss.Status.Phase)
 		return stopReconcile(ctrl.Result{RequeueAfter: r.authentikProbeInterval()}), nil

--- a/operator/internal/controller/tamoss_controller_test.go
+++ b/operator/internal/controller/tamoss_controller_test.go
@@ -389,6 +389,78 @@ var _ = Describe("Tamoss Controller", func() {
 			Eventually(recorder.Events).Should(Receive(ContainSubstring(operatorstatus.ReasonAuthentikAPITokenMissing)))
 		})
 
+		It("should recover from transient managed Authentik API failures", func() {
+			ensureNamespace(ctx, "auth")
+			ensureAuthentikTokenSecret(ctx, "auth")
+			server := authentikManagedServerWithCreateFailures(http.StatusMethodNotAllowed, http.StatusServiceUnavailable)
+			defer server.Close()
+			configureAuthentikIdentity(ctx, typeNamespacedName, "auth", server.URL, []string{"https://app.example.com/auth/callback"})
+			controllerReconciler := &TamossReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			for range 2 {
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+				Expect(err).NotTo(HaveOccurred())
+
+				updated := &tamossv1alpha1.Tamoss{}
+				Expect(k8sClient.Get(ctx, typeNamespacedName, updated)).To(Succeed())
+				blueprint := meta.FindStatusCondition(updated.Status.Conditions, operatorstatus.ConditionIdentityBlueprintSubmitted)
+				progressing := meta.FindStatusCondition(updated.Status.Conditions, operatorstatus.ConditionProgressing)
+				degraded := meta.FindStatusCondition(updated.Status.Conditions, operatorstatus.ConditionDegraded)
+				Expect(updated.Status.Phase).To(Equal(operatorstatus.PhaseProgressing))
+				Expect(blueprint).NotTo(BeNil())
+				Expect(blueprint.Status).To(Equal(metav1.ConditionUnknown))
+				Expect(blueprint.Reason).To(Equal(operatorstatus.ReasonAuthentikManagedBlueprintApplyRetrying))
+				Expect(progressing).NotTo(BeNil())
+				Expect(progressing.Status).To(Equal(metav1.ConditionTrue))
+				Expect(degraded).NotTo(BeNil())
+				Expect(degraded.Status).To(Equal(metav1.ConditionFalse))
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+			updated := &tamossv1alpha1.Tamoss{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, updated)).To(Succeed())
+			blueprint := meta.FindStatusCondition(updated.Status.Conditions, operatorstatus.ConditionIdentityBlueprintSubmitted)
+			Expect(blueprint).NotTo(BeNil())
+			Expect(blueprint.Status).To(Equal(metav1.ConditionTrue))
+			Expect(server.applied()).To(Equal(1))
+		})
+
+		It("should degrade persistent managed Authentik API failures while continuing retries", func() {
+			ensureNamespace(ctx, "auth")
+			ensureAuthentikTokenSecret(ctx, "auth")
+			server := authentikManagedServerWithCreateFailures(http.StatusServiceUnavailable, http.StatusServiceUnavailable)
+			defer server.Close()
+			configureAuthentikIdentity(ctx, typeNamespacedName, "auth", server.URL, []string{"https://app.example.com/auth/callback"})
+			controllerReconciler := &TamossReconciler{
+				Client:                    k8sClient,
+				Scheme:                    k8sClient.Scheme(),
+				AuthentikRetryGracePeriod: time.Nanosecond,
+			}
+
+			for range 2 {
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			updated := &tamossv1alpha1.Tamoss{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, updated)).To(Succeed())
+			blueprint := meta.FindStatusCondition(updated.Status.Conditions, operatorstatus.ConditionIdentityBlueprintSubmitted)
+			progressing := meta.FindStatusCondition(updated.Status.Conditions, operatorstatus.ConditionProgressing)
+			degraded := meta.FindStatusCondition(updated.Status.Conditions, operatorstatus.ConditionDegraded)
+			Expect(updated.Status.Phase).To(Equal(operatorstatus.PhaseDegraded))
+			Expect(blueprint).NotTo(BeNil())
+			Expect(blueprint.Status).To(Equal(metav1.ConditionFalse))
+			Expect(blueprint.Reason).To(Equal(operatorstatus.ReasonAuthentikManagedBlueprintApplyFailed))
+			Expect(progressing).NotTo(BeNil())
+			Expect(progressing.Status).To(Equal(metav1.ConditionTrue))
+			Expect(degraded).NotTo(BeNil())
+			Expect(degraded.Status).To(Equal(metav1.ConditionTrue))
+		})
+
 		It("should report Gateway API unavailable when HTTPRoute CRDs are missing", func() {
 			instance := &tamossv1alpha1.Tamoss{}
 			Expect(k8sClient.Get(ctx, typeNamespacedName, instance)).To(Succeed())
@@ -1288,10 +1360,15 @@ type authentikManagedTestServer struct {
 	mu               sync.Mutex
 	blueprint        authentikbackend.ManagedBlueprint
 	appliedBlueprint int
+	createFailures   []int
 }
 
 func authentikManagedServer() *authentikManagedTestServer {
-	server := &authentikManagedTestServer{}
+	return authentikManagedServerWithCreateFailures()
+}
+
+func authentikManagedServerWithCreateFailures(statuses ...int) *authentikManagedTestServer {
+	server := &authentikManagedTestServer{createFailures: append([]int(nil), statuses...)}
 	server.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/api/v3/managed/blueprints/") {
 			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
@@ -1331,6 +1408,12 @@ func (s *authentikManagedTestServer) handleBlueprintAPI(w http.ResponseWriter, r
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{"results": results})
 	case r.Method == http.MethodPost && r.URL.Path == "/api/v3/managed/blueprints/":
+		if len(s.createFailures) > 0 {
+			status := s.createFailures[0]
+			s.createFailures = s.createFailures[1:]
+			http.Error(w, http.StatusText(status), status)
+			return
+		}
 		var request struct {
 			Name    string `json:"name"`
 			Path    string `json:"path"`

--- a/operator/internal/controller/tamoss_identity.go
+++ b/operator/internal/controller/tamoss_identity.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	tamossv1alpha1 "github.com/livewyer-ops/tamoss/operator/api/v1alpha1"
@@ -97,6 +98,61 @@ func (r *TamossReconciler) updateIdentityBlockedStatus(ctx context.Context, tamo
 		Progressing:       boolCondition(false, reason, "Reconciliation is blocked by identity configuration"),
 		Degraded:          boolCondition(true, reason, message),
 	})
+}
+
+func (r *TamossReconciler) updateAuthentikApplyFailureStatus(ctx context.Context, tamoss *tamossv1alpha1.Tamoss, applyErr error, message string) error {
+	reason := operatorstatus.ReasonAuthentikManagedBlueprintApplyFailed
+	degraded := true
+	if authentik.IsRetryableAPIError(applyErr) && !r.authentikRetryGracePeriodElapsed(tamoss) {
+		reason = operatorstatus.ReasonAuthentikManagedBlueprintApplyRetrying
+		degraded = false
+	}
+
+	identityBlueprint := boolCondition(false, reason, message)
+	if !degraded {
+		identityBlueprint = unknownCondition(reason, message)
+	}
+	identity := boolCondition(false, reason, message)
+	phase := operatorstatus.PhaseProgressing
+	degradedCondition := boolCondition(false, operatorstatus.ReasonNoError, "No terminal reconcile error has been observed")
+	if degraded {
+		phase = operatorstatus.PhaseDegraded
+		degradedCondition = boolCondition(true, reason, message)
+	}
+	return r.patchTamossStatusObservation(ctx, tamoss, tamossStatusObservation{
+		Phase:             phase,
+		SchemaState:       unknownCondition(reason, "Schema reconciliation is blocked by identity configuration"),
+		Backends:          &statusConditionValue{Status: metav1.ConditionTrue, Reason: operatorstatus.ReasonBackendReferencesConfigured, Message: "Backend secret references are configured"},
+		IdentityBlueprint: &identityBlueprint,
+		Identity:          &identity,
+		Ready:             boolCondition(false, reason, message),
+		Progressing:       boolCondition(true, reason, "Retrying Authentik identity reconciliation"),
+		Degraded:          degradedCondition,
+	})
+}
+
+func (r *TamossReconciler) authentikRetryGracePeriodElapsed(tamoss *tamossv1alpha1.Tamoss) bool {
+	condition := meta.FindStatusCondition(tamoss.Status.Conditions, operatorstatus.ConditionIdentityBlueprintSubmitted)
+	if condition == nil || condition.ObservedGeneration != tamoss.Generation {
+		return false
+	}
+	if condition.Reason == operatorstatus.ReasonAuthentikManagedBlueprintApplyFailed {
+		return true
+	}
+	if condition.Status != metav1.ConditionUnknown || condition.Reason != operatorstatus.ReasonAuthentikManagedBlueprintApplyRetrying {
+		return false
+	}
+	if condition.LastTransitionTime.IsZero() {
+		return false
+	}
+	return time.Since(condition.LastTransitionTime.Time) >= r.authentikRetryGracePeriod()
+}
+
+func (r *TamossReconciler) authentikRetryGracePeriod() time.Duration {
+	if r.AuthentikRetryGracePeriod > 0 {
+		return r.AuthentikRetryGracePeriod
+	}
+	return defaultAuthentikRetryGracePeriod
 }
 
 func (r *TamossReconciler) identityResult(ctx context.Context, tamoss *tamossv1alpha1.Tamoss) identityReconcileResult {

--- a/operator/internal/status/reasons.go
+++ b/operator/internal/status/reasons.go
@@ -26,6 +26,8 @@ const (
 
 // Reasons surfaced through Tamoss and StorageBackend status conditions,
 // Kubernetes events, and reason-bearing metrics.
+const ReasonAuthentikManagedBlueprintApplyRetrying = "AuthentikManagedBlueprintApplyRetrying"
+
 const (
 	ReasonAlreadyAtVersion                      = "AlreadyAtVersion"
 	ReasonAllComponentsReady                    = "AllComponentsReady"


### PR DESCRIPTION
## Summary

- report transient Authentik API failures as progressing
- mark failures degraded after a ten-minute retry period
- continue reconciliation until Authentik recovers

## Testing

- `make -C operator test`
- `task operator:lint`
- transient 405/503 recovery and persistent failure envtests