### PR TITLE
fix: harden 8.2 webhook delivery, pagination and release gates

### DIFF
--- a/.github/scripts/release-metadata.py
+++ b/.github/scripts/release-metadata.py
@@ -9,7 +9,6 @@ import sys
 from pathlib import Path
 from typing import Any
 
-
 RELEASE_CANDIDATE_PATTERN = re.compile(r"^(?P<base>.+)-rc(?P<number>0|[1-9][0-9]*)$")
 
 
@@ -88,9 +87,9 @@ def required_string(
     return value
 
 
-def emit_release_metadata(
+def release_metadata(
     version: str, releases: list[dict[str, Any]], path: Path
-) -> None:
+) -> dict[str, str]:
     validate_releases(releases, path, verbose=False)
     releases_by_version = {str(item.get("version")): item for item in releases}
 
@@ -130,6 +129,13 @@ def emit_release_metadata(
     for key, value in metadata.items():
         if value is None:
             fail(f"release {version} is missing {key}")
+    return {key: str(value) for key, value in metadata.items()}
+
+
+def emit_release_metadata(
+    version: str, releases: list[dict[str, Any]], path: Path
+) -> None:
+    for key, value in release_metadata(version, releases, path).items():
         print(f"{key}={value}")
 
 

--- a/.github/scripts/release-preflight.py
+++ b/.github/scripts/release-preflight.py
@@ -5,27 +5,45 @@ from __future__ import annotations
 
 import json
 import os
-from urllib.error import HTTPError
-from urllib.parse import quote
-from urllib.request import Request, urlopen
+from http.client import HTTPSConnection
+from urllib.parse import quote, urlsplit
 
 
 def verify_unpublished(*, api_url: str, repository: str, tag: str, token: str) -> None:
-    url = f"{api_url}/repos/{repository}/releases/tags/{quote(tag, safe='')}"
-    request = Request(
-        url,
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Accept": "application/vnd.github+json",
-        },
+    parsed = urlsplit(api_url)
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError("GitHub API URL must be an HTTPS origin with an optional path")
+    path = (
+        f"{parsed.path.rstrip('/')}/repos/{repository}/releases/tags/"
+        f"{quote(tag, safe='')}"
     )
+    connection = HTTPSConnection(parsed.hostname, parsed.port, timeout=30)
     try:
-        with urlopen(request, timeout=30) as response:
-            release = json.load(response)
-    except HTTPError as exc:
-        if exc.code == 404:
+        connection.request(
+            "GET",
+            path,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+            },
+        )
+        response = connection.getresponse()
+        if response.status == 404:
             return
-        raise
+        if response.status != 200:
+            raise SystemExit(
+                f"GitHub release lookup failed with HTTP {response.status}"
+            )
+        release = json.load(response)
+    finally:
+        connection.close()
     if release.get("draft") is not True:
         raise SystemExit(f"Release {tag} is already published. Use a new version tag.")
 

--- a/.github/scripts/release-preflight.py
+++ b/.github/scripts/release-preflight.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Refuse to overwrite a published release; fail closed on API errors."""
+
+from __future__ import annotations
+
+import json
+import os
+from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+def verify_unpublished(*, api_url: str, repository: str, tag: str, token: str) -> None:
+    url = f"{api_url}/repos/{repository}/releases/tags/{quote(tag, safe='')}"
+    request = Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+        },
+    )
+    try:
+        with urlopen(request, timeout=30) as response:
+            release = json.load(response)
+    except HTTPError as exc:
+        if exc.code == 404:
+            return
+        raise
+    if release.get("draft") is not True:
+        raise SystemExit(f"Release {tag} is already published. Use a new version tag.")
+
+
+def main() -> None:
+    if os.environ["GITHUB_REF_TYPE"] != "tag":
+        raise SystemExit("Release publication requires a version tag.")
+    verify_unpublished(
+        api_url=os.environ.get("GITHUB_API_URL", "https://api.github.com"),
+        repository=os.environ["GITHUB_REPOSITORY"],
+        tag=os.environ["GITHUB_REF_NAME"],
+        token=os.environ["GH_TOKEN"],
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/release-preflight.py
+++ b/.github/scripts/release-preflight.py
@@ -32,6 +32,7 @@ def verify_unpublished(*, api_url: str, repository: str, tag: str, token: str) -
             headers={
                 "Authorization": f"Bearer {token}",
                 "Accept": "application/vnd.github+json",
+                "User-Agent": "tamoss-release-preflight",
             },
         )
         response = connection.getresponse()

--- a/.github/scripts/release-record.py
+++ b/.github/scripts/release-record.py
@@ -8,8 +8,7 @@ import hashlib
 import json
 import os
 import re
-import subprocess
-import sys
+import runpy
 from pathlib import Path
 
 IMAGES = {
@@ -30,26 +29,34 @@ def image_references(environment: dict[str, str]) -> dict[str, str]:
     return images
 
 
+def commit_sha(name: str) -> str:
+    value = os.environ.get(name, "")
+    if re.fullmatch(r"[0-9a-f]{40}", value) is None:
+        raise ValueError(f"Missing or invalid {name}")
+    return value
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--output", required=True, type=Path)
     args = parser.parse_args()
     tag = os.environ["GITHUB_REF_NAME"]
-    metadata = subprocess.check_output(
-        [sys.executable, ".github/scripts/release-metadata.py", tag.removeprefix("v")],
-        text=True,
+    metadata_module = runpy.run_path(
+        str(Path(__file__).with_name("release-metadata.py"))
+    )
+    compatibility_path = Path("operator/compatibility.yaml")
+    metadata = metadata_module["release_metadata"](
+        tag.removeprefix("v"),
+        metadata_module["load_releases"](compatibility_path),
+        compatibility_path,
     )
     images = image_references(dict(os.environ))
     record = {
         "recordVersion": 1,
         "tag": tag,
-        "sourceCommit": subprocess.check_output(
-            ["git", "rev-parse", "HEAD"], text=True
-        ).strip(),
-        "bbcTamsCommit": subprocess.check_output(
-            ["git", "rev-parse", "HEAD:src/vendor/bbc-tams"], text=True
-        ).strip(),
-        "compatibility": dict(line.split("=", 1) for line in metadata.splitlines()),
+        "sourceCommit": commit_sha("SOURCE_COMMIT"),
+        "bbcTamsCommit": commit_sha("BBC_TAMS_COMMIT"),
+        "compatibility": metadata,
         "images": images,
         "workerImage": images["api"],
         "artifacts": {

--- a/.github/scripts/release-record.py
+++ b/.github/scripts/release-record.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Record the complete release, using build outputs rather than mutable tags."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+IMAGES = {
+    "api": "livewyer/tamoss-api",
+    "ui": "livewyer/tamoss-ui",
+    "console_api": "livewyer/tamoss-console-api",
+    "operator": "livewyer/tamoss-operator",
+}
+
+
+def image_references(environment: dict[str, str]) -> dict[str, str]:
+    images = {}
+    for component, repository in IMAGES.items():
+        digest = environment.get(f"{component.upper()}_DIGEST", "")
+        if re.fullmatch(r"sha256:[0-9a-f]{64}", digest) is None:
+            raise ValueError(f"Missing or invalid {component} image digest")
+        images[component] = f"{repository}@{digest}"
+    return images
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    tag = os.environ["GITHUB_REF_NAME"]
+    metadata = subprocess.check_output(
+        [sys.executable, ".github/scripts/release-metadata.py", tag.removeprefix("v")],
+        text=True,
+    )
+    images = image_references(dict(os.environ))
+    record = {
+        "recordVersion": 1,
+        "tag": tag,
+        "sourceCommit": subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], text=True
+        ).strip(),
+        "bbcTamsCommit": subprocess.check_output(
+            ["git", "rev-parse", "HEAD:src/vendor/bbc-tams"], text=True
+        ).strip(),
+        "compatibility": dict(line.split("=", 1) for line in metadata.splitlines()),
+        "images": images,
+        "workerImage": images["api"],
+        "artifacts": {
+            path.name: {"sha256": hashlib.sha256(path.read_bytes()).hexdigest()}
+            for path in (
+                Path("dist/operator-release/install.yaml"),
+                Path("operator/compatibility.yaml"),
+            )
+        },
+        "validationRun": (
+            f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY']}"
+            f"/actions/runs/{os.environ['GITHUB_RUN_ID']}"
+        ),
+        "validationRunAttempt": os.environ["GITHUB_RUN_ATTEMPT"],
+    }
+    args.output.write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/docker-hub.yaml
+++ b/.github/workflows/docker-hub.yaml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref_type != 'tag' }}
 
 env:
   # Push images for trusted release/internal PR branches so deploy tests can
@@ -21,6 +21,50 @@ env:
   PUSH_IMAGES: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository) }}
 
 jobs:
+  release-preflight:
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Validate immutable release target
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 .github/scripts/release-metadata.py "${GITHUB_REF_NAME#v}"
+          python3 .github/scripts/release-preflight.py
+
+  release-tests:
+    if: github.ref_type == 'tag'
+    needs: [release-preflight]
+    uses: ./.github/workflows/test.yaml
+    permissions:
+      contents: read
+      actions: read
+
+  release-operator-tests:
+    if: github.ref_type == 'tag'
+    needs: [release-preflight]
+    uses: ./.github/workflows/operator-ci.yaml
+    permissions:
+      contents: read
+      actions: read
+
+  release-kind-e2e:
+    if: github.ref_type == 'tag'
+    needs: [release-preflight]
+    uses: ./.github/workflows/kind-e2e-run.yaml
+    permissions:
+      contents: read
+      packages: read
+      actions: read
+    with:
+      artifact-name: release-kind-e2e-${{ github.run_id }}
+      retention-days: 90
+      summary-title: Release commit Kind E2E
+      summary-description: Builds and tests the exact tagged source commit before publication.
+
   # A tag build is the only path that produces a versioned release, and nothing
   # previously security-scanned the tree it was cut from. Non-tag builds skip
   # this: pull requests are already covered by validate.yaml, and :main images
@@ -34,8 +78,10 @@ jobs:
       actions: read
 
   tamoss-api:
-    needs: [dependency-audit]
-    if: ${{ !cancelled() && needs.dependency-audit.result != 'failure' }}
+    needs: [dependency-audit, release-preflight]
+    if: ${{ !cancelled() && (github.ref_type != 'tag' || (needs.dependency-audit.result == 'success' && needs.release-preflight.result == 'success')) }}
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     # id-token: write is required for cosign keyless signing (Fulcio OIDC).
@@ -148,8 +194,10 @@ jobs:
           done
 
   tamoss-ui:
-    needs: [dependency-audit]
-    if: ${{ !cancelled() && needs.dependency-audit.result != 'failure' }}
+    needs: [dependency-audit, release-preflight]
+    if: ${{ !cancelled() && (github.ref_type != 'tag' || (needs.dependency-audit.result == 'success' && needs.release-preflight.result == 'success')) }}
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
@@ -228,8 +276,10 @@ jobs:
           done
 
   tamoss-console-api:
-    needs: [dependency-audit]
-    if: ${{ !cancelled() && needs.dependency-audit.result != 'failure' }}
+    needs: [dependency-audit, release-preflight]
+    if: ${{ !cancelled() && (github.ref_type != 'tag' || (needs.dependency-audit.result == 'success' && needs.release-preflight.result == 'success')) }}
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
@@ -307,8 +357,10 @@ jobs:
           done
 
   tamoss-operator:
-    needs: [dependency-audit]
-    if: ${{ !cancelled() && needs.dependency-audit.result != 'failure' }}
+    needs: [dependency-audit, release-preflight]
+    if: ${{ !cancelled() && (github.ref_type != 'tag' || (needs.dependency-audit.result == 'success' && needs.release-preflight.result == 'success')) }}
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     permissions:
@@ -423,3 +475,24 @@ jobs:
           for tag in ${TAGS}; do
             cosign sign --yes "${tag}@${DIGEST}"
           done
+
+  release-assets:
+    if: github.ref_type == 'tag'
+    needs:
+      - dependency-audit
+      - release-preflight
+      - release-tests
+      - release-operator-tests
+      - release-kind-e2e
+      - tamoss-api
+      - tamoss-ui
+      - tamoss-console-api
+      - tamoss-operator
+    uses: ./.github/workflows/operator-release.yaml
+    permissions:
+      contents: write
+    with:
+      api-digest: ${{ needs.tamoss-api.outputs.digest }}
+      ui-digest: ${{ needs.tamoss-ui.outputs.digest }}
+      console-api-digest: ${{ needs.tamoss-console-api.outputs.digest }}
+      operator-digest: ${{ needs.tamoss-operator.outputs.digest }}

--- a/.github/workflows/operator-ci.yaml
+++ b/.github/workflows/operator-ci.yaml
@@ -1,13 +1,14 @@
 name: Operator CI
 
 on:
+  workflow_call:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
   workflow_dispatch:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-operator-ci
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/operator-release.yaml
+++ b/.github/workflows/operator-release.yaml
@@ -94,7 +94,10 @@ jobs:
           UI_DIGEST: ${{ inputs.ui-digest }}
           CONSOLE_API_DIGEST: ${{ inputs.console-api-digest }}
           OPERATOR_DIGEST: ${{ inputs.operator-digest }}
-        run: python3 .github/scripts/release-record.py --output dist/operator-release/release.json
+        run: |
+          SOURCE_COMMIT="$(git rev-parse HEAD)" \
+          BBC_TAMS_COMMIT="$(git rev-parse HEAD:src/vendor/bbc-tams)" \
+          python3 .github/scripts/release-record.py --output dist/operator-release/release.json
 
       - name: Create draft GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2

--- a/.github/workflows/operator-release.yaml
+++ b/.github/workflows/operator-release.yaml
@@ -1,32 +1,26 @@
 name: Operator Release Assets
 
 on:
-  push:
-    tags:
-      - "*.*.*"
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      api-digest:
+        required: true
+        type: string
+      ui-digest:
+        required: true
+        type: string
+      console-api-digest:
+        required: true
+        type: string
+      operator-digest:
+        required: true
+        type: string
 
 permissions:
   contents: write
-  packages: write
-
-env:
-  REGISTRY: ghcr.io
 
 jobs:
-  # Release assets and the GitHub Release itself are user-facing artefacts, so
-  # they gate on the same audit as the images.
-  dependency-audit:
-    if: github.ref_type == 'tag'
-    uses: ./.github/workflows/dependency-audit.yaml
-    permissions:
-      contents: read
-      security-events: write
-      actions: read
-
   build-and-release:
-    needs: [dependency-audit]
-    if: ${{ !cancelled() && needs.dependency-audit.result != 'failure' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
@@ -44,6 +38,8 @@ jobs:
           cache-dependency-path: operator/go.sum
 
       - name: Validate release ref
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "${GITHUB_REF_TYPE}" != "tag" ]; then
             echo "::error::Operator release assets must run from a version tag."
@@ -56,6 +52,7 @@ jobs:
               exit 1
               ;;
           esac
+          python3 .github/scripts/release-preflight.py
 
       - name: Resolve release metadata
         id: version
@@ -72,7 +69,7 @@ jobs:
       - name: Build release install manifest
         shell: bash
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          OPERATOR_DIGEST: ${{ inputs.operator-digest }}
         run: |
           mkdir -p dist/operator-release
           cat > dist/operator-release/kustomization.yaml <<EOF
@@ -83,7 +80,7 @@ jobs:
           images:
             - name: livewyer/tamoss-operator
               newName: livewyer/tamoss-operator
-              newTag: ${VERSION}
+              digest: ${OPERATOR_DIGEST}
           EOF
           # Glob rather than parsing `ls`: the shell expands in the same
           # lexicographic order, so this picks the same binary.
@@ -91,12 +88,21 @@ jobs:
           KUSTOMIZE_BIN="${kustomize_bins[0]}"
           "$KUSTOMIZE_BIN" build dist/operator-release > dist/operator-release/install.yaml
 
+      - name: Record immutable release contents
+        env:
+          API_DIGEST: ${{ inputs.api-digest }}
+          UI_DIGEST: ${{ inputs.ui-digest }}
+          CONSOLE_API_DIGEST: ${{ inputs.console-api-digest }}
+          OPERATOR_DIGEST: ${{ inputs.operator-digest }}
+        run: python3 .github/scripts/release-record.py --output dist/operator-release/release.json
+
       - name: Create draft GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: |
             dist/operator-release/install.yaml
             operator/compatibility.yaml
+            dist/operator-release/release.json
           draft: true
           generate_release_notes: true
           prerelease: ${{ steps.version.outputs.prerelease }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,12 +1,13 @@
 name: Tests
 
 on:
+  workflow_call:
   pull_request:
   workflow_dispatch:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-tests
   cancel-in-progress: true
 
 permissions:

--- a/.tasks/test.yaml
+++ b/.tasks/test.yaml
@@ -146,7 +146,7 @@ tasks:
       # The tests/e2e/test_browser.py and tests/e2e/test_target_env.py modules
       # exercise the e2e harness itself. They need no cluster and no browser, so
       # they belong in the fast subset rather than behind a deployed marker.
-      - "{{.PYTEST}} tests/tams/conformance tests/adapters/postgres/test_connection_pool_reload.py tests/adapters/postgres/test_mappers.py tests/adapters/storage/test_configured_object_storage_unit.py tests/application tests/scripts tests/workers tests/e2e/test_browser.py tests/e2e/test_target_env.py tests/test_documented_task_commands.py tests/test_env_summary_helpers.py tests/test_kind_operand_tag.py tests/test_support_bundle_redaction.py -m 'not needs_db and not needs_s3 and not needs_media and not e2e and not operator_kind and not slow' -ra --junitxml=reports/junit-py-fast.xml"
+      - "{{.PYTEST}} tests/tams/conformance tests/adapters/postgres/test_connection_pool_reload.py tests/adapters/postgres/test_mappers.py tests/adapters/storage/test_configured_object_storage_unit.py tests/application tests/domain tests/scripts tests/workers tests/e2e/test_browser.py tests/e2e/test_target_env.py tests/test_documented_task_commands.py tests/test_env_summary_helpers.py tests/test_kind_operand_tag.py tests/test_support_bundle_redaction.py -m 'not needs_db and not needs_s3 and not needs_media and not e2e and not operator_kind and not slow' -ra --junitxml=reports/junit-py-fast.xml"
 
   application:
     silent: true

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -5,5 +5,6 @@ Development docs cover local contribution loops and validation gates.
 - [Development Workflow](contributing.md) - native and Kubernetes development
   loops.
 - [Testing](testing.md) - local, operator, and deployed validation suites.
+- [Releases](releases.md) - candidate gates, immutable artifacts and promotion.
 - [Task Commands](../reference/task-commands.md) - command reference for
   development and operations tasks.

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -1,0 +1,95 @@
+# Release Runbook
+
+Release candidates and stable releases use the same gates. This runbook builds
+on the release workflow proposed in myauie's PR #176, with all four images and
+immutable release records included.
+
+## Prepare
+
+1. Agree the release branch and exact commit. The 8.2 candidate branch is
+   `8.2-preview`; do not assume `main` contains the candidate changes.
+2. Review dependency and contributor PRs individually. Include compatible
+   updates with passing checks; leave major or behaviour-changing updates for
+   a separate compatibility review. Do not batch-merge solely by author.
+3. Verify `operator/compatibility.yaml`, migration assets, generated manifests,
+   and the pinned `src/vendor/bbc-tams` revision. Do not change the submodule
+   independently of the generated contract and conformance tests.
+4. Run `task check` and the deployed Kind gate. Retain test reports, including
+   PostgreSQL rollback/concurrency tests, webhook transport tests and 8.2
+   contract and semantics results.
+5. Complete the [Cutting Rooms acceptance gate](../operations/cutting-rooms.md)
+   on the candidate. A successful TAMOSS write or webhook HTTP 2xx is not
+   evidence that the CR catalogue or playback works.
+
+Resolve metadata before tagging:
+
+```bash
+python3 .github/scripts/release-metadata.py 8.2.0-oss1-rc5
+git rev-parse HEAD
+git submodule status src/vendor/bbc-tams
+```
+
+The RC number above is an example. Use a new, unused version; never reuse RC4
+or any other published tag. Compatibility metadata derives an RC from its
+base release, so a separate compatibility entry is not required for each RC.
+
+## Publish
+
+Create an annotated version tag on the reviewed commit and push that tag.
+The `Docker Hub` workflow is the sole release orchestrator. It:
+
+1. Validates metadata and refuses to overwrite an already published release.
+2. Runs the dependency audit and the Python, frontend, operator and Kind gates
+   against the tagged commit. Kind builds that source; this is not a claim
+   that Kind tests both architectures of the published images.
+3. Builds, pushes and signs API, UI, Console API and operator images for
+   `linux/amd64` and `linux/arm64`.
+4. Calls `Operator Release Assets` only after every prerequisite succeeds.
+5. Generates a digest-pinned operator install manifest and `release.json`,
+   creates the draft release and then publishes it.
+
+The reusable asset workflow has no independent tag or manual trigger. A
+failed or cancelled prerequisite must leave the release unpublished.
+
+`release.json` contains the source SHA, BBC specification SHA, compatibility
+metadata, four immutable image references, worker/API image identity, asset
+SHA-256 checksums, and the validating workflow run and attempt. The worker
+uses the API image; it is not a fifth independently built image.
+
+## Verify and Promote
+
+- Download `release.json`, `install.yaml` and `compatibility.yaml` from the
+  published release. Verify the asset hashes against the release record and
+  image signatures against this repository's Docker Hub workflow identity.
+- Compare all deployed image digests and schema/API versions with that record.
+  Pin digests where the deployment interface supports them; otherwise record
+  the resolved digest for every configured version tag, including the worker.
+- Upgrade a non-production environment first. For the Cutting Rooms pilot,
+  confirm the actual instance is `cr-tamoss-1` in namespace `cr-tams`; do not
+  infer it from a `dev-` directory name or a similarly named instance.
+- Retain the environment CR revision, migration result, acceptance evidence
+  and a complete restore record alongside the release record. Use the
+  [upgrade](../operations/upgrades.md) and
+  [backup/restore](../operations/backup-restore.md) procedures.
+- Promote a stable release only after CR-side catalogue, playback and outage
+  recovery checks pass. CI's generic receiver cannot certify an external CR
+  deployment. Record any missing access as **not run**, not a pass.
+
+## Failed Releases and Rollback
+
+For an unpublished candidate, fix the cause and rerun the failed jobs against
+the same immutable commit, or abandon it and use a new tag. Re-running all
+jobs after publication is intentionally rejected. Never delete and recreate
+a published tag, overwrite release assets or manually publish a partial draft.
+
+Before upgrading, record the previous four image digests, worker digest,
+source and environment revisions, database migration revision, backup ID and
+recovery point, object-store bucket/versioning state, and a completed restore
+drill. Back up Authentik/platform state under its own ownership as required.
+Keep credentials and signed URLs out of release notes and public CI artifacts.
+
+An image rollback is not a schema rollback. If the previous release cannot
+read the migrated schema, restore the database into a separate instance and
+verify it with the matching images and object storage before moving traffic.
+Stop writers during the final cutover and account for writes after the backup
+point. A backup status alone is not proof that this recovery works.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -16,4 +16,5 @@ diagnosis for operator-led TAMOSS deployments.
   annotations.
 - [Secret Rotation](secret-rotation.md) - runtime secret classes and rotation.
 - [Troubleshooting](troubleshooting.md) - readiness and runtime diagnostics.
+- [Cutting Rooms](cutting-rooms.md) - 8.2 acceptance, webhook diagnosis and recovery.
 - [Upgrades](upgrades.md) - upgrade sequence, checks, and rollback.

--- a/docs/operations/cutting-rooms.md
+++ b/docs/operations/cutting-rooms.md
@@ -1,0 +1,122 @@
+# Cutting Rooms Acceptance and Recovery
+
+The 8.2 release gate covers Reporter ingestion, TAMOSS persistence, webhook
+delivery, CR catalogue visibility and actual media playback. Do not treat
+these as interchangeable success signals.
+
+## Acceptance Record
+
+Run with a designated test account and clearly labelled test media. Retain a
+restricted-access record containing:
+
+- UTC start/end, tester, TAMOSS release/source SHA and all deployed digests,
+  BBC TAMS revision, schema revision, Reporter version and CR version.
+- TAMOSS instance, namespace, API URL and CR application URL. The pilot is
+  expected to use `cr-tamoss-1`; verify the deployed CR and ingress first.
+- Source, parent collection, child Flow, media Object and webhook IDs.
+- Callback and query evidence, redacted of authorization headers, query
+  credentials, webhook keys, payload media URLs and cookies.
+- Each check below marked **pass**, **fail** or **not run**, with an artifact
+  reference. All must pass before stable-release sign-off.
+
+## Checks
+
+1. Register the intended webhook before ingest. Record its event list and
+   every selector. In 8.2, absent `flow_collected_by_ids` means no collection
+   restriction; `[]` selects only top-level Flows. The equivalent distinction
+   applies to Sources. Check IDs refer to the right resource type.
+2. Ingest a short, uniquely labelled audiovisual clip through Reporter. Record
+   its successful upload, segment-registration and metadata responses. Read
+   those same IDs back from the TAMOSS API, including collection relationships,
+   Profiles, Flow status, segment timeranges and initialisation Objects.
+3. Observe the receiver accepting `sources/created`, `flows/created`, relevant
+   metadata updates and `flows/segments_added`. Match event IDs/resource IDs
+   and timestamps to the ingest record. Check callback authentication without
+   logging its key. A receiver HTTP 2xx proves acceptance only, not indexing.
+4. Capture the CR API queries for the same clip. Compare endpoint, scopes,
+   `source_id`, collection selectors, tags, status/Profile filters,
+   `include_timerange`, and URL selection options. Follow each returned
+   `Link: rel=next`; never manufacture page tokens or discard filters.
+5. Confirm the clip appears in the CR catalogue and open it in CR. Play video
+   and audio, seek across a segment boundary, and verify duration and initial
+   segment handling. Read fresh object URLs if old signed URLs have expired.
+6. On a test receiver or isolated CR test integration, return a retryable 503
+   for one callback and restore service before retry exhaustion. Confirm a
+   retry is accepted and CR sees no duplicate clip or segments. Do not take
+   the live CR receiver offline for this test.
+7. Exercise a terminal/disabled webhook and the recovery procedure below in
+   the test integration. Confirm CR reconciles changes made while delivery
+   was inactive. Re-enabling alone is not sufficient.
+8. Clean up only the test resources by their recorded IDs. Capture the
+   expected delete events and confirm the CR catalogue reflects deletion.
+
+If CR-side credentials or playback access are unavailable, this gate remains
+**not run** even when all TAMOSS-local tests pass.
+
+## Diagnose Delivery
+
+The Webhooks page shows actual selector values, including collection filters
+and signed-URL selection. For delivery history, run the read-only diagnostic
+from the repository with the target's existing `POSTGRES_*` configuration:
+
+```bash
+umask 077
+uv run --project src python scripts/webhook_diagnostics.py \
+  --webhook-id 00000000-0000-4000-8000-000000000001 \
+  > webhook-diagnostics.json
+```
+
+Use a read-only database identity where available. The script also enforces a
+read-only, repeatable-read transaction and a five-second statement timeout.
+It reports pending, in-flight, done and dead counts; expired claims; oldest
+pending time; last successful delivery and last attempt-related activity;
+and at most 20 recent deliveries with HTTP status and error type. It does
+not emit webhook keys, full callback URLs, payloads or raw error messages.
+
+These are **retained** rows, not lifetime totals. Completed/dead rows are
+purged according to `TAMOSS_WORKER_QUEUE_RETENTION_SECONDS` (seven days by
+default). A null success timestamp after retention is not proof that the
+receiver has never worked. `last_attempt_activity_at` is the last recorded
+attempt state update, not a precise HTTP request start timestamp.
+
+Interpret the boundary before changing configuration:
+
+- No queued event: inspect registration time, active status and selectors.
+- Pending/expired claim: inspect worker readiness, queue age and leases.
+- 401/403: compare callback authentication with the receiver's expected key.
+- Target blocked: inspect DNS/egress policy. Default delivery pins the validated
+  destination address and ignores ambient HTTP proxies and netrc credentials.
+  Do not enable all private destinations to work around an unexplained error.
+- 2xx but absent in CR: inspect the receiver's indexing result and CR queries.
+- Visible but unplayable: inspect fresh GET URLs, CORS, object availability,
+  Profile/initialisation metadata and segment timeranges.
+
+## Recover and Reconcile
+
+1. Preserve the diagnostic report and record the earliest suspected gap. Fix
+   the receiver, credentials or query/filter mismatch first.
+2. Keep the same webhook ID where possible. With a write-authorized API token,
+   PUT the full registration to `/service/webhooks/{webhookId}` with
+   `status: "created"` and the intended filters and credentials. Use the
+   original secret source, not redacted GET output. Forward-auth UI access is
+   read-only. Verify a new test event reaches CR.
+3. Reconcile CR against the current TAMOSS catalogue and segment listings,
+   including collections and deletions. Follow opaque pagination links;
+   upsert by Source/Flow/Object identity. Use fresh media URLs. The receiver
+   must tolerate duplicate events: delivery is at least once, not exactly once.
+4. Recheck resources changed during reconciliation and compare CR counts and
+   IDs, then repeat catalogue and playback checks. For a definitive snapshot,
+   quiesce test writers or perform repeated reconciliation until stable.
+
+Reactivation does not replay dead rows or reconstruct events never queued
+while the registration was disabled/in error. Do not mass-update queue rows
+to `pending`: historical payload URLs may have expired, routing/filter
+configuration may have changed, and old events can overwrite newer state.
+There is deliberately no one-click historical replay in this release.
+
+Flow/Source lists now issue keyset cursors ordered by the requested sort value
+and ID. Deleting an earlier page or its anchor no longer skips surviving
+records. Numeric tokens remain accepted for transition, but clients must use
+newly issued opaque tokens. These are live listings, not snapshots: changing
+a label or update timestamp can move an item. Prefer `sort_by=created` for
+catalogue reconciliation and reconcile concurrent changes separately.

--- a/scripts/webhook_diagnostics.py
+++ b/scripts/webhook_diagnostics.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Read a bounded, credential-free webhook delivery report from PostgreSQL."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+from urllib.parse import urlsplit
+from uuid import UUID
+
+import psycopg
+from psycopg.rows import dict_row
+from tamoss.settings import Settings
+
+FILTERS = (
+    "flow_ids",
+    "source_ids",
+    "flow_collected_by_ids",
+    "source_collected_by_ids",
+    "accept_get_urls",
+    "accept_storage_ids",
+    "presigned",
+    "verbose_storage",
+    "include_object_timerange",
+)
+
+
+def report(connection: psycopg.Connection, webhook_id: UUID) -> dict[str, Any]:
+    with connection.transaction(), connection.cursor(row_factory=dict_row) as cursor:
+        cursor.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY")
+        cursor.execute("SET LOCAL statement_timeout = '5s'")
+        cursor.execute(
+            "SELECT status, record -> 'data' AS data "
+            "FROM tamoss_webhooks WHERE id = %s",
+            (webhook_id,),
+        )
+        webhook = cursor.fetchone()
+        if webhook is None:
+            raise ValueError("Webhook does not exist")
+        data = webhook["data"]
+        cursor.execute(
+            """
+            SELECT NOW() AS observed_at,
+                COUNT(*) FILTER (WHERE status = 'pending') AS pending,
+                COUNT(*) FILTER (WHERE status = 'started') AS started,
+                COUNT(*) FILTER (WHERE status = 'done') AS done,
+                COUNT(*) FILTER (WHERE status = 'dead') AS dead,
+                COUNT(*) FILTER (
+                    WHERE status IN ('pending', 'started')
+                    AND claim_expires_at <= NOW()
+                ) AS expired_claims,
+                MIN(created_at) FILTER (
+                    WHERE status IN ('pending', 'started')
+                ) AS oldest_pending_at,
+                MIN(next_attempt_at) FILTER (
+                    WHERE status = 'pending'
+                ) AS next_attempt_at,
+                MAX((record ->> 'updated')::timestamptz) FILTER (
+                    WHERE status = 'done'
+                ) AS last_success_at,
+                MAX((record ->> 'updated')::timestamptz) FILTER (
+                    WHERE (record ->> 'attempt_count')::integer > 0
+                ) AS last_attempt_activity_at
+            FROM tamoss_webhook_deliveries
+            WHERE webhook_id = %s
+            """,
+            (webhook_id,),
+        )
+        summary = cursor.fetchone()
+        cursor.execute(
+            """
+            SELECT id, status, created_at, updated_at, next_attempt_at,
+                claim_expires_at,
+                record ->> 'event_type' AS event_type,
+                (record ->> 'attempt_count')::integer AS attempt_count,
+                (record ->> 'response_status')::integer AS response_status,
+                record #>> '{error,type}' AS error_type
+            FROM tamoss_webhook_deliveries
+            WHERE webhook_id = %s
+            ORDER BY updated_at DESC, id DESC
+            LIMIT 20
+            """,
+            (webhook_id,),
+        )
+        return {
+            "webhook_id": str(webhook_id),
+            "status": webhook["status"],
+            "receiver_host": urlsplit(data.get("url", "")).hostname,
+            "events": data.get("events", []),
+            "filters": {name: data[name] for name in FILTERS if name in data},
+            "retained_deliveries": summary,
+            "recent_deliveries": cursor.fetchall(),
+        }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--webhook-id", type=UUID, required=True)
+    args = parser.parse_args()
+    database_url = Settings().database_url_value()
+    if not database_url:
+        parser.error("Configure POSTGRES_HOST and the existing POSTGRES_* credentials")
+    try:
+        with psycopg.connect(database_url, connect_timeout=5, autocommit=True) as conn:
+            result = report(conn, args.webhook_id)
+    except psycopg.Error as exc:
+        raise SystemExit(f"Database diagnostic failed: {type(exc).__name__}") from None
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from None
+    print(json.dumps(result, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/app/frontend/src/pages/WebhooksPage.module.css
+++ b/src/app/frontend/src/pages/WebhooksPage.module.css
@@ -1,0 +1,3 @@
+.filters {
+  min-width: 14rem;
+}

--- a/src/app/frontend/src/pages/WebhooksPage.tsx
+++ b/src/app/frontend/src/pages/WebhooksPage.tsx
@@ -14,6 +14,8 @@ import {
 import { useApi } from "@/contexts/ApiContext";
 import { useCursorPage } from "@/hooks/useCursorPage";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import styles from "@/pages/WebhooksPage.module.css";
+import type { WebhookDetail } from "@/types/tams";
 import { displaySafeUrl } from "@/utils/media-location";
 
 function tone(status?: string) {
@@ -21,6 +23,42 @@ function tone(status?: string) {
   if (status === "error") return "error" as const;
   if (status === "disabled") return "warning" as const;
   return "neutral" as const;
+}
+
+function WebhookFilters({ webhook }: { webhook: WebhookDetail }) {
+  const filters = [
+    ["Flow IDs", webhook.flow_ids, "[]"],
+    ["Source IDs", webhook.source_ids, "[]"],
+    [
+      "Flow collected by",
+      webhook.flow_collected_by_ids,
+      "Top-level Flows only",
+    ],
+    [
+      "Source collected by",
+      webhook.source_collected_by_ids,
+      "Top-level Sources only",
+    ],
+    ["URL labels", webhook.accept_get_urls, "[]"],
+    ["Storage IDs", webhook.accept_storage_ids, "[]"],
+  ] as const;
+  const active = filters.filter(([, values]) => values !== undefined);
+  return (
+    <div>
+      {active.length === 0 && webhook.presigned === undefined && "Unrestricted"}
+      {active.map(([label, values, empty]) => (
+        <div key={label}>
+          <strong>{label}</strong>
+          <div className={`${surfaceStyles.secondary} ${surfaceStyles.mono}`}>
+            {values?.length ? values.join(", ") : empty}
+          </div>
+        </div>
+      ))}
+      {webhook.presigned !== undefined && (
+        <div>Presigned URLs: {webhook.presigned ? "Yes" : "No"}</div>
+      )}
+    </div>
+  );
 }
 
 export default function WebhooksPage() {
@@ -83,10 +121,8 @@ export default function WebhooksPage() {
                       </div>
                     </td>
                     <td>{webhook.events.join(", ")}</td>
-                    <td>
-                      {(webhook.flow_ids?.length ?? 0) +
-                        (webhook.source_ids?.length ?? 0)}{" "}
-                      resource filters
+                    <td className={styles.filters}>
+                      <WebhookFilters webhook={webhook} />
                     </td>
                     <td>
                       <StatusBadge tone={tone(webhook.status)}>

--- a/src/app/frontend/tests/pages/AppRoutes.test.tsx
+++ b/src/app/frontend/tests/pages/AppRoutes.test.tsx
@@ -465,6 +465,42 @@ describe("operational routes", () => {
     expect(document.title).toBe(title);
   });
 
+  it("shows 8.2 webhook selectors and distinguishes absent and empty collections", async () => {
+    mocks.api.getWebhooks.mockResolvedValue({
+      data: [
+        {
+          id: "webhook-filtered",
+          url: "https://receiver.example.test/events?token=secret-value",
+          events: ["flows/segments_added"],
+          status: "started",
+          flow_ids: ["00000000-0000-4000-8000-000000000101"],
+          flow_collected_by_ids: [],
+          source_collected_by_ids: ["00000000-0000-4000-8000-000000000102"],
+          accept_get_urls: ["editorial"],
+          presigned: false,
+        },
+        {
+          id: "webhook-unrestricted",
+          url: "https://receiver.example.test/unrestricted",
+          events: ["sources/created"],
+          status: "created",
+        },
+      ],
+    });
+    renderRoute("/webhooks");
+    expect(await screen.findByText("Top-level Flows only")).toBeVisible();
+    expect(
+      screen.getByText("00000000-0000-4000-8000-000000000101"),
+    ).toBeVisible();
+    expect(
+      screen.getByText("00000000-0000-4000-8000-000000000102"),
+    ).toBeVisible();
+    expect(screen.getByText("editorial")).toBeVisible();
+    expect(screen.getByText("Presigned URLs: No")).toBeVisible();
+    expect(screen.getByText("Unrestricted")).toBeVisible();
+    expect(document.body.textContent).not.toContain("secret-value");
+  });
+
   it("uses the official TAMS assets for the service route", async () => {
     renderRoute("/service");
 

--- a/src/app/tamoss/adapters/postgres_repository/flows_sources.py
+++ b/src/app/tamoss/adapters/postgres_repository/flows_sources.py
@@ -19,12 +19,14 @@ from tamoss.adapters.postgres_repository.mappers import (
 from tamoss.adapters.postgres_repository.query_filters import (
     _append_flow_collected_by_filter,
     _append_flow_timerange_filter,
+    _append_listing_cursor_filter,
     _append_source_collected_by_filter,
     _append_tag_filter_clauses,
     _flows_with_collected_by,
     _listing_order_sql,
     _where_sql,
 )
+from tamoss.domain.listing_pagination import listing_page, listing_window
 from tamoss.domain.listings import FlowSortBy, SourceSortBy
 from tamoss.domain.model import FlowRecord, SourceRecord, SourceRelationships
 from tamoss.domain.pagination import Page, resolve_page_window
@@ -92,7 +94,13 @@ class PostgresFlowSourceMixin:
         page: str | None,
         limit: int | None,
     ) -> Page[FlowRecord]:
-        window = resolve_page_window(page=page, limit=limit)
+        window = listing_window(
+            page=page,
+            limit=limit,
+            resource="flows",
+            sort_by=sort_by,
+            reverse_order=reverse_order,
+        )
         clauses: list[sql.Composable] = []
         params: dict[str, Any] = {
             "offset": window.offset,
@@ -156,12 +164,20 @@ class PostgresFlowSourceMixin:
             collected_by_ids=collected_by_ids,
             top_level_only=top_level_only,
         )
-        where_sql = _where_sql(clauses)
         sort_expression = {
             FlowSortBy.CREATED: sql.SQL("flow.created"),
             FlowSortBy.METADATA_UPDATED: sql.SQL("flow.metadata_updated"),
             FlowSortBy.LABEL: sql.SQL("flow.label"),
         }[sort_by]
+        _append_listing_cursor_filter(
+            clauses,
+            params,
+            window,
+            value_sql=sort_expression,
+            identity_sql=sql.SQL("flow.id"),
+            timestamp=sort_by != FlowSortBy.LABEL,
+        )
+        where_sql = _where_sql(clauses)
         descending = sort_by.descending(reverse_order=reverse_order)
         order_sql = _listing_order_sql(
             sort_expression,
@@ -184,12 +200,18 @@ class PostgresFlowSourceMixin:
                 params,
             )
             rows = cur.fetchall()
-            flows = [_flow_from_record(row[0]) for row in rows[: window.limit]]
+            flows = [_flow_from_record(row[0]) for row in rows]
             flows = _flows_with_collected_by(cur, flows)
-        next_page = (
-            str(window.offset + window.limit) if len(rows) > window.limit else None
+        return listing_page(
+            flows,
+            window,
+            value=lambda flow: {
+                FlowSortBy.CREATED: flow.created,
+                FlowSortBy.METADATA_UPDATED: flow.metadata_updated,
+                FlowSortBy.LABEL: flow.data.get("label"),
+            }[sort_by],
+            identity=lambda flow: flow.id,
         )
-        return Page(items=flows, limit=window.limit, next_page=next_page)
 
     def flow_timeranges(self, flow_ids: Iterable[UUID]) -> dict[UUID, str]:
         requested_ids = list(dict.fromkeys(flow_ids))
@@ -226,6 +248,14 @@ class PostgresFlowSourceMixin:
     def delete_flow(self, flow_id: UUID) -> None:
         with self._connect() as conn, conn.cursor() as cur:
             cur.execute("DELETE FROM tamoss_flows WHERE id = %s", (flow_id,))
+
+    def lock_source(self, source_id: UUID) -> None:
+        if self._transaction_connection.get() is None:
+            raise RuntimeError("Source locks require a unit of work.")
+        with self._connect() as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT id FROM tamoss_sources WHERE id = %s FOR UPDATE", (source_id,)
+            )
 
     def get_source(self, source_id: UUID) -> SourceRecord | None:
         with self._connect() as conn, conn.cursor() as cur:
@@ -301,7 +331,13 @@ class PostgresFlowSourceMixin:
         page: str | None,
         limit: int | None,
     ) -> Page[SourceRecord]:
-        window = resolve_page_window(page=page, limit=limit)
+        window = listing_window(
+            page=page,
+            limit=limit,
+            resource="sources",
+            sort_by=sort_by,
+            reverse_order=reverse_order,
+        )
         clauses: list[sql.Composable] = []
         params: dict[str, Any] = {
             "offset": window.offset,
@@ -326,12 +362,20 @@ class PostgresFlowSourceMixin:
             collected_by_ids=collected_by_ids,
             top_level_only=top_level_only,
         )
-        where_sql = _where_sql(clauses)
         sort_expression = {
             SourceSortBy.CREATED: sql.SQL("source.created"),
             SourceSortBy.UPDATED: sql.SQL("source.metadata_updated"),
             SourceSortBy.LABEL: sql.SQL("source.label"),
         }[sort_by]
+        _append_listing_cursor_filter(
+            clauses,
+            params,
+            window,
+            value_sql=sort_expression,
+            identity_sql=sql.SQL("source.id"),
+            timestamp=sort_by != SourceSortBy.LABEL,
+        )
+        where_sql = _where_sql(clauses)
         descending = sort_by.descending(reverse_order=reverse_order)
         order_sql = _listing_order_sql(
             sort_expression,
@@ -354,11 +398,17 @@ class PostgresFlowSourceMixin:
                 params,
             )
             rows = cur.fetchall()
-        sources = [_source_from_record(row[0]) for row in rows[: window.limit]]
-        next_page = (
-            str(window.offset + window.limit) if len(rows) > window.limit else None
+        sources = [_source_from_record(row[0]) for row in rows]
+        return listing_page(
+            sources,
+            window,
+            value=lambda source: {
+                SourceSortBy.CREATED: source.created,
+                SourceSortBy.UPDATED: source.metadata_updated,
+                SourceSortBy.LABEL: source.label,
+            }[sort_by],
+            identity=lambda source: source.id,
         )
-        return Page(items=sources, limit=window.limit, next_page=next_page)
 
     def source_relationships_for(
         self, source_ids: Iterable[UUID]

--- a/src/app/tamoss/adapters/postgres_repository/query_filters.py
+++ b/src/app/tamoss/adapters/postgres_repository/query_filters.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from datetime import datetime
 from typing import Any
 from uuid import UUID
 
@@ -8,6 +9,7 @@ from psycopg import sql
 from psycopg.types.json import Jsonb
 
 from tamoss.adapters.postgres_repository.types import PostgresCursor
+from tamoss.domain.listing_pagination import ListingWindow
 from tamoss.domain.model import FlowRecord
 
 
@@ -33,6 +35,38 @@ def _listing_order_sql(
         identity_sql,
         direction,
     )
+
+
+def _append_listing_cursor_filter(
+    clauses: list[sql.Composable],
+    params: dict[str, Any],
+    window: ListingWindow,
+    *,
+    value_sql: sql.Composable,
+    identity_sql: sql.Composable,
+    timestamp: bool,
+) -> None:
+    if window.anchor_id is None:
+        return
+    operator = sql.SQL("<") if window.descending else sql.SQL(">")
+    params["cursor_id"] = window.anchor_id
+    tie = sql.SQL("{} {} %(cursor_id)s").format(identity_sql, operator)
+    if window.anchor_value is None:
+        predicate = sql.SQL("({} IS NULL AND {})").format(value_sql, tie)
+        if window.missing_first:
+            predicate += sql.SQL(" OR {} IS NOT NULL").format(value_sql)
+    else:
+        params["cursor_value"] = (
+            datetime.fromisoformat(window.anchor_value)
+            if timestamp
+            else window.anchor_value
+        )
+        predicate = sql.SQL("({}, {}) {} (%(cursor_value)s, %(cursor_id)s)").format(
+            value_sql, identity_sql, operator
+        )
+        if not timestamp and not window.missing_first:
+            predicate += sql.SQL(" OR {} IS NULL").format(value_sql)
+    clauses.append(sql.SQL("(") + predicate + sql.SQL(")"))
 
 
 def _append_flow_collected_by_filter(

--- a/src/app/tamoss/application/contexts/flows.py
+++ b/src/app/tamoss/application/contexts/flows.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Literal
@@ -435,20 +436,26 @@ class FlowUseCases:
         collection: list[dict[str, Any]],
         identity: Identity,
     ) -> None:
-        flow = self.get_flow(flow_id)
-        ensure_flow_writable(flow)
-        self._replace_flow_collection(flow, collection)
-        self._save_and_publish(flow, identity)
+        with self._edit_flow(flow_id, identity) as flow:
+            ensure_flow_writable(flow)
+            self._replace_flow_collection(flow, collection)
 
-    def _save_and_publish(self, flow: FlowRecord, identity: Identity | None) -> None:
-        touch_flow_metadata(flow, identity=identity)
-        self.repository.save_flow(flow)
-        webhooking.publish_flow_event(
-            repository=self.webhook_repository,
-            resource_repository=self.repository,
-            event_type="flows/updated",
-            flow=flow,
-        )
+    @contextmanager
+    def _edit_flow(
+        self, flow_id: UUID, identity: Identity | None
+    ) -> Iterator[FlowRecord]:
+        with self.repository.unit_of_work():
+            self.repository.lock_flow_segments(flow_id)
+            flow = self.get_flow(flow_id)
+            yield flow
+            touch_flow_metadata(flow, identity=identity)
+            self.repository.save_flow(flow)
+            webhooking.publish_flow_event(
+                repository=self.webhook_repository,
+                resource_repository=self.repository,
+                event_type="flows/updated",
+                flow=flow,
+            )
 
     def delete_flow_collection(self, *, flow_id: UUID, identity: Identity) -> None:
         self.set_flow_collection(flow_id=flow_id, collection=[], identity=identity)
@@ -483,26 +490,25 @@ class FlowUseCases:
         *,
         identity: Identity | None = None,
     ) -> None:
-        flow = self.get_flow(flow_id)
-        if property_name in {"label", "description"}:
-            ensure_flow_writable(flow)
-            if not isinstance(value, str):
-                raise BadRequest("Bad request. Invalid Flow property value.")
-        elif property_name in {"avg_bit_rate", "max_bit_rate"}:
-            ensure_flow_writable(flow)
-            if property_name == "avg_bit_rate" and flow.profile_id is not None:
-                raise BadRequest(
-                    "Bad request. Profile-backed Flows cannot override "
-                    "average bit rate."
-                )
-            if not isinstance(value, int) or isinstance(value, bool) or value < 0:
-                raise BadRequest("Bad request. Invalid Flow bit rate.")
-        else:
-            if not isinstance(value, bool):
-                raise BadRequest("Bad request. Invalid Flow read_only value.")
-            flow.read_only = value
-        flow.data[property_name] = value
-        self._save_and_publish(flow, identity)
+        with self._edit_flow(flow_id, identity) as flow:
+            if property_name in {"label", "description"}:
+                ensure_flow_writable(flow)
+                if not isinstance(value, str):
+                    raise BadRequest("Bad request. Invalid Flow property value.")
+            elif property_name in {"avg_bit_rate", "max_bit_rate"}:
+                ensure_flow_writable(flow)
+                if property_name == "avg_bit_rate" and flow.profile_id is not None:
+                    raise BadRequest(
+                        "Bad request. Profile-backed Flows cannot override "
+                        "average bit rate."
+                    )
+                if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                    raise BadRequest("Bad request. Invalid Flow bit rate.")
+            else:
+                if not isinstance(value, bool):
+                    raise BadRequest("Bad request. Invalid Flow read_only value.")
+                flow.read_only = value
+            flow.data[property_name] = value
 
     def delete_flow_property(
         self,
@@ -511,14 +517,14 @@ class FlowUseCases:
         *,
         identity: Identity | None = None,
     ) -> None:
-        flow = self.get_flow(flow_id)
-        ensure_flow_writable(flow)
-        if property_name == "avg_bit_rate" and flow.profile_id is not None:
-            raise BadRequest(
-                "Bad request. Profile-backed Flows cannot override average bit rate."
-            )
-        flow.data.pop(property_name, None)
-        self._save_and_publish(flow, identity)
+        with self._edit_flow(flow_id, identity) as flow:
+            ensure_flow_writable(flow)
+            if property_name == "avg_bit_rate" and flow.profile_id is not None:
+                raise BadRequest(
+                    "Bad request. Profile-backed Flows cannot override "
+                    "average bit rate."
+                )
+            flow.data.pop(property_name, None)
 
     def get_flow_tags(self, flow_id: UUID) -> dict[str, TagValue]:
         return self.get_flow(flow_id).tags
@@ -539,11 +545,10 @@ class FlowUseCases:
     ) -> None:
         if not valid_tag_value(value):
             raise BadRequest("Bad request. Invalid Flow tag value.")
-        flow = self.get_flow(flow_id)
-        ensure_flow_writable(flow)
-        flow.tags[name] = value
-        flow.data["tags"] = flow.tags
-        self._save_and_publish(flow, identity)
+        with self._edit_flow(flow_id, identity) as flow:
+            ensure_flow_writable(flow)
+            flow.tags[name] = value
+            flow.data["tags"] = flow.tags
 
     def delete_flow_tag(
         self,
@@ -552,11 +557,10 @@ class FlowUseCases:
         *,
         identity: Identity | None = None,
     ) -> None:
-        flow = self.get_flow(flow_id)
-        ensure_flow_writable(flow)
-        flow.tags.pop(name, None)
-        flow.data["tags"] = flow.tags
-        self._save_and_publish(flow, identity)
+        with self._edit_flow(flow_id, identity) as flow:
+            ensure_flow_writable(flow)
+            flow.tags.pop(name, None)
+            flow.data["tags"] = flow.tags
 
     def _replace_flow_collection(
         self, flow: FlowRecord, collection: list[dict[str, Any]] | None

--- a/src/app/tamoss/application/contexts/sources.py
+++ b/src/app/tamoss/application/contexts/sources.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
 from typing import Literal
 from uuid import UUID
 
@@ -129,26 +130,29 @@ class SourceUseCases:
     ) -> None:
         if not isinstance(value, str):
             raise BadRequest("Bad request. Invalid Source property value.")
-        source = self.get_source(source_id)
-        setattr(source, property_name, value)
-        self._save_and_publish(source)
+        with self._edit_source(source_id) as source:
+            setattr(source, property_name, value)
 
     def delete_source_property(
         self, source_id: UUID, property_name: SourcePropertyName
     ) -> None:
-        source = self.get_source(source_id)
-        setattr(source, property_name, None)
-        self._save_and_publish(source)
+        with self._edit_source(source_id) as source:
+            setattr(source, property_name, None)
 
-    def _save_and_publish(self, source: SourceRecord) -> None:
-        source.metadata_updated = utc_now()
-        self.repository.save_source(source)
-        webhooking.publish_source_event(
-            repository=self.webhook_repository,
-            resource_repository=self.repository,
-            event_type="sources/updated",
-            source=source,
-        )
+    @contextmanager
+    def _edit_source(self, source_id: UUID) -> Iterator[SourceRecord]:
+        with self.repository.unit_of_work():
+            self.repository.lock_source(source_id)
+            source = self.get_source(source_id)
+            yield source
+            source.metadata_updated = utc_now()
+            self.repository.save_source(source)
+            webhooking.publish_source_event(
+                repository=self.webhook_repository,
+                resource_repository=self.repository,
+                event_type="sources/updated",
+                source=source,
+            )
 
     def get_source_tags(self, source_id: UUID) -> dict[str, TagValue]:
         return self.get_source(source_id).tags
@@ -162,11 +166,9 @@ class SourceUseCases:
     def set_source_tag(self, source_id: UUID, name: str, value: TagValue) -> None:
         if not valid_tag_value(value):
             raise BadRequest("Bad request. Invalid Source tag value.")
-        source = self.get_source(source_id)
-        source.tags[name] = value
-        self._save_and_publish(source)
+        with self._edit_source(source_id) as source:
+            source.tags[name] = value
 
     def delete_source_tag(self, source_id: UUID, name: str) -> None:
-        source = self.get_source(source_id)
-        source.tags.pop(name, None)
-        self._save_and_publish(source)
+        with self._edit_source(source_id) as source:
+            source.tags.pop(name, None)

--- a/src/app/tamoss/application/webhooks.py
+++ b/src/app/tamoss/application/webhooks.py
@@ -8,6 +8,7 @@ import time
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from functools import lru_cache
+from http.cookiejar import DefaultCookiePolicy
 from typing import Protocol
 from urllib.parse import ParseResult, urljoin, urlparse
 from uuid import UUID, uuid4
@@ -15,6 +16,13 @@ from uuid import UUID, uuid4
 import requests
 from requests import Response
 from requests.adapters import HTTPAdapter
+from urllib3.connection import HTTPConnection, HTTPSConnection
+from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
+from urllib3.exceptions import (
+    ConnectTimeoutError,
+    NameResolutionError,
+    NewConnectionError,
+)
 
 from tamoss.application.contexts.object_get_urls import objects_get_urls
 from tamoss.contract.payloads import (
@@ -90,10 +98,8 @@ _WEBHOOK_CREDENTIAL_REF = "webhook.api_key_value"
 _HTTP_POOL_CONNECTIONS = 32
 _HTTP_POOL_MAXSIZE = 128
 
-# Egress validation resolves receiver hostnames repeatedly (twice per
-# delivery attempt); a short TTL cache absorbs that without materially
-# changing rebinding exposure, since the post-validation connect resolves
-# independently either way.
+# Cached addresses are also the literal connection destinations: the HTTP
+# transport never resolves the receiver hostname a second time.
 _DNS_CACHE_TTL_SECONDS = 30.0
 _DNS_CACHE_MAX_ENTRIES = 1024
 _dns_cache_lock = threading.Lock()
@@ -103,16 +109,71 @@ _dns_cache: dict[
 ] = {}
 
 
-@lru_cache(maxsize=1)
-def _http_session() -> requests.Session:
+class _RejectCookies(DefaultCookiePolicy):
+    def set_ok(self, *_args: object, **_kwargs: object) -> bool:
+        return False
+
+
+@lru_cache(maxsize=16)
+def _http_session(policy: WebhookEgressPolicy) -> requests.Session:
+    class ValidatedHTTPConnection(HTTPConnection):
+        def _new_conn(self) -> socket.socket:
+            return _connect_validated(self, super()._new_conn, policy)
+
+    class ValidatedHTTPSConnection(HTTPSConnection):
+        def _new_conn(self) -> socket.socket:
+            return _connect_validated(self, super()._new_conn, policy)
+
+    class ValidatedHTTPPool(HTTPConnectionPool):
+        ConnectionCls = ValidatedHTTPConnection
+
+    class ValidatedHTTPSPool(HTTPSConnectionPool):
+        ConnectionCls = ValidatedHTTPSConnection
+
     session = requests.Session()
+    # Ambient proxies can resolve the hostname themselves, bypassing the
+    # validated socket path. Webhook credentials come only from registration.
+    session.trust_env = False
+    session.cookies.set_policy(_RejectCookies())
     adapter = HTTPAdapter(
         pool_connections=_HTTP_POOL_CONNECTIONS,
         pool_maxsize=_HTTP_POOL_MAXSIZE,
     )
+    adapter.poolmanager.pool_classes_by_scheme = {
+        "http": ValidatedHTTPPool,
+        "https": ValidatedHTTPSPool,
+    }
     session.mount("https://", adapter)
     session.mount("http://", adapter)
     return session
+
+
+def _connect_validated(
+    connection: HTTPConnection,
+    connect: Callable[[], socket.socket],
+    policy: WebhookEgressPolicy,
+) -> socket.socket:
+    hostname = connection._dns_host
+    port = connection.port or connection.default_port
+    addresses = _resolve_host_addresses(hostname, port)
+    _validate_resolved_addresses(hostname, addresses, policy)
+    if not addresses:
+        raise NameResolutionError(
+            hostname, connection, socket.gaierror("Webhook hostname did not resolve")
+        )
+    last_error: NewConnectionError | ConnectTimeoutError | None = None
+    for address in addresses:
+        try:
+            # Only the dial target changes. Restore the original hostname
+            # before urllib3 performs TLS/SNI and HTTP Host processing.
+            connection._dns_host = str(address)
+            return connect()
+        except (NewConnectionError, ConnectTimeoutError) as exc:
+            last_error = exc
+        finally:
+            connection._dns_host = hostname
+    assert last_error is not None
+    raise last_error
 
 
 @dataclass(frozen=True)
@@ -631,7 +692,7 @@ def send_webhook_delivery(
     validate_webhook_url(url, egress_policy=egress_policy)
     start = time.perf_counter()
     try:
-        response = _http_session().post(
+        response = _http_session(egress_policy or WebhookEgressPolicy()).post(
             url,
             headers=webhook_headers(webhook),
             json=payload,
@@ -705,7 +766,21 @@ def validate_webhook_target(
         return
 
     port = parsed.port or (443 if parsed.scheme == "https" else 80)
-    for address in _resolve_host_addresses(hostname, port):
+    _validate_resolved_addresses(
+        hostname, _resolve_host_addresses(hostname, port), policy
+    )
+
+
+def _validate_resolved_addresses(
+    hostname: str,
+    addresses: list[ipaddress.IPv4Address | ipaddress.IPv6Address],
+    policy: WebhookEgressPolicy,
+) -> None:
+    if policy.allow_private_targets or _host_allowed(
+        _normalized_hostname(hostname), policy.allowed_hosts
+    ):
+        return
+    for address in addresses:
         if _blocked_ip(address):
             raise WebhookEgressError(
                 "Webhook URL resolves to a restricted network destination"

--- a/src/app/tamoss/domain/listing_pagination.py
+++ b/src/app/tamoss/domain/listing_pagination.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from uuid import UUID
+
+from tamoss.domain.listings import ListingSortBy
+from tamoss.domain.pagination import Page, resolve_page_window
+from tamoss.errors import BadRequest
+
+_PREFIX = "k1."
+
+
+def listing_value(value: datetime | str | None) -> str | None:
+    return value.astimezone(UTC).isoformat() if isinstance(value, datetime) else value
+
+
+@dataclass(frozen=True)
+class ListingWindow:
+    context: str
+    limit: int
+    offset: int
+    descending: bool
+    missing_first: bool
+    anchor_id: UUID | None = None
+    anchor_value: str | None = None
+
+    def follows(self, value: datetime | str | None, identity: UUID) -> bool:
+        if self.anchor_id is None:
+            return True
+        comparable = listing_value(value)
+        if comparable is None and self.anchor_value is not None:
+            return not self.missing_first
+        if comparable is not None and self.anchor_value is None:
+            return self.missing_first
+        if comparable == self.anchor_value:
+            return (
+                identity < self.anchor_id
+                if self.descending
+                else identity > self.anchor_id
+            )
+        assert comparable is not None and self.anchor_value is not None
+        return (
+            comparable < self.anchor_value
+            if self.descending
+            else comparable > self.anchor_value
+        )
+
+    def next_page(self, value: datetime | str | None, identity: UUID) -> str:
+        payload = json.dumps([self.context, listing_value(value), str(identity)])
+        return _PREFIX + base64.urlsafe_b64encode(payload.encode()).decode().rstrip("=")
+
+
+def listing_window(
+    *,
+    page: str | None,
+    limit: int | None,
+    resource: str,
+    sort_by: ListingSortBy,
+    reverse_order: bool,
+) -> ListingWindow:
+    context = f"{resource}:{sort_by.value}:{int(reverse_order)}"
+    legacy = resolve_page_window(
+        page=None if page and page.startswith(_PREFIX) else page, limit=limit
+    )
+    anchor_id = None
+    anchor_value = None
+    if page and page.startswith(_PREFIX):
+        try:
+            encoded = page[len(_PREFIX) :]
+            decoded = json.loads(
+                base64.b64decode(
+                    encoded + "=" * (-len(encoded) % 4), altchars=b"-_", validate=True
+                )
+            )
+            if (
+                not isinstance(decoded, list)
+                or len(decoded) != 3
+                or decoded[0] != context
+            ):
+                raise BadRequest("page token is invalid for this listing.")
+            anchor_value = decoded[1]
+            if anchor_value is not None and not isinstance(anchor_value, str):
+                raise BadRequest("page token has an invalid value.")
+            anchor_id = UUID(decoded[2])
+            if sort_by.value != "label":
+                if anchor_value is None:
+                    raise BadRequest("page token requires a timestamp.")
+                timestamp = datetime.fromisoformat(anchor_value)
+                if timestamp.tzinfo is None:
+                    raise BadRequest("page token requires a timestamp timezone.")
+                anchor_value = listing_value(timestamp)
+        except (
+            ValueError,
+            TypeError,
+            AttributeError,
+            RecursionError,
+            binascii.Error,
+        ) as exc:
+            raise BadRequest("page token is invalid for this listing.") from exc
+    return ListingWindow(
+        context,
+        legacy.limit,
+        legacy.offset,
+        sort_by.descending(reverse_order=reverse_order),
+        reverse_order,
+        anchor_id,
+        anchor_value,
+    )
+
+
+def listing_page[T](
+    items: Sequence[T],
+    window: ListingWindow,
+    *,
+    value: Callable[[T], datetime | str | None],
+    identity: Callable[[T], UUID],
+) -> Page[T]:
+    chunk = list(items[: window.limit])
+    token = (
+        window.next_page(value(chunk[-1]), identity(chunk[-1]))
+        if len(items) > window.limit
+        else None
+    )
+    return Page(items=chunk, limit=window.limit, next_page=token)
+
+
+def page_listing_sequence[T](
+    items: Sequence[T],
+    *,
+    page: str | None,
+    limit: int | None,
+    resource: str,
+    sort_by: ListingSortBy,
+    reverse_order: bool,
+    value: Callable[[T], datetime | str | None],
+    identity: Callable[[T], UUID],
+) -> Page[T]:
+    window = listing_window(
+        page=page,
+        limit=limit,
+        resource=resource,
+        sort_by=sort_by,
+        reverse_order=reverse_order,
+    )
+    remaining = [item for item in items if window.follows(value(item), identity(item))]
+    return listing_page(
+        remaining[window.offset : window.offset + window.limit + 1],
+        window,
+        value=value,
+        identity=identity,
+    )

--- a/src/app/tamoss/ports/repositories.py
+++ b/src/app/tamoss/ports/repositories.py
@@ -147,7 +147,9 @@ class FlowRepository(TransactionalRepository, FlowCollectionRepository, Protocol
     def save_flow(self, flow: FlowRecord) -> None: ...
 
 
-class SourceRepository(Protocol):
+class SourceRepository(TransactionalRepository, Protocol):
+    def lock_source(self, source_id: UUID) -> None: ...
+
     def list_sources_page(
         self,
         *,

--- a/tests/adapters/postgres/test_listing_cursors.py
+++ b/tests/adapters/postgres/test_listing_cursors.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+import pytest
+from fastapi.testclient import TestClient
+from tamoss.adapters.postgres import PostgresRepository
+from tamoss.app import create_app
+from tamoss.domain.model import FlowRecord, SourceRecord
+
+from tests.adapters.postgres.support import use_cases
+from tests.tams.support import video_flow_payload
+
+pytestmark = pytest.mark.needs_db
+
+
+def seed_listing(repository: PostgresRepository, resource: str) -> None:
+    for index, label in enumerate([None, None, "Alpha", "Alpha", "Beta", "Beta"]):
+        timestamp = datetime(2026, 9, 1, tzinfo=UTC) + timedelta(days=index // 2)
+        identity = UUID(int=index + 1, version=4)
+        source_id = UUID(int=100, version=4)
+        if resource == "flows":
+            repository.flow_repository.save_flow(
+                FlowRecord(
+                    id=identity,
+                    source_id=source_id,
+                    format="urn:x-nmos:format:video",
+                    container="video/mp4",
+                    data={**video_flow_payload(identity, source_id), "label": label},
+                    created=timestamp,
+                    metadata_updated=timestamp,
+                )
+            )
+        else:
+            repository.source_repository.save_source(
+                SourceRecord(
+                    id=identity,
+                    format="urn:x-nmos:format:video",
+                    label=label,
+                    created=timestamp,
+                    metadata_updated=timestamp,
+                )
+            )
+
+
+@pytest.mark.parametrize(
+    ("resource", "sort_by"),
+    [("flows", sort) for sort in ("created", "metadata_updated", "label")]
+    + [("sources", sort) for sort in ("created", "updated", "label")],
+)
+@pytest.mark.parametrize("reverse_order", [False, True])
+def test_cursor_survives_deleting_every_preceding_page_including_anchor(
+    postgres_repo: PostgresRepository,
+    resource: str,
+    sort_by: str,
+    reverse_order: bool,
+) -> None:
+    seed_listing(postgres_repo, resource)
+    delete = (
+        postgres_repo.flow_repository.delete_flow
+        if resource == "flows"
+        else postgres_repo.source_repository.delete_source
+    )
+    with TestClient(create_app(use_cases=use_cases(postgres_repo))) as client:
+        params = {"sort_by": sort_by, "reverse_order": str(reverse_order).lower()}
+        baseline = client.get(f"/{resource}", params=params)
+        assert baseline.status_code == 200
+        expected = [item["id"] for item in baseline.json()]
+        assert len(expected) == 6
+        response = client.get(f"/{resource}", params={**params, "limit": 2})
+        seen = []
+        for _ in range(3):
+            assert response.status_code == 200
+            page = response.json()
+            assert len(page) == 2
+            seen.extend(item["id"] for item in page)
+            for item in page:
+                delete(UUID(item["id"]))
+            if "next" not in response.links:
+                break
+            next_url = response.links["next"]["url"]
+            assert "page=k1." in next_url
+            response = client.get(next_url)
+        assert "next" not in response.links
+        assert seen == expected
+
+
+@pytest.mark.parametrize("resource", ["flows", "sources"])
+def test_newer_insert_does_not_repeat_items_and_legacy_offsets_still_work(
+    postgres_repo: PostgresRepository, resource: str
+) -> None:
+    seed_listing(postgres_repo, resource)
+    with TestClient(create_app(use_cases=use_cases(postgres_repo))) as client:
+        expected = client.get(f"/{resource}").json()
+        first = client.get(f"/{resource}", params={"limit": 2})
+        assert first.status_code == 200
+        assert client.get(f"/{resource}", params={"page": "2"}).json() == expected[2:]
+        if resource == "flows":
+            record = postgres_repo.flow_repository.get_flow(UUID(int=1, version=4))
+            assert record is not None
+            record.id = UUID(int=99, version=4)
+            record.created += timedelta(days=10)
+            postgres_repo.flow_repository.save_flow(record)
+        else:
+            record = postgres_repo.source_repository.get_source(UUID(int=1, version=4))
+            assert record is not None
+            record.id = UUID(int=99, version=4)
+            record.created += timedelta(days=10)
+            postgres_repo.source_repository.save_source(record)
+        seen = first.json()
+        while "next" in first.links:
+            first = client.get(first.links["next"]["url"])
+            assert first.status_code == 200
+            seen.extend(first.json())
+        assert seen == expected
+
+
+def test_invalid_and_wrong_context_cursors_return_bad_request(
+    postgres_repo: PostgresRepository,
+) -> None:
+    seed_listing(postgres_repo, "flows")
+    with TestClient(create_app(use_cases=use_cases(postgres_repo))) as client:
+        for page in ("k1.invalid!", "k1.W10", "k1." + "x" * 4097, "-1"):
+            assert client.get("/flows", params={"page": page}).status_code == 400
+        first = client.get("/flows", params={"limit": 2})
+        next_url = first.links["next"]["url"]
+        assert client.get(next_url.replace("/flows?", "/sources?")).status_code == 400
+        assert client.get(next_url + "&sort_by=label").status_code == 400
+        assert client.get(next_url + "&reverse_order=true").status_code == 400

--- a/tests/adapters/postgres/test_metadata_events.py
+++ b/tests/adapters/postgres/test_metadata_events.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import ExitStack
+from threading import Event
+from uuid import uuid4
+
+import psycopg
+import pytest
+from fastapi.testclient import TestClient
+from psycopg import sql
+from tamoss.adapters.postgres import PostgresRepository
+from tamoss.app import create_app
+
+from tests.adapters.postgres.support import database_url, primary_backend, use_cases
+from tests.tams.support import video_flow_payload, webhook_payload
+
+pytestmark = pytest.mark.needs_db
+
+
+@pytest.mark.parametrize(
+    ("resource", "method", "property_path", "value"),
+    [
+        ("flows", "PUT", "label", "After"),
+        ("flows", "DELETE", "label", None),
+        ("flows", "PUT", "description", "After"),
+        ("flows", "PUT", "avg_bit_rate", 1000),
+        ("flows", "PUT", "max_bit_rate", 2000),
+        ("flows", "PUT", "read_only", True),
+        ("flows", "PUT", "tags/review", "After"),
+        ("flows", "DELETE", "tags/review", None),
+        ("flows", "PUT", "flow_collection", []),
+        ("sources", "PUT", "label", "After"),
+        ("sources", "DELETE", "label", None),
+        ("sources", "PUT", "description", "After"),
+        ("sources", "PUT", "tags/review", "After"),
+        ("sources", "DELETE", "tags/review", None),
+    ],
+)
+def test_metadata_and_all_notifications_roll_back_together(
+    postgres_repo: PostgresRepository,
+    postgres_connection: psycopg.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+    resource: str,
+    method: str,
+    property_path: str,
+    value: object,
+) -> None:
+    cases = use_cases(postgres_repo)
+    hooks = postgres_repo.webhook_repository
+    with TestClient(
+        create_app(use_cases=cases), raise_server_exceptions=False
+    ) as client:
+        flow_id, source_id = uuid4(), uuid4()
+        assert (
+            client.put(
+                f"/flows/{flow_id}",
+                json=video_flow_payload(flow_id, source_id, label="Before"),
+            ).status_code
+            == 201
+        )
+        path = f"/{resource}/{flow_id if resource == 'flows' else source_id}"
+        assert client.put(path + "/tags/review", json="Before").status_code == 204
+        before = client.get(path).json()
+        for _ in range(2):
+            assert (
+                client.post(
+                    "/service/webhooks",
+                    json=webhook_payload(events=[f"{resource}/updated"]),
+                ).status_code
+                == 201
+            )
+        insert = hooks.save_webhook_delivery
+        inserted = 0
+
+        def fail_second_insert(delivery):
+            nonlocal inserted
+            inserted += 1
+            if inserted == 2:
+                postgres_connection.execute("SELECT 1 / 0")
+            insert(delivery)
+
+        with monkeypatch.context() as patch:
+            patch.setattr(hooks, "save_webhook_delivery", fail_second_insert)
+            response = client.request(method, path + "/" + property_path, json=value)
+        assert response.status_code == 500
+        assert inserted == 2
+        assert client.get(path).json() == before
+        assert hooks.list_webhook_deliveries() == []
+        assert all(hook.status == "created" for hook in hooks.list_webhooks())
+
+        retry = client.request(method, path + "/" + property_path, json=value)
+        assert retry.status_code == 204
+        assert len(hooks.list_webhook_deliveries()) == 2
+
+
+@pytest.mark.parametrize("resource", ["flow", "source"])
+def test_concurrent_metadata_edits_lock_before_reading_and_preserve_both_events(
+    postgres_repo: PostgresRepository,
+    postgres_connection: psycopg.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+    resource: str,
+) -> None:
+    cases = use_cases(postgres_repo)
+    flow_id, source_id = uuid4(), uuid4()
+    with TestClient(create_app(use_cases=cases)) as client:
+        assert (
+            client.put(
+                f"/flows/{flow_id}", json=video_flow_payload(flow_id, source_id)
+            ).status_code
+            == 201
+        )
+        assert (
+            client.post(
+                "/service/webhooks",
+                json=webhook_payload(events=[f"{resource}s/updated"]),
+            ).status_code
+            == 201
+        )
+
+    schema = postgres_connection.execute("SELECT current_schema()").fetchone()[0]
+    with ExitStack() as stack:
+        connections = [
+            stack.enter_context(psycopg.connect(database_url(), autocommit=True))
+            for _ in range(2)
+        ]
+        for connection in connections:
+            connection.execute(
+                sql.SQL("SET search_path TO {}").format(sql.Identifier(schema))
+            )
+        repos = [
+            PostgresRepository(connection=connection, storage_backend=primary_backend())
+            for connection in connections
+        ]
+        first = getattr(use_cases(repos[0]), resource + "s")
+        second = getattr(use_cases(repos[1]), resource + "s")
+        repository = getattr(repos[0], resource + "_repository")
+        get_record = getattr(repository, "get_" + resource)
+        entered, release = Event(), Event()
+
+        def hold_first_read(identity):
+            record = get_record(identity)
+            if not entered.is_set():
+                entered.set()
+                assert release.wait(10)
+            return record
+
+        monkeypatch.setattr(repository, "get_" + resource, hold_first_read)
+        identity = flow_id if resource == "flow" else source_id
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            writer = executor.submit(
+                getattr(first, f"set_{resource}_tag"), identity, "first", "one"
+            )
+            try:
+                assert entered.wait(5)
+                waiter = executor.submit(
+                    getattr(second, f"set_{resource}_tag"), identity, "second", "two"
+                )
+                deadline = time.monotonic() + 5
+                blocked = False
+                while time.monotonic() < deadline:
+                    blocked = postgres_connection.execute(
+                        "SELECT %s = ANY(pg_blocking_pids(%s))",
+                        (
+                            connections[0].info.backend_pid,
+                            connections[1].info.backend_pid,
+                        ),
+                    ).fetchone()[0]
+                    if blocked:
+                        break
+                    time.sleep(0.01)
+                assert blocked, "Second writer did not wait for the first writer"
+            finally:
+                release.set()
+            writer.result(timeout=5)
+            waiter.result(timeout=5)
+
+        record = getattr(getattr(cases, resource + "s"), "get_" + resource)(identity)
+        assert record.tags == {"first": "one", "second": "two"}
+        deliveries = postgres_repo.webhook_repository.list_webhook_deliveries()
+        assert len(deliveries) == 2
+        tags = [delivery.payload["event"][resource]["tags"] for delivery in deliveries]
+        assert {"first": "one"} in tags
+        assert {"first": "one", "second": "two"} in tags

--- a/tests/adapters/postgres/test_webhook_diagnostics.py
+++ b/tests/adapters/postgres/test_webhook_diagnostics.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+from uuid import uuid4
+
+import psycopg
+import pytest
+from tamoss.adapters.postgres import PostgresRepository
+from tamoss.domain.model import (
+    DomainErrorPayload,
+    WebhookDeliveryRecord,
+    WebhookRecord,
+    utc_now,
+)
+
+from tests.support.paths import REPO_ROOT, load_python_module
+
+pytestmark = pytest.mark.needs_db
+
+
+def test_diagnostics_are_bounded_scoped_and_do_not_expose_credentials(
+    postgres_repo: PostgresRepository, postgres_connection: psycopg.Connection
+) -> None:
+    module = load_python_module(
+        "webhook_diagnostics", REPO_ROOT / "scripts/webhook_diagnostics.py"
+    )
+    hooks = postgres_repo.webhook_repository
+    webhook_id, unrelated_id = uuid4(), uuid4()
+    for identity in (webhook_id, unrelated_id):
+        hooks.save_webhook(
+            WebhookRecord(
+                id=identity,
+                status="started",
+                data={
+                    "url": "https://user:private-password@receiver.example/events?token=secret-token",
+                    "api_key_value": "private-api-key",
+                    "events": ["flows/created"],
+                    "flow_collected_by_ids": [],
+                },
+            )
+        )
+    now = utc_now()
+    for index in range(25):
+        delivery = WebhookDeliveryRecord(
+            id=uuid4(),
+            webhook_id=webhook_id if index < 24 else unrelated_id,
+            webhook_snapshot={"api_key_value": "private-api-key"},
+            event_type="flows/created",
+            event_timestamp=now,
+            payload={"url": "https://storage.example/?token=private-media-token"},
+            status=["done", "dead", "started", "pending"][index % 4],
+            attempt_count=2,
+            error=DomainErrorPayload.create("HTTPError", "private-error-url"),
+            response_status=503,
+        )
+        if delivery.status == "started":
+            delivery.claimed_by = "expired-worker"
+            delivery.claim_expires_at = now - timedelta(minutes=1)
+        hooks.save_webhook_delivery(delivery)
+    result = module.report(postgres_connection, webhook_id)
+    assert result["receiver_host"] == "receiver.example"
+    assert result["filters"] == {"flow_collected_by_ids": []}
+    summary = result["retained_deliveries"]
+    assert [
+        summary[key] for key in ("pending", "started", "done", "dead", "expired_claims")
+    ] == [6] * 5
+    assert summary["oldest_pending_at"] is not None
+    assert summary["last_success_at"] is not None
+    assert len(result["recent_deliveries"]) == 20
+    serialized = json.dumps(result, default=str)
+    for secret in (
+        "private-",
+        "secret-token",
+        "api_key_value",
+        "webhook_snapshot",
+        "payload",
+    ):
+        assert secret not in serialized
+    assert len(hooks.list_webhook_deliveries()) == 25
+    with pytest.raises(ValueError, match="does not exist"):
+        module.report(postgres_connection, uuid4())
+
+
+def test_expired_delivery_claim_is_recovered_without_resetting_attempts(
+    postgres_repo: PostgresRepository, postgres_connection: psycopg.Connection
+) -> None:
+    hooks = postgres_repo.webhook_repository
+    webhook_id = uuid4()
+    hooks.save_webhook(WebhookRecord(id=webhook_id, status="started", data={}))
+    delivery = WebhookDeliveryRecord(
+        id=uuid4(),
+        webhook_id=webhook_id,
+        webhook_snapshot={},
+        event_type="flows/created",
+        event_timestamp=utc_now(),
+        payload={},
+        status="pending",
+        attempt_count=2,
+    )
+    hooks.save_webhook_delivery(delivery)
+    first = hooks.claim_webhook_deliveries(
+        worker_id="worker-one", limit=1, lease_seconds=60
+    )
+    assert len(first) == 1
+    assert (
+        hooks.claim_webhook_deliveries(
+            worker_id="worker-two", limit=1, lease_seconds=60
+        )
+        == []
+    )
+    postgres_connection.execute(
+        "UPDATE tamoss_webhook_deliveries "
+        "SET claim_expires_at = NOW() - INTERVAL '1 second' WHERE id = %s",
+        (delivery.id,),
+    )
+    recovered = hooks.claim_webhook_deliveries(
+        worker_id="worker-two", limit=1, lease_seconds=60
+    )
+    assert len(recovered) == 1
+    assert recovered[0].id == delivery.id
+    assert recovered[0].claimed_by == "worker-two"
+    assert recovered[0].attempt_count == 2

--- a/tests/application/test_webhook_security.py
+++ b/tests/application/test_webhook_security.py
@@ -84,7 +84,7 @@ def test_webhook_delivery_blocks_redirect_to_private_target(
         lambda hostname, port: [ipaddress.ip_address("93.184.216.34")],
     )
     recording_session = RecordingSession()
-    monkeypatch.setattr(webhooks, "_http_session", lambda: recording_session)
+    monkeypatch.setattr(webhooks, "_http_session", lambda policy: recording_session)
 
     with pytest.raises(webhooks.WebhookEgressError, match="restricted"):
         webhooks.send_webhook_delivery(
@@ -112,7 +112,7 @@ def test_webhook_delivery_records_success_metric(
         "_resolve_host_addresses",
         lambda hostname, port: [ipaddress.ip_address("93.184.216.34")],
     )
-    monkeypatch.setattr(webhooks, "_http_session", OkSession)
+    monkeypatch.setattr(webhooks, "_http_session", lambda policy: OkSession())
 
     before_count = _delivery_count("success")
     before_sum = _delivery_observations("success")
@@ -138,7 +138,7 @@ def test_webhook_delivery_records_failure_metric_on_transport_error(
         "_resolve_host_addresses",
         lambda hostname, port: [ipaddress.ip_address("93.184.216.34")],
     )
-    monkeypatch.setattr(webhooks, "_http_session", FailingSession)
+    monkeypatch.setattr(webhooks, "_http_session", lambda policy: FailingSession())
 
     before = _delivery_count("failure")
     with pytest.raises(requests.Timeout):

--- a/tests/application/test_webhook_transport.py
+++ b/tests/application/test_webhook_transport.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import ipaddress
+import socket
+import ssl
+from datetime import UTC, datetime, timedelta
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from threading import Thread
+from unittest.mock import Mock
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+from tamoss.application import webhooks
+from urllib3.exceptions import NewConnectionError
+
+
+@pytest.mark.parametrize("scheme", ["http", "https"])
+def test_connection_dials_validated_literal_and_preserves_hostname(
+    monkeypatch: pytest.MonkeyPatch, scheme: str
+) -> None:
+    policy = webhooks.WebhookEgressPolicy()
+    adapter = webhooks._http_session(policy).get_adapter(scheme + "://")
+    pool = adapter.poolmanager.connection_from_url(scheme + "://receiver.example.test")
+    connection = pool.ConnectionCls("receiver.example.test", port=443)
+    monkeypatch.setattr(
+        webhooks,
+        "_resolve_host_addresses",
+        lambda hostname, port: [ipaddress.ip_address("93.184.216.34")],
+    )
+    dial = Mock(return_value=object())
+    monkeypatch.setattr("urllib3.util.connection.create_connection", dial)
+    connection._new_conn()
+    assert dial.call_args.args[0] == ("93.184.216.34", 443)
+    assert connection.host == "receiver.example.test"
+    assert connection._dns_host == "receiver.example.test"
+
+
+def test_connection_rejects_rebound_address_before_opening_socket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    policy = webhooks.WebhookEgressPolicy()
+    addresses = [ipaddress.ip_address("93.184.216.34")]
+    monkeypatch.setattr(
+        webhooks, "_resolve_host_addresses", lambda host, port: addresses
+    )
+    webhooks.validate_webhook_url("https://receiver.example.test", egress_policy=policy)
+    addresses[:] = [ipaddress.ip_address("127.0.0.1")]
+    adapter = webhooks._http_session(policy).get_adapter("https://")
+    pool = adapter.poolmanager.connection_from_url("https://receiver.example.test")
+    dial = Mock()
+    monkeypatch.setattr("urllib3.util.connection.create_connection", dial)
+    with pytest.raises(webhooks.WebhookEgressError):
+        pool.ConnectionCls("receiver.example.test")._new_conn()
+    dial.assert_not_called()
+
+
+def test_connection_tries_other_validated_addresses_on_connect_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    policy = webhooks.WebhookEgressPolicy()
+    monkeypatch.setattr(
+        webhooks,
+        "_resolve_host_addresses",
+        lambda host, port: [
+            ipaddress.ip_address("2606:4700:4700::1111"),
+            ipaddress.ip_address("1.1.1.1"),
+        ],
+    )
+    adapter = webhooks._http_session(policy).get_adapter("https://")
+    pool = adapter.poolmanager.connection_from_url("https://receiver.example.test")
+    connection = pool.ConnectionCls("receiver.example.test")
+    dial = Mock(side_effect=[OSError("unreachable"), object()])
+    monkeypatch.setattr("urllib3.util.connection.create_connection", dial)
+    connection._new_conn()
+    assert [call.args[0][0] for call in dial.call_args_list] == [
+        "2606:4700:4700::1111",
+        "1.1.1.1",
+    ]
+    assert connection.host == "receiver.example.test"
+    dial.side_effect = OSError("unreachable")
+    with pytest.raises(NewConnectionError):
+        connection._new_conn()
+    assert connection.host == "receiver.example.test"
+
+
+def test_sessions_isolate_policies_and_ignore_ambient_proxy_credentials() -> None:
+    public = webhooks._http_session(webhooks.WebhookEgressPolicy())
+    private = webhooks._http_session(
+        webhooks.WebhookEgressPolicy(allowed_hosts=("receiver.internal",))
+    )
+    assert public is not private
+    assert public.trust_env is False
+    assert public.cookies.get_policy().set_ok(None, None) is False
+
+
+def test_https_validates_original_hostname_and_sends_sni_without_resolving_it_again(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    hostname = "receiver.example.test"
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, hostname)])
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(private_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(UTC) - timedelta(minutes=1))
+        .not_valid_after(datetime.now(UTC) + timedelta(hours=1))
+        .add_extension(x509.SubjectAlternativeName([x509.DNSName(hostname)]), False)
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), True)
+        .sign(private_key, hashes.SHA256())
+    )
+    cert_path, key_path = tmp_path / "cert.pem", tmp_path / "key.pem"
+    cert_path.write_bytes(certificate.public_bytes(serialization.Encoding.PEM))
+    key_path.write_bytes(
+        private_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
+    )
+    received = []
+
+    class Receiver(BaseHTTPRequestHandler):
+        def do_POST(self):
+            received.append(dict(self.headers))
+            self.rfile.read(int(self.headers.get("Content-Length", 0)))
+            self.send_response(204)
+            self.send_header("Set-Cookie", "receiver-secret=private; Path=/")
+            self.end_headers()
+
+        def log_message(self, *_args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Receiver)
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(cert_path, key_path)
+    server_names = []
+    context.set_servername_callback(
+        lambda _socket, name, _context: server_names.append(name)
+    )
+    server.socket = context.wrap_socket(server.socket, server_side=True)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    resolve = socket.getaddrinfo
+
+    def literal_only(host, *args, **kwargs):
+        assert host == "127.0.0.1", "HTTP transport re-resolved the receiver hostname"
+        return resolve(host, *args, **kwargs)
+
+    monkeypatch.setattr(socket, "getaddrinfo", literal_only)
+    monkeypatch.setattr(
+        webhooks,
+        "_resolve_host_addresses",
+        lambda host, port: [ipaddress.ip_address("127.0.0.1")],
+    )
+    policy = webhooks.WebhookEgressPolicy(allowed_hosts=(hostname,))
+    session = webhooks._http_session(policy)
+    try:
+        for _ in range(2):
+            response = session.post(
+                f"https://{hostname}:{server.server_port}/events",
+                json={"event_type": "flows/created"},
+                verify=str(cert_path),
+                timeout=5,
+            )
+            assert response.status_code == 204
+        assert server_names == [hostname, hostname]
+        assert all(
+            headers["Host"] == f"{hostname}:{server.server_port}"
+            for headers in received
+        )
+        assert all("Cookie" not in headers for headers in received)
+    finally:
+        session.close()
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)

--- a/tests/domain/test_listing_pagination.py
+++ b/tests/domain/test_listing_pagination.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import base64
+from uuid import uuid4
+
+import pytest
+from tamoss.domain.listing_pagination import listing_window
+from tamoss.domain.listings import FlowSortBy
+from tamoss.errors import BadRequest
+
+
+def test_issued_cursor_round_trips_labels_without_an_artificial_length_limit() -> None:
+    options = {
+        "resource": "flows",
+        "sort_by": FlowSortBy.LABEL,
+        "reverse_order": False,
+        "limit": 2,
+    }
+    first = listing_window(page=None, **options)
+    identity, label = uuid4(), "A" * 6000
+    cursor = listing_window(page=first.next_page(label, identity), **options)
+    assert cursor.anchor_id == identity
+    assert cursor.anchor_value == label
+
+
+def test_deeply_nested_invalid_cursor_is_a_bad_request() -> None:
+    malformed = base64.urlsafe_b64encode(("[" * 2000 + "]" * 2000).encode()).decode()
+    with pytest.raises(BadRequest):
+        listing_window(
+            page="k1." + malformed,
+            limit=2,
+            resource="flows",
+            sort_by=FlowSortBy.LABEL,
+            reverse_order=False,
+        )

--- a/tests/scripts/test_release_gate.py
+++ b/tests/scripts/test_release_gate.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import hashlib
-import io
 import json
-from urllib.error import HTTPError
+import sys
+from unittest.mock import Mock
 
 import pytest
 import yaml
@@ -46,11 +46,11 @@ def test_release_preflight_only_allows_drafts(monkeypatch, draft) -> None:
     module = load_python_module(
         "release_preflight", REPO_ROOT / ".github/scripts/release-preflight.py"
     )
-    monkeypatch.setattr(
-        module,
-        "urlopen",
-        lambda *args, **kwargs: io.BytesIO(json.dumps({"draft": draft}).encode()),
+    connection = Mock()
+    connection.getresponse.return_value = Mock(
+        status=200, read=lambda: json.dumps({"draft": draft})
     )
+    monkeypatch.setattr(module, "HTTPSConnection", Mock(return_value=connection))
     arguments = {
         "api_url": "https://api.github.com",
         "repository": "org/repo",
@@ -62,20 +62,19 @@ def test_release_preflight_only_allows_drafts(monkeypatch, draft) -> None:
     else:
         with pytest.raises(SystemExit, match="already published"):
             module.verify_unpublished(**arguments)
+    connection.close.assert_called_once()
 
 
-@pytest.mark.parametrize("status", [401, 403, 404, 429, 500])
+@pytest.mark.parametrize("status", [302, 307, 401, 403, 404, 429, 500])
 def test_release_preflight_fails_closed_except_for_missing_release(
     monkeypatch, status
 ) -> None:
     module = load_python_module(
         "release_preflight", REPO_ROOT / ".github/scripts/release-preflight.py"
     )
-
-    def fail(*args, **kwargs):
-        raise HTTPError("https://api.github.com", status, "error", None, None)
-
-    monkeypatch.setattr(module, "urlopen", fail)
+    connection = Mock()
+    connection.getresponse.return_value.status = status
+    monkeypatch.setattr(module, "HTTPSConnection", Mock(return_value=connection))
     arguments = {
         "api_url": "https://api.github.com",
         "repository": "org/repo",
@@ -85,8 +84,55 @@ def test_release_preflight_fails_closed_except_for_missing_release(
     if status == 404:
         module.verify_unpublished(**arguments)
     else:
-        with pytest.raises(HTTPError):
+        with pytest.raises(SystemExit, match=f"HTTP {status}"):
             module.verify_unpublished(**arguments)
+    connection.request.assert_called_once()
+    connection.close.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "api_url",
+    [
+        "http://api.github.com",
+        "file:///tmp/release",
+        "https://user:password@api.github.com",
+        "https://api.github.com?token=value",
+    ],
+)
+def test_release_preflight_rejects_unsafe_api_urls(monkeypatch, api_url) -> None:
+    module = load_python_module(
+        "release_preflight", REPO_ROOT / ".github/scripts/release-preflight.py"
+    )
+    connect = Mock()
+    monkeypatch.setattr(module, "HTTPSConnection", connect)
+    with pytest.raises(ValueError, match="HTTPS origin"):
+        module.verify_unpublished(
+            api_url=api_url, repository="org/repo", tag="8.2.0-oss1", token="secret"
+        )
+    connect.assert_not_called()
+
+
+def test_release_preflight_preserves_enterprise_api_prefix_and_encodes_tag(
+    monkeypatch,
+) -> None:
+    module = load_python_module(
+        "release_preflight", REPO_ROOT / ".github/scripts/release-preflight.py"
+    )
+    connection = Mock()
+    connection.getresponse.return_value.status = 404
+    connect = Mock(return_value=connection)
+    monkeypatch.setattr(module, "HTTPSConnection", connect)
+    module.verify_unpublished(
+        api_url="https://github.example:8443/api/v3/",
+        repository="org/repo",
+        tag="release/8.2.0",
+        token="secret",
+    )
+    connect.assert_called_once_with("github.example", 8443, timeout=30)
+    assert connection.request.call_args.args == (
+        "GET",
+        "/api/v3/repos/org/repo/releases/tags/release%2F8.2.0",
+    )
 
 
 def test_release_record_rejects_any_missing_or_malformed_image_digest() -> None:
@@ -120,23 +166,20 @@ def test_release_record_includes_assets_specification_and_worker_identity(
     for path in (install, compatibility):
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("release fixture\n")
-    replies = iter(["version=8.2.0-oss1-rc5\ntams_api=8.2\n", "a" * 40, "b" * 40])
-    monkeypatch.setattr(
-        module.subprocess, "check_output", lambda *args, **kwargs: next(replies)
-    )
+    compatibility.write_text((REPO_ROOT / "operator/compatibility.yaml").read_text())
     for name, value in {
         "GITHUB_REF_NAME": "8.2.0-oss1-rc5",
         "GITHUB_SERVER_URL": "https://github.com",
         "GITHUB_REPOSITORY": "livewyer-ops/tamoss",
         "GITHUB_RUN_ID": "1234",
         "GITHUB_RUN_ATTEMPT": "2",
+        "SOURCE_COMMIT": "a" * 40,
+        "BBC_TAMS_COMMIT": "b" * 40,
         **{f"{name.upper()}_DIGEST": "sha256:" + "c" * 64 for name in module.IMAGES},
     }.items():
         monkeypatch.setenv(name, value)
     output = tmp_path / "release.json"
-    monkeypatch.setattr(
-        module.sys, "argv", ["release-record.py", "--output", str(output)]
-    )
+    monkeypatch.setattr(sys, "argv", ["release-record.py", "--output", str(output)])
     module.main()
     record = json.loads(output.read_text())
     assert record["sourceCommit"] == "a" * 40

--- a/tests/scripts/test_release_gate.py
+++ b/tests/scripts/test_release_gate.py
@@ -133,6 +133,10 @@ def test_release_preflight_preserves_enterprise_api_prefix_and_encodes_tag(
         "GET",
         "/api/v3/repos/org/repo/releases/tags/release%2F8.2.0",
     )
+    assert (
+        connection.request.call_args.kwargs["headers"]["User-Agent"]
+        == "tamoss-release-preflight"
+    )
 
 
 def test_release_record_rejects_any_missing_or_malformed_image_digest() -> None:

--- a/tests/scripts/test_release_gate.py
+++ b/tests/scripts/test_release_gate.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+from urllib.error import HTTPError
+
+import pytest
+import yaml
+
+from tests.support.paths import REPO_ROOT, load_python_module
+
+
+def test_release_publication_requires_every_image_and_tag_validation() -> None:
+    workflows = REPO_ROOT / ".github/workflows"
+    build = yaml.safe_load((workflows / "docker-hub.yaml").read_text())
+    publish = yaml.safe_load((workflows / "operator-release.yaml").read_text())
+    # PyYAML's YAML 1.1 loader represents GitHub's `on` key as True.
+    assert set(publish[True]) == {"workflow_call"}
+    jobs = build["jobs"]
+    images = {"tamoss-api", "tamoss-ui", "tamoss-console-api", "tamoss-operator"}
+    gates = {
+        "dependency-audit",
+        "release-preflight",
+        "release-tests",
+        "release-operator-tests",
+        "release-kind-e2e",
+    }
+    assert set(jobs["release-assets"]["needs"]) == images | gates
+    assert jobs["release-assets"]["if"] == "github.ref_type == 'tag'"
+    for job in images:
+        assert jobs[job]["outputs"]["digest"] == "${{ steps.build.outputs.digest }}"
+        assert "release-preflight" in jobs[job]["needs"]
+        assert "needs.dependency-audit.result == 'success'" in jobs[job]["if"]
+    for filename in ("test.yaml", "operator-ci.yaml"):
+        workflow = yaml.safe_load((workflows / filename).read_text())
+        assert "workflow_call" in workflow[True]
+        assert workflow["concurrency"]["group"] != build["concurrency"]["group"]
+    assert (
+        build["concurrency"]["cancel-in-progress"] == "${{ github.ref_type != 'tag' }}"
+    )
+
+
+@pytest.mark.parametrize("draft", [True, False, None])
+def test_release_preflight_only_allows_drafts(monkeypatch, draft) -> None:
+    module = load_python_module(
+        "release_preflight", REPO_ROOT / ".github/scripts/release-preflight.py"
+    )
+    monkeypatch.setattr(
+        module,
+        "urlopen",
+        lambda *args, **kwargs: io.BytesIO(json.dumps({"draft": draft}).encode()),
+    )
+    arguments = {
+        "api_url": "https://api.github.com",
+        "repository": "org/repo",
+        "tag": "8.2.0-oss1-rc5",
+        "token": "secret",
+    }
+    if draft is True:
+        module.verify_unpublished(**arguments)
+    else:
+        with pytest.raises(SystemExit, match="already published"):
+            module.verify_unpublished(**arguments)
+
+
+@pytest.mark.parametrize("status", [401, 403, 404, 429, 500])
+def test_release_preflight_fails_closed_except_for_missing_release(
+    monkeypatch, status
+) -> None:
+    module = load_python_module(
+        "release_preflight", REPO_ROOT / ".github/scripts/release-preflight.py"
+    )
+
+    def fail(*args, **kwargs):
+        raise HTTPError("https://api.github.com", status, "error", None, None)
+
+    monkeypatch.setattr(module, "urlopen", fail)
+    arguments = {
+        "api_url": "https://api.github.com",
+        "repository": "org/repo",
+        "tag": "8.2.0-oss1-rc5",
+        "token": "secret",
+    }
+    if status == 404:
+        module.verify_unpublished(**arguments)
+    else:
+        with pytest.raises(HTTPError):
+            module.verify_unpublished(**arguments)
+
+
+def test_release_record_rejects_any_missing_or_malformed_image_digest() -> None:
+    module = load_python_module(
+        "release_record", REPO_ROOT / ".github/scripts/release-record.py"
+    )
+    environment = {
+        f"{component.upper()}_DIGEST": "sha256:" + "a" * 64
+        for component in module.IMAGES
+    }
+    references = module.image_references(environment)
+    assert len(references) == 4
+    assert all(
+        reference.endswith("@sha256:" + "a" * 64) for reference in references.values()
+    )
+    for key in environment:
+        for invalid in ("", "latest", "sha256:short", "sha256:" + "z" * 64):
+            with pytest.raises(ValueError, match="image digest"):
+                module.image_references({**environment, key: invalid})
+
+
+def test_release_record_includes_assets_specification_and_worker_identity(
+    tmp_path, monkeypatch
+) -> None:
+    module = load_python_module(
+        "release_record", REPO_ROOT / ".github/scripts/release-record.py"
+    )
+    monkeypatch.chdir(tmp_path)
+    install = tmp_path / "dist/operator-release/install.yaml"
+    compatibility = tmp_path / "operator/compatibility.yaml"
+    for path in (install, compatibility):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("release fixture\n")
+    replies = iter(["version=8.2.0-oss1-rc5\ntams_api=8.2\n", "a" * 40, "b" * 40])
+    monkeypatch.setattr(
+        module.subprocess, "check_output", lambda *args, **kwargs: next(replies)
+    )
+    for name, value in {
+        "GITHUB_REF_NAME": "8.2.0-oss1-rc5",
+        "GITHUB_SERVER_URL": "https://github.com",
+        "GITHUB_REPOSITORY": "livewyer-ops/tamoss",
+        "GITHUB_RUN_ID": "1234",
+        "GITHUB_RUN_ATTEMPT": "2",
+        **{f"{name.upper()}_DIGEST": "sha256:" + "c" * 64 for name in module.IMAGES},
+    }.items():
+        monkeypatch.setenv(name, value)
+    output = tmp_path / "release.json"
+    monkeypatch.setattr(
+        module.sys, "argv", ["release-record.py", "--output", str(output)]
+    )
+    module.main()
+    record = json.loads(output.read_text())
+    assert record["sourceCommit"] == "a" * 40
+    assert record["bbcTamsCommit"] == "b" * 40
+    assert record["compatibility"]["tams_api"] == "8.2"
+    assert record["workerImage"] == record["images"]["api"]
+    assert record["validationRun"].endswith("/actions/runs/1234")
+    assert record["validationRunAttempt"] == "2"
+    assert record["artifacts"] == {
+        path.name: {"sha256": hashlib.sha256(path.read_bytes()).hexdigest()}
+        for path in (install, compatibility)
+    }

--- a/tests/support/memory_repository.py
+++ b/tests/support/memory_repository.py
@@ -13,6 +13,7 @@ from tamoss.db.migrations import CURRENT_SCHEMA_REVISION
 from tamoss.domain import flow_collections
 from tamoss.domain import segments as segment_domain
 from tamoss.domain.exceptions import SEGMENT_OVERLAP_MESSAGE, SegmentOverlapError
+from tamoss.domain.listing_pagination import page_listing_sequence
 from tamoss.domain.listings import (
     DeleteRequestSortBy,
     FlowSortBy,
@@ -145,6 +146,9 @@ class FakeTamossRepository:
                 raise
 
     def lock_flow_segments(self, flow_id: UUID) -> None:
+        return None
+
+    def lock_source(self, source_id: UUID) -> None:
         return None
 
     def lock_profile(self, profile_id: UUID) -> None:
@@ -382,7 +386,16 @@ class FakeTamossRepository:
             descending=sort_by.descending(reverse_order=reverse_order),
             missing_first=reverse_order,
         )
-        return page_sequence(flows, page=page, limit=limit)
+        return page_listing_sequence(
+            flows,
+            page=page,
+            limit=limit,
+            resource="flows",
+            sort_by=sort_by,
+            reverse_order=reverse_order,
+            value=flow_sort_value,
+            identity=lambda flow: flow.id,
+        )
 
     def flow_timeranges(self, flow_ids: Iterable[UUID]) -> dict[UUID, str]:
         requested_ids = list(dict.fromkeys(flow_ids))
@@ -474,7 +487,16 @@ class FakeTamossRepository:
             descending=sort_by.descending(reverse_order=reverse_order),
             missing_first=reverse_order,
         )
-        return page_sequence(sources, page=page, limit=limit)
+        return page_listing_sequence(
+            sources,
+            page=page,
+            limit=limit,
+            resource="sources",
+            sort_by=sort_by,
+            reverse_order=reverse_order,
+            value=source_sort_value,
+            identity=lambda source: source.id,
+        )
 
     def source_relationships_for(
         self, source_ids: Iterable[UUID]


### PR DESCRIPTION
## Summary
- Pin webhook connections to validated IP addresses while preserving TLS certificate validation, SNI and Host. Isolate egress policies and disable ambient proxies, netrc authentication and receiver cookies.
- Lock Flow/Source metadata before reading and commit metadata plus all webhook notifications in one PostgreSQL transaction.
- Issue deletion-safe Flow/Source keyset cursors, including nullable labels and deterministic ties; continue accepting legacy numeric tokens.
- Make Docker Hub the sole release orchestrator. Require tagged-commit tests, operator checks, Kind E2E, dependency audit and all four signed images before publishing assets. Refuse published-tag reuse and attach a digest/checksum release record.
- Show actual 8.2 webhook selectors in the UI; add a bounded, read-only delivery diagnostic command and Cutting Rooms acceptance/recovery documentation.
- Incorporate the release-runbook direction from #176, updated for the Console API image and immutable releases. No automatic historical replay or database schema changes.
