### PR TITLE
fix(storage): retry partial deletes and support multipart copies

### DIFF
--- a/src/app/tamoss/adapters/object_storage.py
+++ b/src/app/tamoss/adapters/object_storage.py
@@ -189,14 +189,15 @@ class ConfiguredObjectStorage:
         source = self._resolve_backend(source_backend)
         destination = self._resolve_backend(destination_backend)
         if _same_storage_endpoint(source, destination):
-            self._s3_client(destination).copy_object(
+            self._s3_client(destination).copy(
                 Bucket=_require_bucket(destination),
                 Key=object_id,
                 CopySource={
                     "Bucket": _require_bucket(source),
                     "Key": object_id,
                 },
-                MetadataDirective="COPY",
+                ExtraArgs={"MetadataDirective": "COPY"},
+                SourceClient=self._s3_client(source),
             )
             return
 
@@ -237,10 +238,12 @@ class ConfiguredObjectStorage:
         client = self._s3_client(resolved_backend)
         bucket = _require_bucket(resolved_backend)
         for delete_batch in _chunked(unique_object_ids, 1000):
-            client.delete_objects(
+            response = client.delete_objects(
                 Bucket=bucket,
                 Delete={"Objects": [{"Key": object_id} for object_id in delete_batch]},
             )
+            if response.get("Errors"):
+                raise RuntimeError("S3 batch deletion was incomplete; retry required")
 
     def check_backend(self, backend: StorageBackend) -> None:
         resolved_backend = self._resolve_backend(backend)

--- a/tests/adapters/storage/test_configured_object_storage.py
+++ b/tests/adapters/storage/test_configured_object_storage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from dataclasses import replace
 from urllib.parse import unquote, urlparse
 from uuid import UUID, uuid4
 
@@ -105,3 +106,40 @@ def test_s3_write_read_and_delete_are_scoped_to_configured_backend(
 
     object_storage.delete(object_id, backend=s3_backend)
     assert object_storage.read(object_id, backend=s3_backend) is None
+
+
+def test_managed_multipart_copy_preserves_bytes_and_metadata(
+    object_storage, s3_backend
+):
+    destination = replace(
+        s3_backend, id=uuid4(), bucket_name=f"tamoss-copy-{uuid4().hex[:12]}"
+    )
+    ensure_bucket(destination)
+    body = bytes(range(256)) * (64 * 1024)
+    object_id = "media/large.ts"
+    source_client = s3_client(s3_backend)
+    source_client.put_object(
+        Bucket=s3_backend.bucket_name,
+        Key=object_id,
+        Body=body,
+        ContentType="video/mp2t",
+        Metadata={"origin": "source"},
+    )
+    parts = []
+    destination_client = object_storage._s3_client(destination)
+    destination_client.meta.events.register(
+        "before-call.s3.UploadPartCopy", lambda **kwargs: parts.append(kwargs)
+    )
+    try:
+        object_storage.copy(
+            object_id, source_backend=s3_backend, destination_backend=destination
+        )
+        assert len(parts) >= 2
+        assert object_storage.read(object_id, backend=destination) == body
+        metadata = destination_client.head_object(
+            Bucket=destination.bucket_name, Key=object_id
+        )
+        assert metadata["ContentType"] == "video/mp2t"
+        assert metadata["Metadata"] == {"origin": "source"}
+    finally:
+        empty_and_delete_bucket(destination)

--- a/tests/adapters/storage/test_configured_object_storage_unit.py
+++ b/tests/adapters/storage/test_configured_object_storage_unit.py
@@ -4,6 +4,7 @@ import io
 import json
 import os
 from dataclasses import replace
+from unittest.mock import Mock
 from uuid import UUID
 
 import pytest
@@ -363,8 +364,9 @@ def test_delete_batch_deduplicates_and_chunks_s3_requests(monkeypatch) -> None:
     calls: list[dict] = []
 
     class FakeS3Client:
-        def delete_objects(self, **kwargs) -> None:
+        def delete_objects(self, **kwargs) -> dict:
             calls.append(kwargs)
+            return {}
 
     monkeypatch.setattr(
         "tamoss.adapters.object_storage.boto3.client",
@@ -392,7 +394,8 @@ def test_copy_uses_server_side_copy_for_backends_on_same_endpoint(monkeypatch) -
     calls: list[dict] = []
 
     class FakeS3Client:
-        def copy_object(self, **kwargs) -> None:
+        def copy(self, **kwargs) -> None:
+            assert isinstance(kwargs.pop("SourceClient"), FakeS3Client)
             calls.append(kwargs)
 
     monkeypatch.setattr(
@@ -427,7 +430,7 @@ def test_copy_uses_server_side_copy_for_backends_on_same_endpoint(monkeypatch) -
                 "Bucket": "tamoss-test",
                 "Key": "media/object.ts",
             },
-            "MetadataDirective": "COPY",
+            "ExtraArgs": {"MetadataDirective": "COPY"},
         }
     ]
 
@@ -436,7 +439,7 @@ def test_copy_raises_same_endpoint_copy_errors(monkeypatch) -> None:
     get_object_called = False
 
     class FakeS3Client:
-        def copy_object(self, **kwargs) -> None:
+        def copy(self, **kwargs) -> None:
             raise ClientError(
                 {
                     "Error": {
@@ -478,6 +481,24 @@ def test_copy_raises_same_endpoint_copy_errors(monkeypatch) -> None:
         )
 
     assert get_object_called is False
+
+
+@pytest.mark.parametrize("deleted", [[], [{"Key": "first"}]])
+def test_partial_batch_deletion_fails_and_can_be_retried(monkeypatch, deleted) -> None:
+    client = Mock()
+    client.delete_objects.side_effect = [
+        {"Deleted": deleted, "Errors": [{"Key": "second", "Code": "AccessDenied"}]},
+        {"Deleted": [{"Key": "first"}, {"Key": "second"}]},
+    ]
+    backend = _s3_backend()
+    storage = ConfiguredObjectStorage(
+        Settings(auth_required=False, storage_backend=_settings_backend(backend))
+    )
+    monkeypatch.setattr(storage, "_s3_client", lambda _: client)
+    with pytest.raises(RuntimeError, match="incomplete"):
+        storage.delete_batch(["first", "second"], backend=backend)
+    storage.delete_batch(["first", "second"], backend=backend)
+    assert client.delete_objects.call_count == 2
 
 
 def test_copy_streams_between_different_s3_endpoints(monkeypatch) -> None:

--- a/tests/workers/test_worker_deletion.py
+++ b/tests/workers/test_worker_deletion.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import logging
 from collections.abc import Iterable
 from datetime import timedelta
+from unittest.mock import Mock
 from uuid import UUID, uuid4
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from tamoss import worker
+from tamoss.adapters.object_storage import ConfiguredObjectStorage
 from tamoss.application.contexts import deletion_processor
 from tamoss.domain.model import StorageBackend, utc_now
 
@@ -254,10 +256,12 @@ def test_delete_worker_batches_object_cleanup_by_backend(
     )
 
 
+@pytest.mark.parametrize("failure", ["exception", "s3-response"])
 def test_delete_worker_retries_planned_cleanup_after_storage_failure(
     tamoss_app: FastAPI,
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
+    failure: str,
 ) -> None:
     use_cases = route_worker_to_app(tamoss_app)
     flow_id, _, _ = create_video_flow(client)
@@ -280,6 +284,15 @@ def test_delete_worker_retries_planned_cleanup_after_storage_failure(
         nonlocal attempts
         attempts += 1
         if attempts == 1:
+            if failure == "s3-response":
+                storage = ConfiguredObjectStorage(use_cases.settings)
+                s3 = Mock()
+                s3.delete_objects.return_value = {
+                    "Errors": [{"Key": object_id, "Code": "AccessDenied"}]
+                }
+                monkeypatch.setattr(storage, "_s3_client", lambda _backend: s3)
+                storage.delete_batch(failed_object_ids, backend=backend)
+                return
             raise RuntimeError("storage delete unavailable")
         original_delete_batch(failed_object_ids, backend=backend)
 
@@ -307,6 +320,7 @@ def test_delete_worker_retries_planned_cleanup_after_storage_failure(
     assert failed.timerange_remaining is None
     cleanups = use_cases.repository.list_object_cleanups(delete_request_id=request_id)
     assert cleanups[0].object_id == object_id
+    assert cleanups[0].status == "error"
     assert client.get(f"/flows/{flow_id}").status_code == 404
     assert client.get(f"/objects/{object_id}").status_code == 404
     assert (


### PR DESCRIPTION
Retries S3 batches containing failed deletions and uses managed multipart copies without changing BBC 8.2 object identity or reference semantics. Tests cover retryable cleanup and multipart byte/metadata preservation using a 16 MiB object.