### PR TITLE
docs: backfill changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,54 @@
 
 All notable changes to TAMOSS are documented here.
 
-This project follows semantic versioning for public releases.
+Release versions track the BBC TAMS API version they implement, followed by an `-ossN` counter for TAMOSS releases against that API version: `8.1.0-oss6` is the sixth TAMOSS release implementing TAMS 8.1. Schema revisions and supported upgrade paths for each release are declared in `operator/compatibility.yaml`.
+
+## Unreleased
+
+- Nothing yet.
+
+## 8.1.0-oss6 - 2026-08-08
+
+- Added worker health and readiness endpoints, and moved worker workloads onto
+  HTTP probes.
+- Added targeting of individual instances within an environment.
+- Made the Authentik issuer probe timeout configurable, separated retrying
+  blueprint failures from terminal ones, and relaxed the platform Authentik
+  worker probe timeouts.
+- Reserved the managed operator metrics endpoints.
+- Replaced the UI logo PNG with a scalable vector asset.
+
+## 8.1.0-oss5 - 2026-08-06
+
+- Added managed OAuth support and install hardening to the `edge` profile.
+- Added an optional node memory budget assertion to the deployed checks.
+- Defaulted the `single-server` profile RustFS disk check for single-disk hosts.
+- Made the mainline install golden path self-consistent.
+- Resolved the react-router and cryptography security advisories.
+- Unified the documentation and closed the install-test gaps.
+
+## 8.1.0-oss4 - 2026-07-22
+
+- Added a declarative hibernate and resume lifecycle: `TamossHibernate` exports
+  the managed CNPG database to an external S3 hibernation `StorageBackend` with
+  a checksummed manifest, and `spec.hibernation.resumeFrom` restores it into a
+  target `Tamoss` through CNPG recovery, with configurable artifact retention
+  (`Retain`, `DeleteAfterResume`, `TTL`).
+- Added the `edge` profile for single-node ARM installs.
+- Propagated browser CORS origins to managed S3, and preflighted the bucket URL
+  in the external S3 CORS diagnostic.
+- Avoided redundant Authentik blueprint applies.
+- Improved the environment summary output.
+- Clarified aqua installation, optional media tooling, and browser CORS
+  configuration in the documentation.
+
+## 8.1.0-oss3 - 2026-06-29
+
+- Added configurable API CORS origins.
+- Exposed internal TAMOSS API metrics.
+- Matched scoped auth routes with FastAPI route contexts.
+- Allowed CORS preflight for HEAD requests.
+- Made Authentik proxy application reconciliation idempotent.
 
 ## 8.1.0-oss2 - 2026-06-11
 
@@ -19,43 +66,55 @@ This project follows semantic versioning for public releases.
   rotation; refactored API routes and persistence helpers; improved the
   operator development inner loop.
 
-## Unreleased
+## 8.1.0-oss1 - 2026-06-03
 
-- Preparing the first public TAMOSS release candidate.
-- Added a database hibernate/resume lifecycle: `TamossHibernate` exports the
-  managed CNPG database to an external S3 hibernation `StorageBackend` with a
-  checksummed manifest, and `spec.hibernation.resumeFrom` restores it into a target `Tamoss`
-  through CNPG recovery, with configurable artifact retention
-  (`Retain`, `DeleteAfterResume`, `TTL`).
-- Added the TAMOSS Kubernetes operator as the primary Kubernetes deployment
-  path. Local Kubernetes install now creates Kind, applies the operator with
-  kustomize, and applies a `Tamoss` custom resource.
-- Added zero-to-ready Kind support through `task up`, including bundled
-  PostgreSQL and RustFS reconciliation, operator install, CR readiness waiting,
-  and operator-focused E2E gates.
-- Added a chainsaw-based operator e2e suite with Kind entrypoints, CI reporting,
-  and scenario coverage checks.
-- Aligned user-facing documentation and task commands to the operator-only
-  install model and infrastructure deployment
-  profiles.
-- Removed application chart deployment assets from this operator-only branch.
+- Updated TAMS contract support to 8.1.
+- Restructured the TAMS conformance tests.
+
+## 8.0.0-oss3 - 2026-06-02
+
+- Fixed release schema metadata builds.
+
+## 8.0.0-oss2 - 2026-06-02
+
+- Added OAuth2 route scope authorization.
+- Enforced the presigned timeout contract.
+- Hardened storage allocation first use.
+- Split the operator release and schema versions.
+- Bumped PyJWT for the security audit.
+
+## 8.0.0-oss1 - 2026-06-02
+
+First release on the TAMS-aligned version scheme.
+
+- Replaced the Helm deployment path with operator-managed Kustomize, making the
+  TAMOSS Kubernetes operator the primary Kubernetes deployment path. Local
+  Kubernetes install creates Kind, applies the operator with kustomize, and
+  applies a `Tamoss` custom resource.
 - Added S3 backend selection with `providedBy=external|bundled|rustfs-operator`.
-  The operator now renders bundled RustFS directly and can coordinate with a
-  pinned RustFS Operator install through `rustfs.com/v1alpha1/Tenant`.
+  The operator renders bundled RustFS directly and can coordinate with a pinned
+  RustFS Operator install through `rustfs.com/v1alpha1/Tenant`.
 - Added PostgreSQL backend selection with `providedBy=external|bundled|cnpg`.
   `providedBy=cnpg` emits a CloudNativePG `Cluster`, waits for CNPG readiness,
   and consumes CNPG-generated app/superuser Secrets.
-- Added auth provider selection with `providedBy=external|none|authentik-blueprints`.
-  The Authentik path generates stable OAuth2 client credentials, applies a
-  per-instance managed Blueprint through the platform Authentik API, and reports
-  identity readiness through an OIDC discovery probe.
-- The operator CRD now expresses bundled backends with
-  `spec.backends.db.providedBy=bundled` and
-  `spec.backends.s3.providedBy=bundled`.
-- External OAuth2 configuration now lives under `spec.auth.external.oauth2`
-  with `spec.auth.providedBy=external`.
+- Added auth provider selection with
+  `providedBy=external|none|authentik-blueprints`. The Authentik path generates
+  stable OAuth2 client credentials, applies a per-instance managed Blueprint
+  through the platform Authentik API, and reports identity readiness through an
+  OIDC discovery probe.
+- Expressed bundled backends through `spec.backends.db.providedBy=bundled` and
+  `spec.backends.s3.providedBy=bundled`, and moved external OAuth2 configuration
+  under `spec.auth.external.oauth2` with `spec.auth.providedBy=external`.
+- Added zero-to-ready Kind support, published operator install manifests, and
+  added a chainsaw-based operator e2e suite with Kind entrypoints, CI reporting,
+  and scenario coverage checks.
+- Aligned user-facing documentation and task commands to the operator-only
+  install model and the infrastructure deployment profiles.
+- Removed the application chart deployment assets.
 
 ## 1.0.0-rc.1
+
+Predates the TAMS-aligned version scheme introduced in `8.0.0-oss1`.
 
 - BBC TAMS v8.0-compatible API surface for sources, flows, flow segments,
   objects, storage allocation, webhooks, and deletion requests.


### PR DESCRIPTION
## Summary

- Document the eight tagged releases missing from `CHANGELOG.md`. Only `8.1.0-oss2` was recorded, while the git tags and `operator/compatibility.yaml` both list nine. Entries are reconstructed from the commit range between each tag.
- Fold the stale `Unreleased` block into the releases where they were shipped.

## Risk

- Just a documentation step. No runtime, API, or deployment paths touched.
