### PR TITLE
fix(worker): fence claims and retain required queue history

### DIFF
--- a/src/app/tamoss/adapters/postgres_repository/mappers.py
+++ b/src/app/tamoss/adapters/postgres_repository/mappers.py
@@ -785,6 +785,7 @@ def _webhook_delivery_from_row(row: DatabaseRow) -> WebhookDeliveryRecord:
     delivery.status = row[1]
     delivery.next_attempt_at = _optional_datetime_from_record(row[2])
     delivery.claimed_at = _optional_datetime_from_record(row[3])
+    delivery.claim_token = delivery.claimed_at
     delivery.claimed_by = row[4]
     delivery.claim_expires_at = _optional_datetime_from_record(row[5])
     return delivery
@@ -831,6 +832,7 @@ def _delete_request_from_row(row: DatabaseRow) -> DeletionRequestRecord:
     request.status = row[1]
     request.updated = _datetime_from_record(row[2])
     request.claimed_at = _optional_datetime_from_record(row[3])
+    request.claim_token = request.claimed_at
     request.claimed_by = row[4]
     request.claim_expires_at = _optional_datetime_from_record(row[5])
     return request
@@ -872,6 +874,7 @@ def _object_cleanup_from_row(row: DatabaseRow) -> ObjectCleanupRecord:
     cleanup.status = row[1]
     cleanup.updated = _datetime_from_record(row[2])
     cleanup.claimed_at = _optional_datetime_from_record(row[3])
+    cleanup.claim_token = cleanup.claimed_at
     cleanup.claimed_by = row[4]
     cleanup.claim_expires_at = _optional_datetime_from_record(row[5])
     return cleanup
@@ -910,6 +913,7 @@ def _object_copy_from_row(row: DatabaseRow) -> ObjectCopyRecord:
     copy.status = row[1]
     copy.updated = _datetime_from_record(row[2])
     copy.claimed_at = _optional_datetime_from_record(row[3])
+    copy.claim_token = copy.claimed_at
     copy.claimed_by = row[4]
     copy.claim_expires_at = _optional_datetime_from_record(row[5])
     return copy

--- a/src/app/tamoss/adapters/postgres_repository/queues.py
+++ b/src/app/tamoss/adapters/postgres_repository/queues.py
@@ -34,10 +34,18 @@ from tamoss.domain.model import (
     ObjectCopyRecord,
     WebhookDeliveryRecord,
     WebhookRecord,
+    utc_now,
 )
 from tamoss.domain.pagination import Page, resolve_page_window
+from tamoss.worker_claims import WorkerClaimLost, WorkerRecord, active_worker_claims
 
 _EMPTY_SQL = sql.SQL("")
+_QUEUE_TABLES = {
+    WebhookDeliveryRecord: "tamoss_webhook_deliveries",
+    DeletionRequestRecord: "tamoss_delete_requests",
+    ObjectCleanupRecord: "tamoss_object_cleanups",
+    ObjectCopyRecord: "tamoss_object_copies",
+}
 
 # Terminal rows are kept for observability but never read by claim queries;
 # without retention the queue tables (webhook deliveries especially: one row
@@ -51,6 +59,91 @@ _PURGEABLE_QUEUE_TABLES: tuple[tuple[str, tuple[str, ...]], ...] = (
 
 
 class PostgresQueueMixin:
+    def renew_worker_claim(self, record: WorkerRecord, lease_seconds: int) -> bool:
+        if record.claim_token is None:
+            return False
+        with self._connect() as conn, conn.cursor() as cur:
+            cur.execute(
+                sql.SQL(
+                    """
+                    UPDATE {table}
+                    SET claim_expires_at = clock_timestamp()
+                        + (%s * INTERVAL '1 second')
+                    WHERE id = %s AND claimed_at = %s
+                      AND claim_expires_at > clock_timestamp()
+                    """
+                ).format(table=sql.Identifier(_QUEUE_TABLES[type(record)])),
+                (lease_seconds, record.id, record.claim_token),
+            )
+            return cur.rowcount == 1
+
+    def _save_worker_record(
+        self, record: WorkerRecord, payload: dict[str, Any], **values: Any
+    ) -> None:
+        table = sql.Identifier(_QUEUE_TABLES[type(record)])
+        active = active_worker_claims.get() or {}
+        claim = active.get(record.id, record)
+        values.update(
+            id=record.id,
+            status=record.status,
+            claimed_at=record.claimed_at,
+            claimed_by=record.claimed_by,
+            claim_expires_at=record.claim_expires_at,
+            record=Jsonb(payload),
+            updated_at=utc_now(),
+        )
+        assignments = sql.SQL(", ").join(
+            sql.SQL("{} = %({})s").format(sql.Identifier(name), sql.SQL(name))
+            if name != "claim_expires_at"
+            else sql.SQL(
+                "claim_expires_at = CASE WHEN %(claimed_at)s::timestamptz IS NULL "
+                "THEN %(claim_expires_at)s ELSE GREATEST("
+                "{table}.claim_expires_at, %(claim_expires_at)s) END"
+            ).format(table=table)
+            for name in values
+            if name != "id"
+        )
+        with self._connect() as conn, conn.transaction(), conn.cursor() as cur:
+            # Child cleanups are owned by the parent deletion claim, not by
+            # their own leases. Check the original parent before saving them.
+            if (
+                isinstance(record, ObjectCleanupRecord)
+                and record.delete_request_id in active
+            ):
+                parent = active[record.delete_request_id]
+                cur.execute(
+                    """
+                    SELECT id FROM tamoss_delete_requests
+                    WHERE id = %s AND claimed_at = %s
+                      AND claim_expires_at > clock_timestamp()
+                    FOR UPDATE
+                    """,
+                    (parent.id, parent.claim_token),
+                )
+                if cur.fetchone() is None:
+                    raise WorkerClaimLost(str(parent.id))
+            if claim.claim_token is None:
+                query = sql.SQL(
+                    "INSERT INTO {table} ({columns}) VALUES ({parameters}) "
+                    "ON CONFLICT (id) DO UPDATE SET {assignments} "
+                    "WHERE {table}.claimed_at IS NULL"
+                ).format(
+                    table=table,
+                    columns=sql.SQL(", ").join(map(sql.Identifier, values)),
+                    parameters=sql.SQL(", ").join(map(sql.Placeholder, values)),
+                    assignments=assignments,
+                )
+            else:
+                query = sql.SQL(
+                    "UPDATE {table} SET {assignments} "
+                    "WHERE id = %(id)s AND claimed_at = %(claim_token)s "
+                    "AND claim_expires_at > clock_timestamp()"
+                ).format(table=table, assignments=assignments)
+                values["claim_token"] = claim.claim_token
+            cur.execute(query, values)
+            if cur.rowcount != 1:
+                raise WorkerClaimLost(str(record.id))
+
     def list_webhooks(self) -> list[WebhookRecord]:
         with self._connect() as conn, conn.cursor() as cur:
             cur.execute("SELECT record FROM tamoss_webhooks ORDER BY id")
@@ -172,56 +265,13 @@ class PostgresQueueMixin:
             return _webhook_delivery_from_row(row) if row else None
 
     def save_webhook_delivery(self, delivery: WebhookDeliveryRecord) -> None:
-        record = _webhook_delivery_to_record(delivery)
-        with self._connect() as conn, conn.cursor() as cur:
-            cur.execute(
-                """
-                INSERT INTO tamoss_webhook_deliveries (
-                    id,
-                    webhook_id,
-                    status,
-                    next_attempt_at,
-                    claimed_at,
-                    claimed_by,
-                    claim_expires_at,
-                    record,
-                    created_at,
-                    updated_at
-                )
-                VALUES (
-                    %(id)s,
-                    %(webhook_id)s,
-                    %(status)s,
-                    %(next_attempt_at)s,
-                    %(claimed_at)s,
-                    %(claimed_by)s,
-                    %(claim_expires_at)s,
-                    %(record)s,
-                    %(created_at)s,
-                    NOW()
-                )
-                ON CONFLICT (id) DO UPDATE SET
-                    webhook_id = EXCLUDED.webhook_id,
-                    status = EXCLUDED.status,
-                    next_attempt_at = EXCLUDED.next_attempt_at,
-                    claimed_at = EXCLUDED.claimed_at,
-                    claimed_by = EXCLUDED.claimed_by,
-                    claim_expires_at = EXCLUDED.claim_expires_at,
-                    record = EXCLUDED.record,
-                    updated_at = NOW()
-                """,
-                {
-                    "id": delivery.id,
-                    "webhook_id": delivery.webhook_id,
-                    "status": delivery.status,
-                    "next_attempt_at": delivery.next_attempt_at,
-                    "claimed_at": delivery.claimed_at,
-                    "claimed_by": delivery.claimed_by,
-                    "claim_expires_at": delivery.claim_expires_at,
-                    "record": Jsonb(record),
-                    "created_at": delivery.created,
-                },
-            )
+        self._save_worker_record(
+            delivery,
+            _webhook_delivery_to_record(delivery),
+            webhook_id=delivery.webhook_id,
+            next_attempt_at=delivery.next_attempt_at,
+            created_at=delivery.created,
+        )
 
     def claim_webhook_deliveries(
         self, *, worker_id: str, limit: int, lease_seconds: int
@@ -336,55 +386,13 @@ class PostgresQueueMixin:
             return _delete_request_from_row(row) if row else None
 
     def save_delete_request(self, request: DeletionRequestRecord) -> None:
-        record = _delete_request_to_record(request)
-        with self._connect() as conn, conn.cursor() as cur:
-            cur.execute(
-                """
-                INSERT INTO tamoss_delete_requests (
-                    id,
-                    flow_id,
-                    status,
-                    claimed_at,
-                    claimed_by,
-                    claim_expires_at,
-                    record,
-                    updated,
-                    created_at
-                )
-                VALUES (
-                    %(id)s,
-                    %(flow_id)s,
-                    %(status)s,
-                    %(claimed_at)s,
-                    %(claimed_by)s,
-                    %(claim_expires_at)s,
-                    %(record)s,
-                    %(updated)s,
-                    %(created_at)s
-                )
-                ON CONFLICT (id) DO UPDATE SET
-                    flow_id = EXCLUDED.flow_id,
-                    status = EXCLUDED.status,
-                    claimed_at = EXCLUDED.claimed_at,
-                    claimed_by = EXCLUDED.claimed_by,
-                    claim_expires_at = EXCLUDED.claim_expires_at,
-                    record = EXCLUDED.record,
-                    updated = EXCLUDED.updated,
-                    created_at = EXCLUDED.created_at,
-                    updated_at = NOW()
-                """,
-                {
-                    "id": request.id,
-                    "flow_id": request.flow_id,
-                    "status": request.status,
-                    "claimed_at": request.claimed_at,
-                    "claimed_by": request.claimed_by,
-                    "claim_expires_at": request.claim_expires_at,
-                    "record": Jsonb(record),
-                    "updated": request.updated,
-                    "created_at": request.created,
-                },
-            )
+        self._save_worker_record(
+            request,
+            _delete_request_to_record(request),
+            flow_id=request.flow_id,
+            updated=request.updated,
+            created_at=request.created,
+        )
 
     def claim_delete_requests(
         self, *, worker_id: str, limit: int, lease_seconds: int
@@ -439,59 +447,14 @@ class PostgresQueueMixin:
             return [_object_cleanup_from_row(row) for row in cur.fetchall()]
 
     def save_object_cleanup(self, cleanup: ObjectCleanupRecord) -> None:
-        record = _object_cleanup_to_record(cleanup)
-        with self._connect() as conn, conn.cursor() as cur:
-            cur.execute(
-                """
-                INSERT INTO tamoss_object_cleanups (
-                    id,
-                    delete_request_id,
-                    object_id,
-                    storage_backend_id,
-                    status,
-                    claimed_at,
-                    claimed_by,
-                    claim_expires_at,
-                    record,
-                    updated
-                )
-                VALUES (
-                    %(id)s,
-                    %(delete_request_id)s,
-                    %(object_id)s,
-                    %(storage_backend_id)s,
-                    %(status)s,
-                    %(claimed_at)s,
-                    %(claimed_by)s,
-                    %(claim_expires_at)s,
-                    %(record)s,
-                    %(updated)s
-                )
-                ON CONFLICT (id) DO UPDATE SET
-                    delete_request_id = EXCLUDED.delete_request_id,
-                    object_id = EXCLUDED.object_id,
-                    storage_backend_id = EXCLUDED.storage_backend_id,
-                    status = EXCLUDED.status,
-                    claimed_at = EXCLUDED.claimed_at,
-                    claimed_by = EXCLUDED.claimed_by,
-                    claim_expires_at = EXCLUDED.claim_expires_at,
-                    record = EXCLUDED.record,
-                    updated = EXCLUDED.updated,
-                    updated_at = NOW()
-                """,
-                {
-                    "id": cleanup.id,
-                    "delete_request_id": cleanup.delete_request_id,
-                    "object_id": cleanup.object_id,
-                    "storage_backend_id": cleanup.storage_backend_id,
-                    "status": cleanup.status,
-                    "claimed_at": cleanup.claimed_at,
-                    "claimed_by": cleanup.claimed_by,
-                    "claim_expires_at": cleanup.claim_expires_at,
-                    "record": Jsonb(record),
-                    "updated": cleanup.updated,
-                },
-            )
+        self._save_worker_record(
+            cleanup,
+            _object_cleanup_to_record(cleanup),
+            delete_request_id=cleanup.delete_request_id,
+            object_id=cleanup.object_id,
+            storage_backend_id=cleanup.storage_backend_id,
+            updated=cleanup.updated,
+        )
 
     def claim_object_cleanups(
         self, *, worker_id: str, limit: int, lease_seconds: int
@@ -541,62 +504,14 @@ class PostgresQueueMixin:
             return [_object_copy_from_row(row) for row in cur.fetchall()]
 
     def save_object_copy(self, copy: ObjectCopyRecord) -> None:
-        record = _object_copy_to_record(copy)
-        with self._connect() as conn, conn.cursor() as cur:
-            cur.execute(
-                """
-                INSERT INTO tamoss_object_copies (
-                    id,
-                    object_id,
-                    source_storage_backend_id,
-                    destination_storage_backend_id,
-                    status,
-                    claimed_at,
-                    claimed_by,
-                    claim_expires_at,
-                    record,
-                    updated
-                )
-                VALUES (
-                    %(id)s,
-                    %(object_id)s,
-                    %(source_storage_backend_id)s,
-                    %(destination_storage_backend_id)s,
-                    %(status)s,
-                    %(claimed_at)s,
-                    %(claimed_by)s,
-                    %(claim_expires_at)s,
-                    %(record)s,
-                    %(updated)s
-                )
-                ON CONFLICT (id) DO UPDATE SET
-                    object_id = EXCLUDED.object_id,
-                    source_storage_backend_id = EXCLUDED.source_storage_backend_id,
-                    destination_storage_backend_id =
-                        EXCLUDED.destination_storage_backend_id,
-                    status = EXCLUDED.status,
-                    claimed_at = EXCLUDED.claimed_at,
-                    claimed_by = EXCLUDED.claimed_by,
-                    claim_expires_at = EXCLUDED.claim_expires_at,
-                    record = EXCLUDED.record,
-                    updated = EXCLUDED.updated,
-                    updated_at = NOW()
-                """,
-                {
-                    "id": copy.id,
-                    "object_id": copy.object_id,
-                    "source_storage_backend_id": copy.source_storage_backend_id,
-                    "destination_storage_backend_id": (
-                        copy.destination_storage_backend_id
-                    ),
-                    "status": copy.status,
-                    "claimed_at": copy.claimed_at,
-                    "claimed_by": copy.claimed_by,
-                    "claim_expires_at": copy.claim_expires_at,
-                    "record": Jsonb(record),
-                    "updated": copy.updated,
-                },
-            )
+        self._save_worker_record(
+            copy,
+            _object_copy_to_record(copy),
+            object_id=copy.object_id,
+            source_storage_backend_id=copy.source_storage_backend_id,
+            destination_storage_backend_id=copy.destination_storage_backend_id,
+            updated=copy.updated,
+        )
 
     def purge_finished_worker_records(self, *, older_than: datetime, limit: int) -> int:
         if limit < 1:
@@ -604,6 +519,20 @@ class PostgresQueueMixin:
         purged = 0
         with self._connect() as conn, conn.cursor() as cur:
             for table_name, statuses in _PURGEABLE_QUEUE_TABLES:
+                if purged >= limit:
+                    break
+                preserve_dependencies = _EMPTY_SQL
+                if table_name == "tamoss_object_cleanups":
+                    preserve_dependencies = sql.SQL(
+                        "AND NOT EXISTS (SELECT 1 FROM tamoss_delete_requests "
+                        "WHERE id = tamoss_object_cleanups.delete_request_id)"
+                    )
+                elif table_name == "tamoss_delete_requests":
+                    preserve_dependencies = sql.SQL(
+                        "AND NOT EXISTS (SELECT 1 FROM tamoss_object_cleanups "
+                        "WHERE delete_request_id = tamoss_delete_requests.id "
+                        "AND status <> 'done')"
+                    )
                 cur.execute(
                     sql.SQL(
                         """
@@ -612,6 +541,7 @@ class PostgresQueueMixin:
                             FROM {table}
                             WHERE status = ANY(%(statuses)s::text[])
                               AND updated_at < %(older_than)s
+                              {preserve_dependencies}
                             LIMIT %(limit)s
                             FOR UPDATE SKIP LOCKED
                         )
@@ -619,11 +549,14 @@ class PostgresQueueMixin:
                         USING target
                         WHERE finished.id = target.id
                         """
-                    ).format(table=sql.Identifier(table_name)),
+                    ).format(
+                        table=sql.Identifier(table_name),
+                        preserve_dependencies=preserve_dependencies,
+                    ),
                     {
                         "statuses": list(statuses),
                         "older_than": older_than,
-                        "limit": limit,
+                        "limit": limit - purged,
                     },
                 )
                 purged += cur.rowcount or 0
@@ -685,9 +618,9 @@ def _claim_worker_records[T](
             )
             UPDATE {table} AS {alias}
             SET status = 'started',
-                claimed_at = NOW(),
+                claimed_at = clock_timestamp(),
                 claimed_by = %(worker_id)s,
-                claim_expires_at = NOW()
+                claim_expires_at = clock_timestamp()
                     + (%(lease_seconds)s * INTERVAL '1 second'),
                 {touch_sql}
                 updated_at = NOW()

--- a/src/app/tamoss/application/contexts/deletion.py
+++ b/src/app/tamoss/application/contexts/deletion.py
@@ -28,6 +28,7 @@ from tamoss.settings import (
     DEFAULT_WORKER_LEASE_SECONDS,
     Settings,
 )
+from tamoss.worker_claims import WorkerClaimLost, keep_worker_claims
 
 
 class DeletionUseCases:
@@ -200,14 +201,20 @@ class DeletionUseCases:
             limit=max_requests,
             lease_seconds=lease_seconds,
         )
-        for request in requests:
-            deletion_processor.process_delete_request(
-                repository=self.repository,
-                webhook_repository=self.webhook_repository,
-                object_storage=self.object_storage,
-                request_id=request.id,
-            )
-            processed += 1
+        with keep_worker_claims(
+            requests,
+            renew=self.repository.renew_worker_claim,
+            lease_seconds=lease_seconds,
+        ):
+            for request in requests:
+                with suppress(WorkerClaimLost):
+                    deletion_processor.process_delete_request(
+                        repository=self.repository,
+                        webhook_repository=self.webhook_repository,
+                        object_storage=self.object_storage,
+                        request_id=request.id,
+                    )
+                    processed += 1
         return processed
 
     def process_pending_object_cleanups(
@@ -222,7 +229,14 @@ class DeletionUseCases:
             limit=max_cleanups,
             lease_seconds=lease_seconds,
         )
-        with suppress(deletion_processor.ObjectCleanupFailed):
+        with (
+            suppress(deletion_processor.ObjectCleanupFailed, WorkerClaimLost),
+            keep_worker_claims(
+                cleanups,
+                renew=self.repository.renew_worker_claim,
+                lease_seconds=lease_seconds,
+            ),
+        ):
             deletion_processor.process_object_cleanups(
                 repository=self.repository,
                 object_storage=self.object_storage,

--- a/src/app/tamoss/application/contexts/objects.py
+++ b/src/app/tamoss/application/contexts/objects.py
@@ -19,6 +19,7 @@ from tamoss.ports.repositories import (
     ObjectRepository,
     StorageBackendRepository,
 )
+from tamoss.worker_claims import WorkerClaimLost, keep_worker_claims
 
 
 def reserved_storage_labels(repository: StorageBackendRepository) -> set[str]:
@@ -135,7 +136,14 @@ class ObjectUseCases:
             limit=max_copies,
             lease_seconds=lease_seconds,
         )
-        with suppress(object_copy.ObjectCopyFailed):
+        with (
+            suppress(object_copy.ObjectCopyFailed, WorkerClaimLost),
+            keep_worker_claims(
+                copies,
+                renew=self.repository.renew_worker_claim,
+                lease_seconds=lease_seconds,
+            ),
+        ):
             object_copy.process_object_copies(
                 repository=self.repository,
                 object_storage=self.object_storage,

--- a/src/app/tamoss/application/contexts/webhooks.py
+++ b/src/app/tamoss/application/contexts/webhooks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import suppress
 from datetime import timedelta
 from typing import Any
 from uuid import UUID, uuid4
@@ -23,6 +24,7 @@ from tamoss.settings import (
     DEFAULT_WORKER_LEASE_SECONDS,
     Settings,
 )
+from tamoss.worker_claims import WorkerClaimLost, keep_worker_claims
 
 
 class WebhookUseCases:
@@ -136,13 +138,22 @@ class WebhookUseCases:
         # Sends are network-bound and independent rows; bounded concurrency
         # stops one slow or black-holed receiver stalling the whole batch.
         max_workers = min(self.settings.webhook_delivery_concurrency, len(deliveries))
-        if max_workers <= 1:
-            for delivery in deliveries:
-                self._process_claimed_delivery(delivery)
-        else:
-            with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                list(executor.map(self._process_claimed_delivery, deliveries))
+        with keep_worker_claims(
+            deliveries,
+            renew=self.repository.renew_worker_claim,
+            lease_seconds=lease_seconds,
+        ):
+            if max_workers <= 1:
+                for delivery in deliveries:
+                    self._process_owned_delivery(delivery)
+            else:
+                with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                    list(executor.map(self._process_owned_delivery, deliveries))
         return len(deliveries)
+
+    def _process_owned_delivery(self, delivery: WebhookDeliveryRecord) -> None:
+        with suppress(WorkerClaimLost):
+            self._process_claimed_delivery(delivery)
 
     def process_webhook_delivery(
         self, delivery_id: UUID

--- a/src/app/tamoss/domain/model.py
+++ b/src/app/tamoss/domain/model.py
@@ -178,6 +178,7 @@ class WebhookDeliveryRecord:
     claimed_at: datetime | None = None
     claimed_by: str | None = None
     claim_expires_at: datetime | None = None
+    claim_token: datetime | None = field(default=None, repr=False, compare=False)
 
 
 @dataclass
@@ -195,6 +196,7 @@ class DeletionRequestRecord:
     claimed_at: datetime | None = None
     claimed_by: str | None = None
     claim_expires_at: datetime | None = None
+    claim_token: datetime | None = field(default=None, repr=False, compare=False)
 
 
 @dataclass
@@ -211,6 +213,7 @@ class ObjectCleanupRecord:
     claimed_at: datetime | None = None
     claimed_by: str | None = None
     claim_expires_at: datetime | None = None
+    claim_token: datetime | None = field(default=None, repr=False, compare=False)
 
 
 @dataclass
@@ -227,6 +230,7 @@ class ObjectCopyRecord:
     claimed_at: datetime | None = None
     claimed_by: str | None = None
     claim_expires_at: datetime | None = None
+    claim_token: datetime | None = field(default=None, repr=False, compare=False)
 
 
 @dataclass

--- a/src/app/tamoss/ports/repositories.py
+++ b/src/app/tamoss/ports/repositories.py
@@ -24,10 +24,15 @@ from tamoss.domain.model import (
 )
 from tamoss.domain.pagination import Page
 from tamoss.domain.segments import SegmentDeleteFilter, SegmentTimerangeBounds
+from tamoss.worker_claims import WorkerRecord
 
 
 class TransactionalRepository(Protocol):
     def unit_of_work(self) -> AbstractContextManager[object]: ...
+
+
+class WorkerQueueRepository(Protocol):
+    def renew_worker_claim(self, record: WorkerRecord, lease_seconds: int) -> bool: ...
 
 
 class StorageBackendRepository(Protocol):
@@ -194,7 +199,11 @@ class WebhookResourceRepository(Protocol):
     ) -> dict[UUID, SourceRelationships]: ...
 
 
-class WebhookRepository(WebhookEventRepository, Protocol):
+class WebhookRepository(WebhookEventRepository, WorkerQueueRepository, Protocol):
+    def purge_finished_worker_records(
+        self, *, older_than: datetime, limit: int
+    ) -> int: ...
+
     def list_webhooks_page(
         self,
         *,
@@ -266,6 +275,7 @@ class SegmentRepository(TransactionalRepository, StorageBackendRepository, Proto
 
 class ObjectRepository(
     TransactionalRepository,
+    WorkerQueueRepository,
     StorageBackendRepository,
     Protocol,
 ):
@@ -306,6 +316,7 @@ class StorageRepository(
 
 class DeletionRepository(
     TransactionalRepository,
+    WorkerQueueRepository,
     StorageBackendRepository,
     FlowCollectionRepository,
     ObjectCleanupRepository,

--- a/src/app/tamoss/worker.py
+++ b/src/app/tamoss/worker.py
@@ -115,11 +115,10 @@ def purge_finished_queue_records(
     """
     if retention_seconds <= 0:
         return 0
-    purge = getattr(use_cases.repository, "purge_finished_worker_records", None)
-    if not callable(purge):
-        return 0
     cutoff = utc_now() - timedelta(seconds=retention_seconds)
-    return int(purge(older_than=cutoff, limit=limit))
+    return use_cases.webhooks.repository.purge_finished_worker_records(
+        older_than=cutoff, limit=limit
+    )
 
 
 def _default_worker_id() -> str:

--- a/src/app/tamoss/worker_claims.py
+++ b/src/app/tamoss/worker_claims.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import replace
+from threading import Event, Thread
+from uuid import UUID
+
+from tamoss.domain.model import (
+    DeletionRequestRecord,
+    ObjectCleanupRecord,
+    ObjectCopyRecord,
+    WebhookDeliveryRecord,
+)
+
+type WorkerRecord = (
+    WebhookDeliveryRecord
+    | DeletionRequestRecord
+    | ObjectCleanupRecord
+    | ObjectCopyRecord
+)
+
+logger = logging.getLogger(__name__)
+active_worker_claims: ContextVar[dict[UUID, WorkerRecord] | None] = ContextVar(
+    "active_worker_claims", default=None
+)
+
+
+class WorkerClaimLost(RuntimeError):
+    """The worker no longer owns this queue record."""
+
+
+@contextmanager
+def keep_worker_claims(
+    records: Iterable[WorkerRecord],
+    *,
+    renew: Callable[[WorkerRecord, int], bool],
+    lease_seconds: int,
+) -> Iterator[None]:
+    # Keep the original generation even when processors clear or re-read claims.
+    claims = [replace(record) for record in records]
+    if not claims:
+        yield
+        return
+    for claim in claims:
+        if not renew(claim, lease_seconds):
+            raise WorkerClaimLost(str(claim.id))
+    stopped = Event()
+
+    def heartbeat() -> None:
+        pending = claims
+        while pending and not stopped.wait(lease_seconds / 3):
+            try:
+                pending = [claim for claim in pending if renew(claim, lease_seconds)]
+            except Exception:
+                # Saves also check expiry, so renewal failure cannot authorise
+                # stale results. Leave work retryable once its lease expires.
+                logger.exception("worker claim renewal failed")
+                return
+
+    token = active_worker_claims.set({claim.id: claim for claim in claims})
+    thread = Thread(target=heartbeat, name="tamoss-claim-renewal", daemon=True)
+    thread.start()
+    try:
+        yield
+    finally:
+        stopped.set()
+        thread.join()
+        active_worker_claims.reset(token)

--- a/tests/adapters/postgres/test_repository.py
+++ b/tests/adapters/postgres/test_repository.py
@@ -6,6 +6,7 @@ from uuid import UUID, uuid4
 
 import psycopg
 import pytest
+from psycopg import sql
 from tamoss.adapters.postgres import PostgresRepository
 from tamoss.domain.exceptions import SegmentOverlapError
 from tamoss.domain.listings import DeleteRequestSortBy, FlowSortBy, SourceSortBy
@@ -1063,6 +1064,7 @@ def test_repository_rejects_open_or_empty_segment_timeranges(
 
 def test_repository_claims_delete_requests_and_webhook_deliveries_with_leases(
     postgres_repo: PostgresRepository,
+    postgres_connection: psycopg.Connection,
 ) -> None:
     now = datetime.now(UTC)
     flow_id = uuid4()
@@ -1211,38 +1213,18 @@ def test_repository_claims_delete_requests_and_webhook_deliveries_with_leases(
     )
 
     expired_at = datetime.now(UTC) - timedelta(seconds=1)
-    postgres_repo.webhook_repository.save_webhook_delivery(
-        replace(
-            claimed_delivery,
-            status="started",
-            claimed_by="worker-a",
-            claim_expires_at=expired_at,
+    for table in (
+        "tamoss_webhook_deliveries",
+        "tamoss_delete_requests",
+        "tamoss_object_cleanups",
+        "tamoss_object_copies",
+    ):
+        postgres_connection.execute(
+            sql.SQL("UPDATE {} SET claim_expires_at = %s").format(
+                sql.Identifier(table)
+            ),
+            (expired_at,),
         )
-    )
-    postgres_repo.deletion_repository.save_delete_request(
-        replace(
-            claimed_delete,
-            status="started",
-            claimed_by="worker-a",
-            claim_expires_at=expired_at,
-        )
-    )
-    postgres_repo.deletion_repository.save_object_cleanup(
-        replace(
-            claimed_cleanup,
-            status="started",
-            claimed_by="worker-a",
-            claim_expires_at=expired_at,
-        )
-    )
-    postgres_repo.object_repository.save_object_copy(
-        replace(
-            claimed_copy,
-            status="started",
-            claimed_by="worker-a",
-            claim_expires_at=expired_at,
-        )
-    )
 
     reclaimed_delivery = postgres_repo.webhook_repository.claim_webhook_deliveries(
         worker_id="worker-b",

--- a/tests/adapters/postgres/test_worker_queues.py
+++ b/tests/adapters/postgres/test_worker_queues.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import timedelta
+from threading import Event
+from uuid import uuid4
+
+import psycopg
+import pytest
+from psycopg import sql
+from tamoss.adapters.postgres import PostgresRepository
+from tamoss.domain.model import (
+    DeletionRequestRecord,
+    ObjectCleanupRecord,
+    ObjectCopyRecord,
+    WebhookDeliveryRecord,
+    utc_now,
+)
+from tamoss.worker import purge_finished_queue_records
+from tamoss.worker_claims import WorkerClaimLost, keep_worker_claims
+
+from tests.adapters.postgres.support import database_url, primary_backend, use_cases
+
+pytestmark = pytest.mark.needs_db
+
+
+@pytest.fixture
+def peer_repo(postgres_connection):
+    schema = postgres_connection.execute("SHOW search_path").fetchone()[0]
+    with psycopg.connect(database_url(), autocommit=True) as connection:
+        connection.execute(
+            sql.SQL("SET search_path TO {}").format(sql.Identifier(schema))
+        )
+        yield PostgresRepository(
+            connection=connection, storage_backend=primary_backend()
+        )
+
+
+@pytest.fixture(
+    params=["webhook_delivery", "delete_request", "object_cleanup", "object_copy"]
+)
+def queue(request, postgres_repo, peer_repo):
+    kind = request.param
+    record = {
+        "webhook_delivery": lambda: WebhookDeliveryRecord(
+            id=uuid4(),
+            webhook_id=uuid4(),
+            webhook_snapshot={},
+            event_type="flows/created",
+            event_timestamp=utc_now(),
+            payload={},
+            status="pending",
+        ),
+        "delete_request": lambda: DeletionRequestRecord(
+            id=uuid4(),
+            flow_id=uuid4(),
+            timerange_to_delete="_",
+            delete_flow=False,
+            status="created",
+        ),
+        "object_cleanup": lambda: ObjectCleanupRecord(
+            id=uuid4(),
+            object_id="media",
+            storage_backend_id=primary_backend().id,
+            status="pending",
+        ),
+        "object_copy": lambda: ObjectCopyRecord(
+            id=uuid4(),
+            object_id="media",
+            source_storage_backend_id=primary_backend().id,
+            destination_storage_backend_id=uuid4(),
+            status="pending",
+        ),
+    }[kind]()
+    store_name = {
+        "webhook_delivery": "webhook_repository",
+        "delete_request": "deletion_repository",
+        "object_cleanup": "deletion_repository",
+        "object_copy": "object_repository",
+    }[kind]
+    plural = {
+        "webhook_delivery": "webhook_deliveries",
+        "object_copy": "object_copies",
+    }.get(kind, kind + "s")
+    store = getattr(postgres_repo, store_name)
+    peer = getattr(peer_repo, store_name)
+    save = getattr(store, "save_" + kind)
+    save(record)
+    return (
+        record,
+        store,
+        save,
+        getattr(store, "claim_" + plural),
+        getattr(peer, "claim_" + plural),
+        "tamoss_" + plural,
+    )
+
+
+def expire(connection, table):
+    connection.execute(
+        sql.SQL(
+            "UPDATE {} SET claim_expires_at = clock_timestamp() - INTERVAL '1 second'"
+        ).format(sql.Identifier(table))
+    )
+
+
+def test_stale_claim_cannot_overwrite_or_recreate_work(queue, postgres_connection):
+    _, _, save, claim, peer_claim, table = queue
+    stale = claim(worker_id="a", limit=1, lease_seconds=30)[0]
+    expire(postgres_connection, table)
+    current = peer_claim(worker_id="b", limit=1, lease_seconds=30)[0]
+    stale.status = "done"
+    stale.claimed_at = stale.claimed_by = stale.claim_expires_at = None
+    with pytest.raises(WorkerClaimLost):
+        save(stale)
+    save(
+        replace(
+            current,
+            status="done",
+            claimed_at=None,
+            claimed_by=None,
+            claim_expires_at=None,
+        )
+    )
+    with pytest.raises(WorkerClaimLost):
+        save(stale)
+    assert (
+        postgres_connection.execute(
+            sql.SQL("SELECT status FROM {}").format(sql.Identifier(table))
+        ).fetchone()[0]
+        == "done"
+    )
+    postgres_connection.execute(sql.SQL("DELETE FROM {}").format(sql.Identifier(table)))
+    with pytest.raises(WorkerClaimLost):
+        save(stale)
+
+
+def test_renewal_keeps_active_and_waiting_work_owned(queue, postgres_connection):
+    record, store, save, claim, peer_claim, table = queue
+    save(replace(record, id=uuid4()))
+    claimed = claim(worker_id="a", limit=2, lease_seconds=1)
+    assert len(claimed) == 2
+    with keep_worker_claims(claimed, renew=store.renew_worker_claim, lease_seconds=1):
+        Event().wait(1.4)
+        assert peer_claim(worker_id="b", limit=2, lease_seconds=30) == []
+        for item in claimed:
+            save(item)
+        assert postgres_connection.execute(
+            sql.SQL(
+                "SELECT bool_and(claim_expires_at > clock_timestamp()) FROM {}"
+            ).format(sql.Identifier(table))
+        ).fetchone()[0]
+    expire(postgres_connection, table)
+    assert len(peer_claim(worker_id="b", limit=2, lease_seconds=30)) == 2
+
+
+def test_stale_parent_cannot_adopt_a_new_claim_or_save_children(
+    postgres_repo, peer_repo, postgres_connection
+):
+    store = postgres_repo.deletion_repository
+    request = DeletionRequestRecord(
+        id=uuid4(),
+        flow_id=uuid4(),
+        timerange_to_delete="_",
+        delete_flow=False,
+        status="created",
+    )
+    store.save_delete_request(request)
+    claimed = store.claim_delete_requests(worker_id="a", limit=1, lease_seconds=30)[0]
+    with keep_worker_claims(
+        [claimed], renew=store.renew_worker_claim, lease_seconds=30
+    ):
+        expire(postgres_connection, "tamoss_delete_requests")
+        peer_repo.deletion_repository.claim_delete_requests(
+            worker_id="b", limit=1, lease_seconds=30
+        )
+        fresh = store.get_delete_request(request.id)
+        with pytest.raises(WorkerClaimLost):
+            store.save_delete_request(replace(fresh, status="done"))
+        with pytest.raises(WorkerClaimLost):
+            store.save_object_cleanup(
+                ObjectCleanupRecord(
+                    id=uuid4(),
+                    object_id="media",
+                    storage_backend_id=primary_backend().id,
+                    status="done",
+                    delete_request_id=request.id,
+                )
+            )
+    assert store.list_object_cleanups() == []
+
+
+def test_production_retention_preserves_unfinished_dependencies(
+    postgres_repo, postgres_connection
+):
+    store = postgres_repo.deletion_repository
+    old = utc_now() - timedelta(days=8)
+    active = DeletionRequestRecord(
+        id=uuid4(),
+        flow_id=uuid4(),
+        timerange_to_delete="_",
+        delete_flow=False,
+        status="started",
+    )
+    finished = replace(active, id=uuid4(), status="done")
+    for request in [active, finished]:
+        store.save_delete_request(request)
+        store.save_object_cleanup(
+            ObjectCleanupRecord(
+                id=uuid4(),
+                object_id=str(request.id),
+                storage_backend_id=primary_backend().id,
+                status="done",
+                delete_request_id=request.id,
+            )
+        )
+    for table in ["tamoss_delete_requests", "tamoss_object_cleanups"]:
+        postgres_connection.execute(
+            sql.SQL("UPDATE {} SET updated_at = %s").format(sql.Identifier(table)),
+            (old,),
+        )
+    cases = use_cases(postgres_repo)
+    assert (
+        purge_finished_queue_records(cases, retention_seconds=7 * 86400, limit=1) == 1
+    )
+    assert purge_finished_queue_records(cases, retention_seconds=7 * 86400) == 1
+    assert store.get_delete_request(active.id) is not None
+    assert len(store.list_object_cleanups(delete_request_id=active.id)) == 1
+    assert purge_finished_queue_records(cases, retention_seconds=7 * 86400) == 0

--- a/tests/support/memory_repository.py
+++ b/tests/support/memory_repository.py
@@ -41,13 +41,7 @@ from tamoss.domain.pagination import Page, page_sequence
 from tamoss.domain.segments import SegmentDeleteFilter, SegmentTimerangeBounds
 from tamoss.domain.tags import tags_match
 from tamoss.errors import normalize_error_payload
-
-WorkerRecord = (
-    WebhookDeliveryRecord
-    | DeletionRequestRecord
-    | ObjectCleanupRecord
-    | ObjectCopyRecord
-)
+from tamoss.worker_claims import WorkerClaimLost, WorkerRecord, active_worker_claims
 
 
 class FakeTamossRepository:
@@ -569,6 +563,17 @@ class FakeTamossRepository:
                     if purged >= limit:
                         return purged
                     record = store[key]
+                    if (
+                        isinstance(record, ObjectCleanupRecord)
+                        and record.delete_request_id in self._delete_requests
+                    ):
+                        continue
+                    if isinstance(record, DeletionRequestRecord) and any(
+                        cleanup.delete_request_id == record.id
+                        and cleanup.status != "done"
+                        for cleanup in self._object_cleanups.values()
+                    ):
+                        continue
                     updated = getattr(record, "updated", None)
                     if (
                         record.status in statuses
@@ -852,16 +857,16 @@ class FakeTamossRepository:
 
     def list_webhook_deliveries(self) -> list[WebhookDeliveryRecord]:
         with self._lock:
-            return list(self._webhook_deliveries.values())
+            return deepcopy(list(self._webhook_deliveries.values()))
 
     def get_webhook_delivery(self, delivery_id: UUID) -> WebhookDeliveryRecord | None:
         with self._lock:
-            return self._webhook_deliveries.get(delivery_id)
+            return deepcopy(self._webhook_deliveries.get(delivery_id))
 
     def save_webhook_delivery(self, delivery: WebhookDeliveryRecord) -> None:
         with self._lock:
             delivery.error = DomainErrorPayload.from_json_dict(delivery.error)
-            self._webhook_deliveries[delivery.id] = delivery
+            self._save_worker_record(delivery, self._webhook_deliveries)
 
     def claim_webhook_deliveries(
         self, *, worker_id: str, limit: int, lease_seconds: int
@@ -877,7 +882,7 @@ class FakeTamossRepository:
 
     def list_delete_requests(self) -> list[DeletionRequestRecord]:
         with self._lock:
-            return list(self._delete_requests.values())
+            return deepcopy(list(self._delete_requests.values()))
 
     def list_delete_requests_page(
         self,
@@ -889,7 +894,7 @@ class FakeTamossRepository:
         limit: int | None,
     ) -> Page[DeletionRequestRecord]:
         with self._lock:
-            requests = list(self._delete_requests.values())
+            requests = deepcopy(list(self._delete_requests.values()))
         value = {
             DeleteRequestSortBy.CREATED: lambda request: request.created,
             DeleteRequestSortBy.EXPIRY: lambda request: (
@@ -909,12 +914,12 @@ class FakeTamossRepository:
 
     def get_delete_request(self, request_id: UUID) -> DeletionRequestRecord | None:
         with self._lock:
-            return self._delete_requests.get(request_id)
+            return deepcopy(self._delete_requests.get(request_id))
 
     def save_delete_request(self, request: DeletionRequestRecord) -> None:
         with self._lock:
             request.error = DomainErrorPayload.from_json_dict(request.error)
-            self._delete_requests[request.id] = request
+            self._save_worker_record(request, self._delete_requests)
 
     def claim_delete_requests(
         self, *, worker_id: str, limit: int, lease_seconds: int
@@ -935,7 +940,7 @@ class FakeTamossRepository:
         statuses: set[str] | None = None,
     ) -> list[ObjectCleanupRecord]:
         with self._lock:
-            cleanups = list(self._object_cleanups.values())
+            cleanups = deepcopy(list(self._object_cleanups.values()))
         if delete_request_id is not None:
             cleanups = [
                 cleanup
@@ -950,7 +955,7 @@ class FakeTamossRepository:
     def save_object_cleanup(self, cleanup: ObjectCleanupRecord) -> None:
         with self._lock:
             cleanup.error = DomainErrorPayload.from_json_dict(cleanup.error)
-            self._object_cleanups[cleanup.id] = cleanup
+            self._save_worker_record(cleanup, self._object_cleanups)
 
     def claim_object_cleanups(
         self, *, worker_id: str, limit: int, lease_seconds: int
@@ -969,7 +974,7 @@ class FakeTamossRepository:
         self, *, statuses: set[str] | None = None
     ) -> list[ObjectCopyRecord]:
         with self._lock:
-            copies = list(self._object_copies.values())
+            copies = deepcopy(list(self._object_copies.values()))
         if statuses is not None:
             copies = [copy for copy in copies if copy.status in statuses]
         copies.sort(key=lambda copy: (copy.created, str(copy.id)))
@@ -978,7 +983,7 @@ class FakeTamossRepository:
     def save_object_copy(self, copy: ObjectCopyRecord) -> None:
         with self._lock:
             copy.error = DomainErrorPayload.from_json_dict(copy.error)
-            self._object_copies[copy.id] = copy
+            self._save_worker_record(copy, self._object_copies)
 
     def claim_object_copies(
         self, *, worker_id: str, limit: int, lease_seconds: int
@@ -991,6 +996,56 @@ class FakeTamossRepository:
                 limit=limit,
                 lease_seconds=lease_seconds,
             )
+
+    def _worker_store(self, record: WorkerRecord) -> dict:
+        return {
+            WebhookDeliveryRecord: self._webhook_deliveries,
+            DeletionRequestRecord: self._delete_requests,
+            ObjectCleanupRecord: self._object_cleanups,
+            ObjectCopyRecord: self._object_copies,
+        }[type(record)]
+
+    def renew_worker_claim(self, record: WorkerRecord, lease_seconds: int) -> bool:
+        with self._lock:
+            current = self._worker_store(record).get(record.id)
+            if not self._owns_claim(record, current):
+                return False
+            current.claim_expires_at = utc_now() + timedelta(seconds=lease_seconds)
+            return True
+
+    @staticmethod
+    def _owns_claim(record: WorkerRecord, current: WorkerRecord | None) -> bool:
+        return bool(
+            current is not None
+            and record.claim_token is not None
+            and current.claimed_at == record.claim_token
+            and current.claim_expires_at is not None
+            and current.claim_expires_at > utc_now()
+        )
+
+    def _save_worker_record(self, record: WorkerRecord, store: dict) -> None:
+        active = active_worker_claims.get() or {}
+        if (
+            isinstance(record, ObjectCleanupRecord)
+            and record.delete_request_id in active
+        ):
+            parent = active[record.delete_request_id]
+            if not self._owns_claim(parent, self._delete_requests.get(parent.id)):
+                raise WorkerClaimLost(str(parent.id))
+        claim = active.get(record.id, record)
+        current = store.get(record.id)
+        if claim.claim_token is not None:
+            if not self._owns_claim(claim, current):
+                raise WorkerClaimLost(str(record.id))
+        elif current is not None and current.claimed_at is not None:
+            raise WorkerClaimLost(str(record.id))
+        saved = deepcopy(record)
+        if saved.claimed_at is not None and current is not None:
+            saved.claim_expires_at = max(
+                current.claim_expires_at, saved.claim_expires_at
+            )
+        saved.claim_token = saved.claimed_at
+        store[record.id] = saved
 
 
 def _claim_worker_records[WorkerRecordT: WorkerRecord](
@@ -1019,10 +1074,11 @@ def _claim_worker_records[WorkerRecordT: WorkerRecord](
             continue
         record.status = "started"
         record.claimed_at = now
+        record.claim_token = now
         record.claimed_by = worker_id
         record.claim_expires_at = lease_expires
         record.updated = now
-        claimed.append(record)
+        claimed.append(deepcopy(record))
     return claimed
 
 


### PR DESCRIPTION
Fences stale queue writes, renews active and waiting claims, and purges only terminal history no longer needed by pending work. Real PostgreSQL regressions pass without changing BBC 8.2 payloads or media retention.