### PR TITLE
fix(ci): isolate RC4 release audit concurrency

### DIFF
--- a/.github/workflows/dependency-audit.yaml
+++ b/.github/workflows/dependency-audit.yaml
@@ -30,7 +30,10 @@ on:
     - cron: "17 3 * * *"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # A called workflow inherits the caller's github.workflow value. Keep this
+  # key distinct from a caller's own concurrency group so the audit cannot
+  # cancel or queue behind the release workflow that is waiting for it.
+  group: ${{ github.workflow }}-${{ github.ref }}-dependency-audit
   cancel-in-progress: false
 
 permissions:


### PR DESCRIPTION
## Summary

- give the reusable dependency-audit job a concurrency key distinct from its caller
- prevent the Docker Hub tag workflow from cancelling itself while waiting for its release audit

The first RC4 tag attempt was withdrawn before any release or versioned image was published. This patch is required before recreating that tag.

## Verification

- `aqua exec -- actionlint`
- `pre-commit run --all-files`
