### PR TITLE
fix: harden release readiness checks

### DIFF
--- a/.github/workflows/kind-e2e-run.yaml
+++ b/.github/workflows/kind-e2e-run.yaml
@@ -62,6 +62,20 @@ jobs:
       - name: Run Kind E2E gate
         run: task kind:e2e PROFILE=local-kind KUBECONFIG=tams.kubeconfig KIND_SUMMARY=false
 
+      - name: Capture Kind diagnostics
+        if: failure() || cancelled()
+        run: |
+          python3 scripts/support_bundle.py \
+            --kubeconfig tams.kubeconfig \
+            --namespace tams \
+            --operator-namespace tamoss-system \
+            --additional-namespace auth \
+            --additional-namespace cert-manager \
+            --additional-namespace cnpg-system \
+            --additional-namespace rustfs-system \
+            --additional-namespace traefik \
+            --output-root reports/kind-support || true
+
       - name: Upload test reports
         uses: actions/upload-artifact@v7
         if: always()

--- a/docs/reference/runtime-configuration.md
+++ b/docs/reference/runtime-configuration.md
@@ -102,6 +102,16 @@ name in the error. This applies equally to API and worker pods, including
 operator-rendered values such as webhook policy, OAuth2, S3 timeout, and worker
 poll settings.
 
+Worker `/healthz` reports unhealthy when the process has made no polling
+progress for `TAMOSS_WORKER_HEALTH_STALE_AFTER_SECONDS` (default `600`). Set it
+longer than the slowest expected poll batch when large request batches or slow
+external services can legitimately occupy a worker for more than ten minutes.
+This controls the worker's internal stale-progress decision; Kubernetes probe
+periods and failure thresholds control how quickly the pod is restarted after
+that decision. Operator-managed API and worker workloads reserve
+`TAMOSS_METRICS_BIND_ADDRESS` and `TAMOSS_METRICS_PORT` because metrics and HTTP
+health probes depend on their rendered values.
+
 PostgreSQL URLs derived from `POSTGRES_HOST`, `POSTGRES_USER`,
 `POSTGRES_PASSWORD`, `POSTGRES_DB`, and `POSTGRES_PORT` percent-encode the user,
 password, and database components. Prefer these component variables when the

--- a/operator/internal/controller/auth/authentik/probe.go
+++ b/operator/internal/controller/auth/authentik/probe.go
@@ -23,10 +23,6 @@ type discoveryDocument struct {
 	JWKSURI               string `json:"jwks_uri"`
 }
 
-func ProbeWithClient(ctx context.Context, client *http.Client, issuerURL, applicationSlug string) error {
-	return ProbeWithClientTimeout(ctx, client, issuerURL, applicationSlug, DefaultProbeTimeout)
-}
-
 func ProbeWithClientTimeout(ctx context.Context, client *http.Client, issuerURL, applicationSlug string, timeout time.Duration) error {
 	if client == nil {
 		client = http.DefaultClient

--- a/operator/internal/controller/auth/authentik/probe_test.go
+++ b/operator/internal/controller/auth/authentik/probe_test.go
@@ -21,7 +21,7 @@ func TestProbeSucceedsWithValidDiscoveryDocument(t *testing.T) {
 	}))
 	defer server.Close()
 
-	if err := ProbeWithClient(context.Background(), server.Client(), server.URL, "tamoss-prod"); err != nil {
+	if err := ProbeWithClientTimeout(context.Background(), server.Client(), server.URL, "tamoss-prod", DefaultProbeTimeout); err != nil {
 		t.Fatalf("expected probe to succeed: %v", err)
 	}
 }
@@ -41,7 +41,7 @@ func TestProbeReportsNonOKStatus(t *testing.T) {
 	server := httptest.NewServer(http.NotFoundHandler())
 	defer server.Close()
 
-	err := ProbeWithClient(context.Background(), server.Client(), server.URL, "missing")
+	err := ProbeWithClientTimeout(context.Background(), server.Client(), server.URL, "missing", DefaultProbeTimeout)
 	if err == nil || !strings.Contains(err.Error(), "unexpected HTTP status 404") {
 		t.Fatalf("expected 404 error, got %v", err)
 	}
@@ -52,7 +52,7 @@ func TestProbeReportsConnectionRefused(t *testing.T) {
 	url := server.URL
 	server.Close()
 
-	err := ProbeWithClient(context.Background(), server.Client(), url, "down")
+	err := ProbeWithClientTimeout(context.Background(), server.Client(), url, "down", DefaultProbeTimeout)
 	if err == nil {
 		t.Fatalf("expected connection error")
 	}
@@ -67,7 +67,7 @@ func TestProbeHonoursContextTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
 
-	err := ProbeWithClient(ctx, server.Client(), server.URL, "slow")
+	err := ProbeWithClientTimeout(ctx, server.Client(), server.URL, "slow", DefaultProbeTimeout)
 	if err == nil {
 		t.Fatalf("expected timeout error")
 	}

--- a/operator/internal/controller/workload_renderer/deployment_api.go
+++ b/operator/internal/controller/workload_renderer/deployment_api.go
@@ -30,7 +30,11 @@ func renderAPIDeployment(tamoss *tamossv1alpha1.Tamoss) []client.Object {
 	if !tamoss.Spec.Secrets.APIToken.Generate {
 		env = append(env, corev1.EnvVar{Name: "TAMOSS_API_TOKEN", Value: tamoss.Spec.Secrets.APIToken.Token})
 	}
-	env = append(env, literalEnv(tamoss.Spec.API.Env)...)
+	env = append(env, literalEnv(
+		tamoss.Spec.API.Env,
+		"TAMOSS_METRICS_BIND_ADDRESS",
+		"TAMOSS_METRICS_PORT",
+	)...)
 	spec := withStorageBackendCredentialsVolume(tamoss.Spec.API.WorkloadCommonSpec, tamoss)
 	return []client.Object{
 		deploymentFor(

--- a/operator/internal/controller/workload_renderer/deployment_common.go
+++ b/operator/internal/controller/workload_renderer/deployment_common.go
@@ -176,9 +176,16 @@ func secretKeyEnv(name, secretName, key string) corev1.EnvVar {
 	}
 }
 
-func literalEnv(env map[string]string) []corev1.EnvVar {
+func literalEnv(env map[string]string, excluded ...string) []corev1.EnvVar {
+	excludedNames := make(map[string]struct{}, len(excluded))
+	for _, name := range excluded {
+		excludedNames[name] = struct{}{}
+	}
 	vars := make([]corev1.EnvVar, 0, len(env))
 	for _, key := range sortedEnv(env) {
+		if _, excluded := excludedNames[key]; excluded {
+			continue
+		}
 		vars = append(vars, corev1.EnvVar{Name: key, Value: env[key]})
 	}
 	return vars

--- a/operator/internal/controller/workload_renderer/deployment_worker.go
+++ b/operator/internal/controller/workload_renderer/deployment_worker.go
@@ -32,7 +32,11 @@ func renderWorkerDeployment(tamoss *tamossv1alpha1.Tamoss) []client.Object {
 		corev1.EnvVar{Name: "TAMOSS_METRICS_BIND_ADDRESS", Value: "0.0.0.0"},
 		corev1.EnvVar{Name: "TAMOSS_METRICS_PORT", Value: fmt.Sprintf("%d", apiMetricsPort)},
 	)
-	env = append(env, literalEnv(tamoss.Spec.Worker.Env)...)
+	env = append(env, literalEnv(
+		tamoss.Spec.Worker.Env,
+		"TAMOSS_METRICS_BIND_ADDRESS",
+		"TAMOSS_METRICS_PORT",
+	)...)
 	spec := withStorageBackendCredentialsVolume(tamoss.Spec.Worker.WorkloadCommonSpec, tamoss)
 	deployment := deploymentFor(
 		tamoss,

--- a/operator/internal/controller/workload_renderer/render_test.go
+++ b/operator/internal/controller/workload_renderer/render_test.go
@@ -247,6 +247,10 @@ func TestRenderAdvancedExtraResources(t *testing.T) {
 
 func TestRenderUsesServicePortForAPIContainer(t *testing.T) {
 	tamoss := rendererFixture()
+	tamoss.Spec.API.Env = map[string]string{
+		"TAMOSS_METRICS_BIND_ADDRESS": "127.0.0.1",
+		"TAMOSS_METRICS_PORT":         "0",
+	}
 	tamoss.Spec.Service.API.Ports = []corev1.ServicePort{{
 		Name:       "http",
 		Port:       9000,
@@ -275,6 +279,10 @@ func TestRenderUsesServicePortForAPIContainer(t *testing.T) {
 		if envValue(container.Env, "TAMOSS_METRICS_BIND_ADDRESS") != "0.0.0.0" {
 			t.Fatalf("expected API metrics bind address env, got %#v", container.Env)
 		}
+		if envCount(container.Env, "TAMOSS_METRICS_PORT") != 1 ||
+			envCount(container.Env, "TAMOSS_METRICS_BIND_ADDRESS") != 1 {
+			t.Fatalf("expected operator-managed API metrics env once, got %#v", container.Env)
+		}
 		return
 	}
 	t.Fatalf("expected API deployment in %v", renderedIDs(objects))
@@ -283,6 +291,10 @@ func TestRenderUsesServicePortForAPIContainer(t *testing.T) {
 func TestRenderExposesWorkerMetricsPort(t *testing.T) {
 	tamoss := rendererFixture()
 	tamoss.Spec.Worker.Enabled = ptr.To(true)
+	tamoss.Spec.Worker.Env = map[string]string{
+		"TAMOSS_METRICS_BIND_ADDRESS": "127.0.0.1",
+		"TAMOSS_METRICS_PORT":         "0",
+	}
 
 	objects := Render(tamoss)
 	for _, obj := range objects {
@@ -301,6 +313,10 @@ func TestRenderExposesWorkerMetricsPort(t *testing.T) {
 		}
 		if envValue(container.Env, "TAMOSS_METRICS_BIND_ADDRESS") != "0.0.0.0" {
 			t.Fatalf("expected worker metrics bind address env, got %#v", container.Env)
+		}
+		if envCount(container.Env, "TAMOSS_METRICS_PORT") != 1 ||
+			envCount(container.Env, "TAMOSS_METRICS_BIND_ADDRESS") != 1 {
+			t.Fatalf("expected operator-managed worker metrics env once, got %#v", container.Env)
 		}
 		return
 	}
@@ -1048,6 +1064,16 @@ func envValue(env []corev1.EnvVar, name string) string {
 		}
 	}
 	return ""
+}
+
+func envCount(env []corev1.EnvVar, name string) int {
+	count := 0
+	for _, item := range env {
+		if item.Name == name {
+			count++
+		}
+	}
+	return count
 }
 
 func envNames(env []corev1.EnvVar) []string {

--- a/scripts/support_bundle.py
+++ b/scripts/support_bundle.py
@@ -57,6 +57,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--output-root", default=".local/support-bundles", help="Bundle root directory"
     )
+    parser.add_argument(
+        "--additional-namespace",
+        action="append",
+        default=[],
+        help="Additional platform namespace to collect; may be repeated",
+    )
     parser.add_argument("--tail", default="500", help="Log lines per container")
     return parser.parse_args()
 
@@ -91,6 +97,7 @@ def main() -> int:
             "namespace": args.namespace,
             "tamossName": args.name or None,
             "operatorNamespace": args.operator_namespace,
+            "additionalNamespaces": args.additional_namespace,
             "versions": tamoss_version_summary(tamoss_document),
             "firstStart": first_start_summary(
                 tamoss_document, storage_backend_document
@@ -147,6 +154,26 @@ def main() -> int:
 
     collector.collect_logs(args.namespace, "namespace", args.tail)
     collector.collect_logs(args.operator_namespace, "operator", args.tail)
+    for namespace in args.additional_namespace:
+        if not collector.check_namespace(namespace):
+            continue
+        scope = f"platform/{safe_filename(namespace)}"
+        for resource in (
+            "pods",
+            "deployments",
+            "statefulsets",
+            "jobs",
+            "services",
+            "configmaps",
+            "secrets",
+            "events",
+        ):
+            collector.collect_json(
+                namespace,
+                [resource],
+                f"{scope}/{resource}.json",
+            )
+        collector.collect_logs(namespace, scope, args.tail)
     print(bundle_dir)
     return 0
 

--- a/tests/application/test_contract_serialization.py
+++ b/tests/application/test_contract_serialization.py
@@ -13,6 +13,13 @@ from tests.tams.support import (
 )
 
 
+def test_generated_storage_backend_identity_fields_are_required() -> None:
+    fields = contract_models.StorageBackendsListItem.model_fields
+
+    for name in ("store_type", "provider", "store_product"):
+        assert fields[name].is_required()
+
+
 def test_generated_contract_models_validate_representative_bbc_payloads() -> None:
     flow_id = uuid4()
     source_id = uuid4()

--- a/tests/tams/conformance/test_service_and_metadata.py
+++ b/tests/tams/conformance/test_service_and_metadata.py
@@ -71,7 +71,9 @@ def test_storage_backend_listing_returns_configured_s3_backend(
     assert len(payload) == 1
     assert payload[0]["label"] == PRIMARY_BACKEND_LABEL
     assert payload[0]["default_storage"] is True
-    assert all(item["store_type"] == "http_object_store" for item in payload)
+    assert payload[0]["store_type"] == "http_object_store"
+    assert payload[0]["provider"] == "tamoss"
+    assert payload[0]["store_product"] == "s3"
 
     storage_head = client.head("/service/storage-backends")
     assert storage_head.status_code == 200

--- a/tests/tams/deployed/test_api_workflow.py
+++ b/tests/tams/deployed/test_api_workflow.py
@@ -36,6 +36,9 @@ def test_deployed_default_install_has_playable_demo_media(
     backends = e2e_client.request_json("GET", "/service/storage-backends")
     default_backend = next((item for item in backends if item["default_storage"]), None)
     assert default_backend is not None
+    assert default_backend["store_type"] == "http_object_store"
+    assert default_backend["provider"]
+    assert default_backend["store_product"]
 
     flow = e2e_client.request_json("GET", f"/flows/{DEMO_FLOW_ID}")
     assert flow["id"] == DEMO_FLOW_ID


### PR DESCRIPTION
## Summary

- capture redacted Kind diagnostics on E2E failure
- keep operator-managed metrics endpoints reachable by health probes
- pin required storage-backend response fields and remove an obsolete probe wrapper

## Test

- `task operator:lint`
- `task operator:test`
- `task test:fast`
- `task openapi:check`
- `task lint:ruff:lint`
- `task lint:mypy`