### PR TITLE
fix(webhooks): close responses without buffering bodies

### DIFF
--- a/src/app/tamoss/application/webhooks.py
+++ b/src/app/tamoss/application/webhooks.py
@@ -698,8 +698,13 @@ def send_webhook_delivery(
             json=payload,
             allow_redirects=False,
             timeout=timeout_seconds,
+            stream=True,
         )
-        _validate_redirect_response(url, response, egress_policy=egress_policy)
+        try:
+            _validate_redirect_response(url, response, egress_policy=egress_policy)
+        finally:
+            # Delivery processing only uses status and reason, never the body.
+            response.close()
     except Exception:
         observe_webhook_delivery("failure", time.perf_counter() - start)
         raise

--- a/tests/application/test_webhook_security.py
+++ b/tests/application/test_webhook_security.py
@@ -73,6 +73,9 @@ def test_webhook_delivery_blocks_redirect_to_private_target(
         status_code = 302
         headers: ClassVar[dict[str, str]] = {"Location": "http://127.0.0.1/internal"}
 
+        def close(self) -> None:
+            pass
+
     class RecordingSession:
         def post(self, *_args: object, **kwargs: object) -> RedirectResponse:
             post_calls.append(kwargs)
@@ -102,6 +105,9 @@ def test_webhook_delivery_records_success_metric(
     class OkResponse:
         status_code = 202
         headers: ClassVar[dict[str, str]] = {}
+
+        def close(self) -> None:
+            pass
 
     class OkSession:
         def post(self, *_args: object, **_kwargs: object) -> OkResponse:

--- a/tests/application/test_webhook_transport.py
+++ b/tests/application/test_webhook_transport.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import ipaddress
 import socket
 import ssl
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from threading import Thread
+from threading import Event, Thread
 from unittest.mock import Mock
 
 import pytest
@@ -16,6 +17,49 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.x509.oid import NameOID
 from tamoss.application import webhooks
 from urllib3.exceptions import NewConnectionError
+
+
+@pytest.mark.parametrize("status", [200, 503])
+def test_delivery_closes_an_unfinished_large_response_without_reading_it(status):
+    release_body = Event()
+
+    class Receiver(BaseHTTPRequestHandler):
+        def do_POST(self):
+            self.rfile.read(int(self.headers.get("Content-Length", 0)))
+            self.send_response(status)
+            self.send_header("Content-Length", str(1024**3))
+            self.end_headers()
+            release_body.wait(5)
+
+        def log_message(self, *_args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Receiver)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(
+                webhooks.send_webhook_delivery,
+                webhook={"url": f"http://127.0.0.1:{server.server_port}/hook"},
+                payload={"event_type": "flows/created"},
+                timeout_seconds=3,
+                egress_policy=webhooks.WebhookEgressPolicy(
+                    allowed_hosts=("127.0.0.1",)
+                ),
+            )
+            try:
+                response = future.result(timeout=1)
+                assert response.status_code == status
+                assert response.raw.closed
+                assert response._content_consumed is False
+            finally:
+                release_body.set()
+    finally:
+        release_body.set()
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
 
 
 @pytest.mark.parametrize("scheme", ["http", "https"])


### PR DESCRIPTION
Closes callback responses without buffering unused bodies, preserving BBC 8.2 events and existing egress checks. Real HTTP regressions cover blocked bodies on success and error responses; this does not impose a total DNS/header deadline.