### PR TITLE
docs: add adopters list, issue form, Slack links

### DIFF
--- a/.github/ISSUE_TEMPLATE/adopter.yaml
+++ b/.github/ISSUE_TEMPLATE/adopter.yaml
@@ -1,0 +1,87 @@
+name: Adopter listing
+description: Tell us your organisation is using TAMOSS, and a maintainer will add you to ADOPTERS.md
+title: "adopter: "
+labels: ["adopter"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for using TAMOSS. Fill this in, and a maintainer will add your row to
+        [ADOPTERS.md](https://github.com/livewyer-ops/tamoss/blob/main/ADOPTERS.md)
+        for you. No pull request needed.
+
+        Issues are public. Only include details you are happy to publish, and no
+        hostnames, credentials, or deployment specifics you would keep out of a
+        public bug report.
+  - type: input
+    attributes:
+      label: Organisation
+      description: The name to show in the adopters table.
+      placeholder: Acme Media
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Website
+      description: Your organisation's main website.
+      placeholder: https://example.com
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: How you use TAMOSS
+      description: Your relationship to the store. You run one, you build a client that talks to one, or you provide the object storage underneath.
+      options:
+        - Running a TAMS store
+        - Client integration
+        - Storage backend
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: Status
+      description: If you run TAMOSS yourself, how far along is your deployment? Leave blank if you do not run it.
+      options:
+        - Evaluating
+        - Non-production
+        - Production
+    validations:
+      required: false
+  - type: checkboxes
+    attributes:
+      label: Profile
+      description: If you run TAMOSS yourself, which deployment profiles? Select all that apply.
+      options:
+        - label: local-kind
+        - label: edge
+        - label: single-server
+        - label: multi-server
+  - type: input
+    attributes:
+      label: Using since
+      description: Roughly when you started using TAMOSS.
+      placeholder: June 2026
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: What you use it for
+      description: One or two sentences of context for the maintainers. Not published in the table.
+      placeholder: We run TAMOSS as the media store behind our archive ingest pipeline.
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Public contact
+      description: Optional. A team alias or GitHub handle is fine, no need for a named person.
+      placeholder: "@acme-platform"
+    validations:
+      required: false
+  - type: checkboxes
+    attributes:
+      label: Consent
+      options:
+        - label: I am authorised to list my organisation publicly.
+          required: true
+        - label: I consent to our name and logo appearing on LiveWyer's website, in the adopters section, and in the rotating logo carousel.
+          required: true

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,27 @@
+# Adopters
+
+This page lists organisations and projects using TAMOSS, in production, for evaluation, or as a reference implementation of the [BBC TAMS API](https://github.com/bbc/tams).
+
+TAMOSS is pre-1.0. The current release series (`8.1.0-ossN`) tracks BBC TAMS v8.1, and the operator API (`Tamoss`, `StorageBackend`, `IngestRun`, `TamossHibernation`, etc) may still change between releases.
+
+## Who is using TAMOSS
+
+| Adopter                  | Since | Status | Profile | Contact (optional) | Use case |
+|--------------------------|-------|--------|---------|--------------------|----------|
+| _your organisation here_ |       |        |         |                    |          |
+
+**Status**: `Evaluating`, `Non-production`, or `Production`.
+
+**Profile**: One or more of `local-kind`, `edge`, `single-server`, `multi-server`. See [Profiles](docs/concepts/profiles.md).
+
+**Use case**: `Running a TAMS store`, `Client integration` (you build a client that talks to a store), `Storage backend` (you provide the object storage underneath), etc.
+
+## Adding yourself
+
+This document also lists organisations using TAMOSS based on public information in blog posts, events, and videos.
+
+If you are running TAMOSS (even a Kind evaluation, a lab deployment, or a conformance comparison against your own TAMS implementation), **[open an adopter issue](https://github.com/livewyer-ops/tamoss/issues/new?template=adopter.yaml)** with your details. No pull request is needed, a maintainer will add your row for you. Please note:
+
+- Only include what you are happy to publish. A row with just an organisation name and a status is welcome; a public contact is optional, and a team alias or GitHub handle is fine in place of a person.
+
+If you want to talk about a deployment before listing it, feel free to use [GitHub Discussions](https://github.com/livewyer-ops/tamoss/discussions) or the `#tamoss` Slack channel. If you would rather not be listed publicly but are happy for us to know, you can also email <hello@livewyer.com>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,6 +237,7 @@ URLs in public issues.
 ## Getting help
 
 - Bugs and feature requests: [GitHub Issues](https://github.com/livewyer-ops/tamoss/issues)
+- Chat: the `#tamoss` Slack channel, invite in [SUPPORT.md](SUPPORT.md)
 - Questions: [GitHub Discussions](https://github.com/livewyer-ops/tamoss/discussions)
 - Security disclosure: [SECURITY.md](SECURITY.md)
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ See [Development Workflow](docs/development/contributing.md) and
 ## Community
 
 - Bug reports and feature requests: [GitHub Issues](https://github.com/livewyer-ops/tamoss/issues)
+- Chat: [#tamoss in the Cloud Native Agile Production Slack](https://join.slack.com/t/cnap-media/shared_invite/zt-46so866cy-YstgGBzIgcA6U1c3J1Rg1g)
 - Discussions: [GitHub Discussions](https://github.com/livewyer-ops/tamoss/discussions)
 - Security vulnerabilities: see [SECURITY.md](SECURITY.md)
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -3,6 +3,9 @@
 Use GitHub Issues for public bug reports, feature requests, and operational
 questions.
 
+For informal questions and community chat, join the `#tamoss` channel in the
+[Cloud Native Agile Production Slack](https://join.slack.com/t/cnap-media/shared_invite/zt-46so866cy-YstgGBzIgcA6U1c3J1Rg1g).
+
 Before opening an issue, check:
 
 - [README](README.md) for the supported deployment and development paths
@@ -27,4 +30,4 @@ hostnames if they are not public.
 
 Maintainers triage public issues on a best-effort basis. If you have a separate
 commercial support agreement, use that channel for urgent production incidents;
-otherwise use GitHub Issues or Discussions.
+otherwise use GitHub Issues, GitHub Discussions, or the `#tamoss` Slack channel.


### PR DESCRIPTION
## Summary

- Add `ADOPTERS.md`, a public register of organisations using TAMOSS, recording status, deployment profile, and how each adopter relates to the store: running one, integrating a client against one, or providing the storage underneath.
- Add `.github/ISSUE_TEMPLATE/adopter.yaml` so adopters submit through an issue form and a maintainer transcribes the row. No pull request is needed.
- Add the `#tamoss` Slack channel to the README, `SUPPORT.md`, and `CONTRIBUTING.md` community lists.