### PR TITLE
perf(catalogue): reuse page records for flow timeranges

### DIFF
--- a/src/app/tamoss/api/routes/flows.py
+++ b/src/app/tamoss/api/routes/flows.py
@@ -116,7 +116,9 @@ def list_flows(
     if head := head_response(request, response):
         return head
     timeranges = (
-        flows.flow_timeranges(flow.id for flow in flow_page.items)
+        flows.flow_timeranges(
+            (flow.id for flow in flow_page.items), seed_flows=flow_page.items
+        )
         if include_timerange
         else {}
     )

--- a/src/app/tamoss/application/contexts/flows.py
+++ b/src/app/tamoss/application/contexts/flows.py
@@ -371,8 +371,10 @@ class FlowUseCases:
             return str(flow_range)
         return str(flow_range.intersect_with(requested_range))
 
-    def flow_timeranges(self, flow_ids: Iterable[UUID]) -> dict[UUID, str]:
-        return self._flow_timeranges(flow_ids)
+    def flow_timeranges(
+        self, flow_ids: Iterable[UUID], *, seed_flows: Iterable[FlowRecord] = ()
+    ) -> dict[UUID, str]:
+        return self._flow_timeranges(flow_ids, seed_flows=seed_flows)
 
     def _flow_timeranges(
         self,

--- a/tests/application/test_segment_repository_shape.py
+++ b/tests/application/test_segment_repository_shape.py
@@ -23,6 +23,7 @@ from tamoss.domain.segments import SegmentTimerangeBounds, timerange_union
 from tamoss.settings import Settings, StorageBackendSettings
 
 from tests.support.object_storage import InMemoryObjectStorage
+from tests.tams.support import video_flow_payload
 
 pytestmark = pytest.mark.architecture
 
@@ -259,6 +260,26 @@ def test_single_flow_timerange_uses_bounded_collection_lookup() -> None:
     assert repository.list_flows_calls == 0
     assert repository.get_flow_calls == 2
     assert repository.flow_timeranges_requests == [[parent_id, child_id]]
+
+
+def test_flow_listing_reuses_loaded_records_for_timeranges() -> None:
+    repository = CountingRepository(_storage_backend())
+    for _ in range(50):
+        flow = _flow(uuid4())
+        flow.data.update(video_flow_payload(flow.id, flow.source_id))
+        repository.save_flow(flow)
+        repository.append_segment(
+            SegmentRecord(flow_id=flow.id, object_id="media", timerange="[0:1_1:2)")
+        )
+    cases = _use_cases(repository, object_storage=InMemoryObjectStorage())
+    repository.reset_counts()
+    with TestClient(create_app(_settings(), use_cases=cases)) as client:
+        response = client.get("/flows", params={"limit": 50, "include_timerange": True})
+    assert response.status_code == 200, response.text
+    assert len(response.json()) == 50
+    assert {item["timerange"] for item in response.json()} == {"[0:1_1:2)"}
+    assert repository.get_flow_calls == 0
+    assert len(repository.flow_timeranges_requests) == 1
 
 
 class CountingRepository:


### PR DESCRIPTION
Reuses the existing page records when calculating Flow timeranges without changing BBC 8.2 responses or pagination. A 50-Flow regression verifies identical ranges with no per-Flow lookup.