### PR TITLE
fix(ui): preserve empty filters and international media URLs

### DIFF
--- a/src/app/frontend/src/api/transport.ts
+++ b/src/app/frontend/src/api/transport.ts
@@ -105,9 +105,7 @@ export class ApiTransport {
       const encodedValue = Array.isArray(value)
         ? value.map(String).join(",")
         : String(value);
-      if (encodedValue.length > 0) {
-        url.searchParams.set(key, encodedValue);
-      }
+      url.searchParams.set(key, encodedValue);
     }
   }
 

--- a/src/app/frontend/src/components/Surface.module.css
+++ b/src/app/frontend/src/components/Surface.module.css
@@ -379,7 +379,7 @@
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .panelHeader > .toolbar > * {
+  .panelHeader > .toolbar > :not(:global(.srOnly)) {
     width: 100%;
     max-width: 100%;
   }

--- a/src/app/frontend/src/player/url-policy.ts
+++ b/src/app/frontend/src/player/url-policy.ts
@@ -10,9 +10,6 @@ export interface SanitizedMediaUrl {
   storageId?: string;
 }
 
-const ENCODED_CONTROL_CHARACTER =
-  /%(?:0[0-9a-f]|1[0-9a-f]|7f|8[0-9a-f]|9[0-9a-f])/iu;
-
 function hasControlCharacter(value: string): boolean {
   for (const character of value) {
     const codePoint = character.codePointAt(0);
@@ -62,7 +59,6 @@ export function sanitizeMediaUrl(
     typeof rawUrl !== "string" ||
     rawUrl.length === 0 ||
     hasControlCharacter(rawUrl) ||
-    ENCODED_CONTROL_CHARACTER.test(rawUrl) ||
     rawUrl.includes("#")
   ) {
     return undefined;
@@ -71,6 +67,7 @@ export function sanitizeMediaUrl(
   const pageOrigin = parsePolicyOrigin(locationOrigin);
   let parsed: URL;
   try {
+    if (hasControlCharacter(decodeURIComponent(rawUrl))) return undefined;
     parsed = new URL(rawUrl, pageOrigin);
   } catch {
     return undefined;

--- a/src/app/frontend/tests/api/client.test.ts
+++ b/src/app/frontend/tests/api/client.test.ts
@@ -32,6 +32,59 @@ describe("TamossApiClient", () => {
     mockFetch.mockReset();
   });
 
+  it.each(["", []] as const)(
+    "preserves explicit empty TAMS filters (%j)",
+    async (empty) => {
+      mockFetch.mockResolvedValue(mockResponse([]));
+      const client = createClient();
+      for (const list of [
+        client.getSources.bind(client),
+        client.getFlows.bind(client),
+      ]) {
+        await list({
+          collected_by_ids: empty,
+          label: null,
+          page: undefined,
+          limit: 50,
+        });
+        expect(lastCalledUrl().searchParams.get("collected_by_ids")).toBe("");
+        expect(lastCalledUrl().searchParams.has("label")).toBe(false);
+        expect(lastCalledUrl().searchParams.has("page")).toBe(false);
+        expect(lastCalledUrl().searchParams.get("limit")).toBe("50");
+        await list();
+        expect(lastCalledUrl().searchParams.has("collected_by_ids")).toBe(
+          false,
+        );
+      }
+      for (const get of [
+        (params: {
+          accept_get_urls?: string | readonly string[];
+          accept_storage_ids?: string | readonly string[];
+          presigned?: boolean;
+        }) => client.getFlowSegments("flow-1", params),
+        (params: {
+          accept_get_urls?: string | readonly string[];
+          accept_storage_ids?: string | readonly string[];
+          presigned?: boolean;
+        }) => client.getObject("object/1", params),
+      ]) {
+        await get({
+          accept_get_urls: empty,
+          accept_storage_ids: empty,
+          presigned: false,
+        });
+        expect(lastCalledUrl().searchParams.get("accept_get_urls")).toBe("");
+        expect(lastCalledUrl().searchParams.get("accept_storage_ids")).toBe("");
+        expect(lastCalledUrl().searchParams.get("presigned")).toBe("false");
+        await get({});
+        expect(lastCalledUrl().searchParams.has("accept_get_urls")).toBe(false);
+        expect(lastCalledUrl().searchParams.has("accept_storage_ids")).toBe(
+          false,
+        );
+      }
+    },
+  );
+
   describe("getService", () => {
     it("fetches service information", async () => {
       const serviceData = { name: "Test TAMS", api_version: "8.2" };

--- a/src/app/frontend/tests/player/url-policy.test.ts
+++ b/src/app/frontend/tests/player/url-policy.test.ts
@@ -77,10 +77,30 @@ describe("media URL policy", () => {
     "https://storage.example/clip.ts#fragment",
     "https://storage.example/clip%0a.ts",
     "https://storage.example/clip\n.ts",
+    "https://storage.example/clip%C2%85.ts",
+    "https://storage.example/clip%7f.ts",
+    "https://storage.example/clip%80.ts",
+    "https://storage.example/clip%GG.ts",
+    "https://storage.example/clip%E6%97.ts",
   ])("rejects an unsafe URL without returning it: %s", (url) => {
     expect(
       sanitizeMediaUrl(mediaUrl(url), "https://app.example"),
     ).toBeUndefined();
+  });
+
+  it("preserves UTF-8 paths and the original signed query encoding", () => {
+    const url =
+      "https://storage.example/%E6%97%A5%E6%9C%AC%E8%AA%9E.mp4?X-Signature=a%2fb%2Bc&name=%C3%89t%C3%A9&part=2&part=1";
+    expect(
+      sanitizeMediaUrl(
+        mediaUrl(url, { presigned: true }),
+        "https://app.example",
+      ),
+    ).toEqual({
+      url,
+      credentials: "omit",
+      presigned: true,
+    });
   });
 
   it("does not include candidate URL values in policy errors", () => {


### PR DESCRIPTION
Preserves meaningful empty BBC 8.2 filters, accepts valid international media URLs without rewriting signatures, and fixes mobile overflow from hidden labels. Frontend tests and 96 desktop/mobile browser checks pass.